### PR TITLE
List imports

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -658,6 +658,44 @@ def list_globals(
     """List all globals in the database (paginated)"""
     return list_globals_filter(offset, count, "")
 
+class Import(TypedDict):
+    address: str
+    name: str
+    library: str
+
+@jsonrpc
+@idaread
+def list_imports(
+        offset: Annotated[int, "Offset to start listing from (start at 0)"],
+        count: Annotated[int, "Number of imports to list (100 is a good default, 0 means remainder)"],
+) -> Page[Import]:
+    """ List all imported symbols with their name and module (paginated) """
+    nimps = ida_nalt.get_import_module_qty()
+
+    rv = []
+    for i in range(nimps):
+        module_name = ida_nalt.get_import_module_name(i)
+        if not module_name:
+            module_name = "<unnamed>"
+
+        def imp_cb(ea, symbol_name, ordinal, acc):
+            if not symbol_name:
+                symbol_name = "<unnamed>"
+
+            acc += [{
+                "module": module_name,
+                "import": symbol_name,
+                "address": f"{ea:#x}",
+                "ordinal": f"#{ordinal}"
+            }]
+
+            return True
+
+        imp_cb_w_context = lambda ea, symbol_name, ordinal: imp_cb(ea, symbol_name, ordinal, rv)
+        ida_nalt.enum_import_names(i, imp_cb_w_context)
+
+    return paginate(rv, offset, count)
+
 class String(TypedDict):
     address: str
     length: int


### PR DESCRIPTION
Adds a paginated `list_imports`.

Returns data that looks like this:

```json
{
  "data": [
    {
      "module": ".dynsym",
      "import": "sprintf@@GLIBC_2.0",
      "address": "0x804e580",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "err@@GLIBC_2.0",
      "address": "0x804e584",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "signal@@GLIBC_2.0",
      "address": "0x804e588",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "recv@@GLIBC_2.0",
      "address": "0x804e58c",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "calloc@@GLIBC_2.0",
      "address": "0x804e590",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "listen@@GLIBC_2.0",
      "address": "0x804e594",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "__libc_start_main@@GLIBC_2.0",
      "address": "0x804e598",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "htons@@GLIBC_2.0",
      "address": "0x804e59c",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "setegid@@GLIBC_2.0",
      "address": "0x804e5a0",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "read@@GLIBC_2.0",
      "address": "0x804e5a4",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "free@@GLIBC_2.0",
      "address": "0x804e5a8",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "accept@@GLIBC_2.0",
      "address": "0x804e5ac",
      "ordinal": "0x0"
    },
    {
      "module": ".dynsym",
      "import": "socket@@GLIBC_2.0",
      "address": "0x804e5b0",
      "ordinal": "0x0"
    }
  ],
  "next_offset": null
}
```