### PR TITLE
Fix error return type of `dbg_get_registers`

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -1979,8 +1979,8 @@ def dbg_get_registers() -> list[dict[str, str]]:
                 "value": reg_value,
             })
         result.append({
-            "thread_id": tid,
-            "registers": regs,
+            "thread_id": str(tid),
+            "registers": json.dumps(regs),
         })
     return result
 


### PR DESCRIPTION
When using the `dbg_get_registers` function within the claude code, I encountered a Pydantic validation error. The tool expected string values, but the function returned an integer for `thread_id` and a list for `registers`.

Error log:

```
Error: Error executing tool dbg_get_registers: 4 validation errors for dbg_get_registersOutput
  result.0.thread_id
    Input should be a valid string [type=string_type, input_value=12656, input_type=int]
      For further information visit https://errors.pydantic.dev/2.11/v/string_type
  result.0.registers
    Input should be a valid string [type=string_type, input_value=[{'name': 'ST0', 'value':...': 'YMM7', 'value':
 ''}], input_type=list]
     For further information visit https://errors.pydantic.dev/2.11/v/string_type
 result.1.thread_id
   Input should be a valid string [type=string_type, input_value=23268, input_type=int]
     For further information visit https://errors.pydantic.dev/2.11/v/string_type
 result.1.registers
   Input should be a valid string [type=string_type, input_value=[{'name': 'ST0', 'value':...': 'YMM7', 'value':
 ''}], input_type=list]
     For further information visit https://errors.pydantic.dev/2.11/v/string_type
```

I fixed the issue by explicitly converting the thread_id to a string and serializing the registers list into a JSON string. 