### PR TITLE
handle tinfo_t() exception when ctor not supported

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -976,9 +976,15 @@ def set_local_variable_type(
 ):
     """Set a local variable's type"""
     try:
+        # Some versions of IDA don't support this constructor
         new_tif = ida_typeinf.tinfo_t(new_type, None, ida_typeinf.PT_SIL)
     except Exception:
-        raise IDAError(f"Failed to parse type: {new_type}")
+        try:
+            new_tif = ida_typeinf.tinfo_t()
+            # parse_decl requires semicolon for the type
+            ida_typeinf.parse_decl(new_tif, None, new_type+";", ida_typeinf.PT_SIL)
+        except Exception:
+            raise IDAError(f"Failed to parse type: {new_type}")
     func = idaapi.get_func(parse_address(function_address))
     if not func:
         raise IDAError(f"No function found at address {function_address}")


### PR DESCRIPTION
`ida_typeinf.tinfo_t(new_type, None, ida_typeinf.PT_SIL)` throws an exception with various versions of IDA.
```
new_tinfo_t expected at most 1 arguments, got 3
Additional information:
Wrong number or type of arguments for overloaded function 'new_tinfo_t'.
  Possible C/C++ prototypes are:
    tinfo_t::tinfo_t()
    tinfo_t::tinfo_t(type_t)
    tinfo_t::tinfo_t(tinfo_t const &)
```

I believe this was fixed in IDA 9.0 SP1. Below is a table of versions I was able to test on.

|       | 8.40 | 8.50 | 9.00 | 9.0 SP1 | 9.10 |
|-------|------|------|------|---------|------|
| win32 | ❌   | ✅    | ❌   |     ❓    | ✅    |
| linux | ❌   |   ❓   | ❌   | ✅       | ✅    |

A workaround is to create an empty type with `ida_typeinf.tinfo_t()` and then create the type with `ida_typeinf.parse_decl()`. This requires adding a semicolon to the type or it will fail.