### PR TITLE
Add the highlight functionality to disassembly code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available functionality:
 - `set_function_prototype(function_address, prototype)`: Set a function's prototype.
 - `declare_c_type(c_declaration)`: Create or update a local type from a C declaration.
 - `set_local_variable_type(function_address, variable_name, new_type)`: Set a local variable's type.
+- `highlight_disassemble` : Highlight disassembly lines or functions
 
 ## Prerequisites
 

--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -989,6 +989,37 @@ def set_local_variable_type(
         raise IDAError(f"Failed to modify local variable: {variable_name}")
     refresh_decompiler_ctext(func.start_ea)
 
+    
+@jsonrpc
+@idawrite
+def highlight_disassemble(
+    start_ea: Annotated[str, "Highlight the disassembly code start address(Start address rather than address range，If "
+                             "there are multiple addresses, separate them with ', ')"],
+    highlight_range: Annotated[str, "Highlight range (line/function/segment)"],
+    mark_color: Annotated[str, "Set the highlight color (default set 0x00D888),The color order is Blue, Green, Red,"
+                               "If  want to restore the original color, enter None"]
+):
+    """Highlight disassembly lines or functions"""
+    if highlight_range == "line":
+        mode = idc.CIC_ITEM
+    elif highlight_range == "function":
+        mode = idc.CIC_FUNC
+    elif highlight_range == "segment":
+        mode = idc.CIC_SEGM
+    else:
+        raise ValueError("Unexpected values, normally only the 'line','function' and 'segment' options exist")
+    if mark_color == "None":
+        color = idc.DEFCOLOR
+    else:
+        color = parse_address(mark_color)  # Parsing indicates that the color string is of type int
+    for item in (x.strip() for x in start_ea.split(',')):
+        address = parse_address(item)
+        try:
+            idc.set_color(address, mode, color)
+        except Exception as e:
+            raise IDAError(f"Set_color error, the reason is {e}")
+
+
 class MCP(idaapi.plugin_t):
     flags = idaapi.PLUGIN_KEEP
     comment = "MCP Plugin"

--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -1001,19 +1001,11 @@ def set_local_variable_type(
 def highlight_disassemble(
     start_ea: Annotated[str, "Highlight the disassembly code start address(Start address rather than address range，If "
                              "there are multiple addresses, separate them with ', ')"],
-    highlight_range: Annotated[str, "Highlight range (line/function/segment)"],
     mark_color: Annotated[str, "Set the highlight color (default set 0x00D888),The color order is Blue, Green, Red,"
-                               "If  want to restore the original color, enter None"]
+                               "If  want to Unhighlight, enter None"]
 ):
     """Highlight disassembly lines or functions"""
-    if highlight_range == "line":
-        mode = idc.CIC_ITEM
-    elif highlight_range == "function":
-        mode = idc.CIC_FUNC
-    elif highlight_range == "segment":
-        mode = idc.CIC_SEGM
-    else:
-        raise ValueError("Unexpected values, normally only the 'line','function' and 'segment' options exist")
+    mode = idc.CIC_ITEM
     if mark_color == "None":
         color = idc.DEFCOLOR
     else:
@@ -1024,6 +1016,7 @@ def highlight_disassemble(
             idc.set_color(address, mode, color)
         except Exception as e:
             raise IDAError(f"Set_color error, the reason is {e}")
+
 
 
 class MCP(idaapi.plugin_t):


### PR DESCRIPTION
At first I tried to add this functionality to both decompile and disassemble code，but it doesn't run correctly in the decompile code . So I had to remove that part of the functionality. I think I need more time to finish the `highlight_decompile`.

Below is a demo of the functionality:

https://github.com/user-attachments/assets/c7ec3e4f-6a33-4fd0-a50c-c39023775612

