### PR TITLE
Structured function disassembly

### DIFF
--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -163,7 +163,7 @@ visitor = MCPVisitor()
 visitor.visit(module)
 code = """# NOTE: This file has been automatically generated, do not modify!
 # Architecture based on https://github.com/mrexodia/ida-pro-mcp (MIT License)
-from typing import Annotated, Optional, TypedDict, Generic, TypeVar
+from typing import Annotated, Optional, TypedDict, Generic, TypeVar, NotRequired
 from pydantic import Field
 
 T = TypeVar("T")


### PR DESCRIPTION
This PR reimplements the `disassemble_function` function to return structured disassembly, including stack locals, segments, labels, address references, and comments.

It uses the memory read functions from #82 to provide extra context (such as string decoding or value inlining).

Currently left as a draft. It should satisfy #35, however, I'm unsure if this is too verbose and if we should be more concise. 

## Some change details
The function now returns the following datatypes:

```py
class DisassemblyLine(TypedDict):
    segment: str
    address: str
    label: Optional[str]
    instruction: str
    comments: list[str]

class Argument(TypedDict):
    name: str
    type: str

class DisassemblyFunction(TypedDict):
    name: str
    start_ea: str
    return_type: Optional[str]
    arguments: Optional[list[Argument]]
    stack_frame: list[dict]
    lines: list[DisassemblyLine]
```

Example output:
```json
{
  "name": "setup_server_socket",
  "start_ea": "0x8048944",
  "return_type": null,
  "arguments": null,
  "stack_frame": [
    {
      "name": "var_2C",
      "offset": "0x2c",
      "size": "0x2",
      "type": "_WORD"
    },
    {
      "name": "addr",
      "offset": "0x38",
      "size": "0x10",
      "type": "sockaddr"
    },
    {
      "name": "optval",
      "offset": "0x48",
      "size": "0x4",
      "type": "_DWORD"
    },
    {
      "name": "fd",
      "offset": "0x4c",
      "size": "0x4",
      "type": "int"
    },
    {
      "name": "__saved_registers",
      "offset": "0x58",
      "size": "0x4",
      "type": "_DWORD"
    },
    {
      "name": "__return_address",
      "offset": "0x5c",
      "size": "0x4",
      "type": "_UNKNOWN *"
    },
    {
      "name": "arg_0",
      "offset": "0x60",
      "size": "0x4",
      "type": "_DWORD"
    }
  ],
  "lines": [
    {
      "segment": ".text",
      "address": "0x8048944",
      "label": null,
      "instruction": "push ebp",
      "comments": [
        "Creates and configures a listening TCP socket"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048945",
      "label": null,
      "instruction": "mov ebp, esp",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048947",
      "label": null,
      "instruction": "sub esp, 58h",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x804894a",
      "label": null,
      "instruction": "mov eax, [ebp+arg_0]",
      "comments": [
        "Port number from argument"
      ]
    },
    {
      "segment": ".text",
      "address": "0x804894d",
      "label": null,
      "instruction": "mov [ebp+var_2C], ax",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048951",
      "label": null,
      "instruction": "mov [ebp+fd], 0",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048958",
      "label": null,
      "instruction": "mov [ebp+optval], 1",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x804895f",
      "label": null,
      "instruction": "mov [ebp+addr.sa_family], 2",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048965",
      "label": null,
      "instruction": "movzx eax, [ebp+var_2C]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048969",
      "label": null,
      "instruction": "mov [esp], eax",
      "comments": [
        "hostshort"
      ]
    },
    {
      "segment": ".text",
      "address": "0x804896c",
      "label": null,
      "instruction": "call _htons",
      "comments": [
        "_htons=0x80486dc"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048971",
      "label": null,
      "instruction": "mov word ptr [ebp+addr.sa_data], ax",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048975",
      "label": null,
      "instruction": "mov dword ptr [esp], 0",
      "comments": [
        "hostlong"
      ]
    },
    {
      "segment": ".text",
      "address": "0x804897c",
      "label": null,
      "instruction": "call _htonl",
      "comments": [
        "_htonl=0x80487ec"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048981",
      "label": null,
      "instruction": "mov dword ptr [ebp+addr.sa_data+2], eax",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048984",
      "label": null,
      "instruction": "mov dword ptr [esp+4], 1",
      "comments": [
        "Ignore SIGPIPE signals"
      ]
    },
    {
      "segment": ".text",
      "address": "0x804898c",
      "label": null,
      "instruction": "mov dword ptr [esp], 11h",
      "comments": [
        "sig"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048993",
      "label": null,
      "instruction": "call _signal",
      "comments": [
        "_signal=0x804867c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048998",
      "label": null,
      "instruction": "cmp eax, 0FFFFFFFFh",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x804899b",
      "label": null,
      "instruction": "jnz loc_80489B1",
      "comments": [
        "loc_80489B1=0x80489b1",
        "*loc_80489B1=0x6082444c7"
      ]
    },
    {
      "segment": ".text",
      "address": "0x804899d",
      "label": null,
      "instruction": "mov dword ptr [esp+4], offset format",
      "comments": [
        "format=0x80498d0",
        "*format=\"Unable to set SIGCHLD handler\""
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489a5",
      "label": null,
      "instruction": "mov dword ptr [esp], 0FFFFFFFFh",
      "comments": [
        "status"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489ac",
      "label": null,
      "instruction": "call _err",
      "comments": [
        "_err=0x804866c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489b1",
      "label": "loc_80489B1",
      "instruction": "mov dword ptr [esp+8], 6",
      "comments": [
        "protocol"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489b9",
      "label": null,
      "instruction": "mov dword ptr [esp+4], 1",
      "comments": [
        "type"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489c1",
      "label": null,
      "instruction": "mov dword ptr [esp], 2",
      "comments": [
        "AF_INET, SOCK_STREAM, TCP socket"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489c8",
      "label": null,
      "instruction": "call _socket",
      "comments": [
        "_socket=0x804872c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489cd",
      "label": null,
      "instruction": "mov [ebp+fd], eax",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x80489d0",
      "label": null,
      "instruction": "cmp [ebp+fd], 0FFFFFFFFh",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x80489d4",
      "label": null,
      "instruction": "jnz loc_80489EA",
      "comments": [
        "loc_80489EA=0x80489ea",
        "*loc_80489EA=0x4102444c7"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489d6",
      "label": null,
      "instruction": "mov dword ptr [esp+4], offset aUnableToCreate",
      "comments": [
        "aUnableToCreate=0x80498ee",
        "*aUnableToCreate=\"Unable to create socket\""
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489de",
      "label": null,
      "instruction": "mov dword ptr [esp], 0FFFFFFFFh",
      "comments": [
        "status"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489e5",
      "label": null,
      "instruction": "call _err",
      "comments": [
        "_err=0x804866c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489ea",
      "label": "loc_80489EA",
      "instruction": "mov dword ptr [esp+10h], 4",
      "comments": [
        "optlen"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489f2",
      "label": null,
      "instruction": "lea eax, [ebp+optval]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x80489f5",
      "label": null,
      "instruction": "mov [esp+0Ch], eax",
      "comments": [
        "optval"
      ]
    },
    {
      "segment": ".text",
      "address": "0x80489f9",
      "label": null,
      "instruction": "mov dword ptr [esp+8], 2",
      "comments": [
        "Set SO_REUSEADDR socket option"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a01",
      "label": null,
      "instruction": "mov dword ptr [esp+4], 1",
      "comments": [
        "level"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a09",
      "label": null,
      "instruction": "mov eax, [ebp+fd]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a0c",
      "label": null,
      "instruction": "mov [esp], eax",
      "comments": [
        "fd"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a0f",
      "label": null,
      "instruction": "call _setsockopt",
      "comments": [
        "_setsockopt=0x80487dc"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a14",
      "label": null,
      "instruction": "cmp eax, 0FFFFFFFFh",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a17",
      "label": null,
      "instruction": "jnz loc_8048A2D",
      "comments": [
        "loc_8048A2D=0x8048a2d",
        "*loc_8048A2D=0x8d 0x55 0xe0"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a19",
      "label": null,
      "instruction": "mov dword ptr [esp+4], offset aUnableToSetReu",
      "comments": [
        "aUnableToSetReu=0x8049906",
        "*aUnableToSetReu=\"Unable to set reuse\""
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a21",
      "label": null,
      "instruction": "mov dword ptr [esp], 0FFFFFFFFh",
      "comments": [
        "status"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a28",
      "label": null,
      "instruction": "call _err",
      "comments": [
        "_err=0x804866c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a2d",
      "label": "loc_8048A2D",
      "instruction": "lea edx, [ebp+addr]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a30",
      "label": null,
      "instruction": "mov eax, 0",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a35",
      "label": null,
      "instruction": "mov eax, edx",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a37",
      "label": null,
      "instruction": "mov dword ptr [esp+8], 10h",
      "comments": [
        "len"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a3f",
      "label": null,
      "instruction": "mov [esp+4], eax",
      "comments": [
        "addr"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a43",
      "label": null,
      "instruction": "mov eax, [ebp+fd]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a46",
      "label": null,
      "instruction": "mov [esp], eax",
      "comments": [
        "fd"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a49",
      "label": null,
      "instruction": "call _bind",
      "comments": [
        "_bind=0x804877c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a4e",
      "label": null,
      "instruction": "cmp eax, 0FFFFFFFFh",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a51",
      "label": null,
      "instruction": "jnz loc_8048A67",
      "comments": [
        "loc_8048A67=0x8048a67",
        "*loc_8048A67=0x14042444c7"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a53",
      "label": null,
      "instruction": "mov dword ptr [esp+4], offset aUnableToBindSo",
      "comments": [
        "aUnableToBindSo=0x804991a",
        "*aUnableToBindSo=\"Unable to bind socket\""
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a5b",
      "label": null,
      "instruction": "mov dword ptr [esp], 0FFFFFFFFh",
      "comments": [
        "status"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a62",
      "label": null,
      "instruction": "call _err",
      "comments": [
        "_err=0x804866c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a67",
      "label": "loc_8048A67",
      "instruction": "mov dword ptr [esp+4], 14h",
      "comments": [
        "Listen with backlog of 20 connections"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a6f",
      "label": null,
      "instruction": "mov eax, [ebp+fd]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a72",
      "label": null,
      "instruction": "mov [esp], eax",
      "comments": [
        "fd"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a75",
      "label": null,
      "instruction": "call _listen",
      "comments": [
        "_listen=0x80486bc"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a7a",
      "label": null,
      "instruction": "cmp eax, 0FFFFFFFFh",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a7d",
      "label": null,
      "instruction": "jnz loc_8048A93",
      "comments": [
        "loc_8048A93=0x8048a93",
        "*loc_8048A93=0x8b 0x45 0xf4"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a7f",
      "label": null,
      "instruction": "mov dword ptr [esp+4], offset aUnableToListen",
      "comments": [
        "aUnableToListen=0x8049930",
        "*aUnableToListen=\"Unable to listen on socket\""
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a87",
      "label": null,
      "instruction": "mov dword ptr [esp], 0FFFFFFFFh",
      "comments": [
        "status"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a8e",
      "label": null,
      "instruction": "call _err",
      "comments": [
        "_err=0x804866c"
      ]
    },
    {
      "segment": ".text",
      "address": "0x8048a93",
      "label": "loc_8048A93",
      "instruction": "mov eax, [ebp+fd]",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a96",
      "label": null,
      "instruction": "leave ",
      "comments": []
    },
    {
      "segment": ".text",
      "address": "0x8048a97",
      "label": null,
      "instruction": "retn ",
      "comments": []
    }
  ]
}
```

```asm
.text:08048944 setup_server_socket proc near           ; CODE XREF: main+1C↑p
.text:08048944
.text:08048944 var_2C          = word ptr -2Ch
.text:08048944 addr            = sockaddr ptr -20h
.text:08048944 optval          = dword ptr -10h
.text:08048944 fd              = dword ptr -0Ch
.text:08048944 arg_0           = dword ptr  8
.text:08048944
.text:08048944                 push    ebp             ; Creates and configures a listening TCP socket
.text:08048945                 mov     ebp, esp
.text:08048947                 sub     esp, 58h
.text:0804894A                 mov     eax, [ebp+arg_0] ; Port number from argument
.text:0804894D                 mov     [ebp+var_2C], ax
.text:08048951                 mov     [ebp+fd], 0
.text:08048958                 mov     [ebp+optval], 1
.text:0804895F                 mov     [ebp+addr.sa_family], 2
.text:08048965                 movzx   eax, [ebp+var_2C]
.text:08048969                 mov     [esp], eax      ; hostshort
.text:0804896C                 call    _htons
.text:08048971                 mov     word ptr [ebp+addr.sa_data], ax
.text:08048975                 mov     dword ptr [esp], 0 ; hostlong
.text:0804897C                 call    _htonl
.text:08048981                 mov     dword ptr [ebp+addr.sa_data+2], eax
.text:08048984                 mov     dword ptr [esp+4], 1 ; Ignore SIGPIPE signals
.text:0804898C                 mov     dword ptr [esp], 11h ; sig
.text:08048993                 call    _signal
.text:08048998                 cmp     eax, 0FFFFFFFFh
.text:0804899B                 jnz     short loc_80489B1
.text:0804899D                 mov     dword ptr [esp+4], offset format ; "Unable to set SIGCHLD handler"
.text:080489A5                 mov     dword ptr [esp], 0FFFFFFFFh ; status
.text:080489AC                 call    _err
.text:080489B1 ; ---------------------------------------------------------------------------
.text:080489B1
.text:080489B1 loc_80489B1:                            ; CODE XREF: setup_server_socket+57↑j
.text:080489B1                 mov     dword ptr [esp+8], 6 ; protocol
.text:080489B9                 mov     dword ptr [esp+4], 1 ; type
.text:080489C1                 mov     dword ptr [esp], 2 ; AF_INET, SOCK_STREAM, TCP socket
.text:080489C8                 call    _socket
.text:080489CD                 mov     [ebp+fd], eax
.text:080489D0                 cmp     [ebp+fd], 0FFFFFFFFh
.text:080489D4                 jnz     short loc_80489EA
.text:080489D6                 mov     dword ptr [esp+4], offset aUnableToCreate ; "Unable to create socket"
.text:080489DE                 mov     dword ptr [esp], 0FFFFFFFFh ; status
.text:080489E5                 call    _err
.text:080489EA ; ---------------------------------------------------------------------------
.text:080489EA
.text:080489EA loc_80489EA:                            ; CODE XREF: setup_server_socket+90↑j
.text:080489EA                 mov     dword ptr [esp+10h], 4 ; optlen
.text:080489F2                 lea     eax, [ebp+optval]
.text:080489F5                 mov     [esp+0Ch], eax  ; optval
.text:080489F9                 mov     dword ptr [esp+8], 2 ; Set SO_REUSEADDR socket option
.text:08048A01                 mov     dword ptr [esp+4], 1 ; level
.text:08048A09                 mov     eax, [ebp+fd]
.text:08048A0C                 mov     [esp], eax      ; fd
.text:08048A0F                 call    _setsockopt
.text:08048A14                 cmp     eax, 0FFFFFFFFh
.text:08048A17                 jnz     short loc_8048A2D
.text:08048A19                 mov     dword ptr [esp+4], offset aUnableToSetReu ; "Unable to set reuse"
.text:08048A21                 mov     dword ptr [esp], 0FFFFFFFFh ; status
.text:08048A28                 call    _err
.text:08048A2D ; ---------------------------------------------------------------------------
.text:08048A2D
.text:08048A2D loc_8048A2D:                            ; CODE XREF: setup_server_socket+D3↑j
.text:08048A2D                 lea     edx, [ebp+addr]
.text:08048A30                 mov     eax, 0
.text:08048A35                 mov     eax, edx
.text:08048A37                 mov     dword ptr [esp+8], 10h ; len
.text:08048A3F                 mov     [esp+4], eax    ; addr
.text:08048A43                 mov     eax, [ebp+fd]
.text:08048A46                 mov     [esp], eax      ; fd
.text:08048A49                 call    _bind
.text:08048A4E                 cmp     eax, 0FFFFFFFFh
.text:08048A51                 jnz     short loc_8048A67
.text:08048A53                 mov     dword ptr [esp+4], offset aUnableToBindSo ; "Unable to bind socket"
.text:08048A5B                 mov     dword ptr [esp], 0FFFFFFFFh ; status
.text:08048A62                 call    _err
.text:08048A67 ; ---------------------------------------------------------------------------
.text:08048A67
.text:08048A67 loc_8048A67:                            ; CODE XREF: setup_server_socket+10D↑j
.text:08048A67                 mov     dword ptr [esp+4], 14h ; Listen with backlog of 20 connections
.text:08048A6F                 mov     eax, [ebp+fd]
.text:08048A72                 mov     [esp], eax      ; fd
.text:08048A75                 call    _listen
.text:08048A7A                 cmp     eax, 0FFFFFFFFh
.text:08048A7D                 jnz     short loc_8048A93
.text:08048A7F                 mov     dword ptr [esp+4], offset aUnableToListen ; "Unable to listen on socket"
.text:08048A87                 mov     dword ptr [esp], 0FFFFFFFFh ; status
.text:08048A8E                 call    _err
.text:08048A93 ; ---------------------------------------------------------------------------
.text:08048A93
.text:08048A93 loc_8048A93:                            ; CODE XREF: setup_server_socket+139↑j
.text:08048A93                 mov     eax, [ebp+fd]
.text:08048A96                 leave
.text:08048A97                 retn
.text:08048A97 setup_server_socket endp
```