### PR TITLE
Add callee function listing feature

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -868,6 +868,41 @@ def get_xrefs_to_field(
 
 @jsonrpc
 @idaread
+def get_callee(
+    function_address: Annotated[str, "Address of the function to get callee functions"],
+) -> list[dict[str, str]]:
+    """Get all callee functions of the given address"""
+    func_start = parse_address(function_address)
+    func = idaapi.get_func(func_start)
+    if not func:
+        raise IDAError(f"No function found containing address {function_address}")
+    func_end = idc.find_func_end(func_start)
+    callees: list[dict[str, str]] = []
+    current_ea = func_start
+    while current_ea < func_end:
+        insn = idaapi.insn_t()
+        idaapi.decode_insn(insn, current_ea)
+        if insn.itype in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]:
+            target = idc.get_operand_value(current_ea, 0)
+            # in here, we do not use get_function because the target can be external function.
+            # but, we should mark the target as internal/external function.
+            func_type = (
+                "internal" if idaapi.get_func(target) is not None else "external"
+            )
+            func_name = idc.get_name(target)
+            if func_name is not None:
+                callees.append(
+                    {"address": hex(target), "name": func_name, "type": func_type}
+                )
+        current_ea = idc.next_head(current_ea, func_end)
+
+    # deduplicate callees
+    unique_callee_tuples = {tuple(callee.items()) for callee in callees}
+    unique_callees = [dict(callee) for callee in unique_callee_tuples]
+    return unique_callees  # type: ignore
+
+@jsonrpc
+@idaread
 def get_entry_points() -> list[Function]:
     """Get all entry points in the database"""
     result = []


### PR DESCRIPTION
- Adds callee listing feature
- param: the function address to get callees
- return: list of callee informations (address, name and type - internal or external)


```python
>>> get_callee("0x417C7E")

[
  {'address': '0x415cc3', 'name': 'sub_415CC3', 'type': 'internal'}, # internal - the code exists in same binary
  {'address': '0x415da9', 'name': 'sub_415DA9', 'type': 'internal'}, 
  {'address': '0x4181cd', 'name': 'sub_4181CD', 'type': 'internal'}, 
  {'address': '0x417e06', 'name': 'sub_417E06', 'type': 'internal'}, 
  {'address': '0x415e1c', 'name': 'sub_415E1C', 'type': 'internal'}, 
  {'address': '0x44d264', 'name': 'exit', 'type': 'external'}, # external - imported from other libs
  {'address': '0x417b37', 'name': 'sub_417B37', 'type': 'internal'}
]
```