### PR TITLE
Allow set_comment to work with no decompiler available

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -275,6 +275,9 @@ class IDAError(Exception):
 class IDASyncError(Exception):
     pass
 
+class DecompilerLicenseError(IDAError):
+    pass
+
 # Important note: Always make sure the return value from your function f is a
 # copy of the data you have gotten from IDA, and not the original data.
 #
@@ -736,6 +739,9 @@ def decompile_checked(address: int) -> ida_hexrays.cfunc_t:
     error = ida_hexrays.hexrays_failure_t()
     cfunc: ida_hexrays.cfunc_t = ida_hexrays.decompile_func(address, error, ida_hexrays.DECOMP_WARNINGS)
     if not cfunc:
+        if error.code == ida_hexrays.MERR_LICENSE:
+            raise DecompilerLicenseError("Decompiler licence is not available. Use `disassemble_function` to get the assembly code instead.")
+
         message = f"Decompilation failed at {hex(address)}"
         if error.str:
             message += f": {error.str}"
@@ -898,7 +904,8 @@ def set_comment(
     # Check if the address corresponds to a line
     try:
         cfunc = decompile_checked(address)
-    except:
+    except DecompilerLicenseError:
+        # We failed to decompile the function due to a decompiler license error
         return
 
     # Special case for function entry comments

--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -891,6 +891,9 @@ def set_comment(
     if not idaapi.set_cmt(address, comment, False):
         raise IDAError(f"Failed to set disassembly comment at {hex(address)}")
 
+    if not ida_hexrays.init_hexrays_plugin():
+        return
+
     # Reference: https://cyber.wtf/2019/03/22/using-ida-python-to-analyze-trickbot/
     # Check if the address corresponds to a line
     cfunc = decompile_checked(address)

--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -896,7 +896,10 @@ def set_comment(
 
     # Reference: https://cyber.wtf/2019/03/22/using-ida-python-to-analyze-trickbot/
     # Check if the address corresponds to a line
-    cfunc = decompile_checked(address)
+    try:
+        cfunc = decompile_checked(address)
+    except:
+        return
 
     # Special case for function entry comments
     if address == cfunc.entry_ea:


### PR DESCRIPTION
Currently, if you do not have a decompiler for the platform, the `set_comment` function fails.

This PR adds a check to see if the hex rays plugin has been initialized and only sets the function comment if not.