### PR TITLE
Fixed `SyntaxWaring: "is not" with a literal`

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -834,7 +834,7 @@ def create_new_type(
 ):
     """Create a new local type from a C declaration"""
     result = idaapi.idc_parse_types(c_declaration, 1)  # PT_PAKDEF | PT_SILENT
-    if result is not 0:
+    if result != 0:
         raise IDAError(f"Failed to parse type: {c_declaration}")
 
 @jsonrpc


### PR DESCRIPTION
Just simple SyntaxWarning fixed
 
```
$HOME/.idapro/plugins/mcp-plugin.py:837: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if result is not 0:
```

Ref.
- https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/