### PR TITLE
Support for multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The binaries and prompt for the video are available in the [mcp-reversing-datase
 
 Available functionality:
 
-- `check_connection()`: Check if the IDA plugin is running.
+- `check_connection()`: Check if the IDA plugin is running and show the connected port.
+- `list_ida_instances()`: List all running IDA Pro instances with their ports and open files.
+- `switch_ida_instance(port)`: Switch to a different IDA Pro instance by port number.
 - `get_metadata()`: Get metadata about the current IDB.
 - `get_function_by_name(name)`: Get a function by its name.
 - `get_function_by_address(address)`: Get a function by its address.


### PR DESCRIPTION
This PR originates from issue #89 .

I've implemented a feature where the IDA MCP plugin (mcp-plugin.py), upon startup, automatically finds and uses an available port within a specific range (13337-13437).

Subsequently, on the server side, I have provided the functions list_ida_instances() and switch_ida_instance(port) to display the current instances and to switch control between them.

This should be a relatively straightforward way to control multiple IDA instances. However, this approach requires the large model to have strong contextual capabilities, and perhaps there is a better way.