### PR TITLE
Fix headless mode startup on Python 3.11

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -13,15 +13,20 @@ from typing import (
     Any,
     Callable,
     get_type_hints,
-    TypedDict,
     Optional,
     Annotated,
     TypeVar,
     Generic,
-    NotRequired,
     overload,
     Literal,
 )
+
+# Use typing_extensions for TypedDict and NotRequired on Python < 3.12
+# to ensure compatibility with Pydantic
+if sys.version_info >= (3, 12):
+    from typing import TypedDict, NotRequired
+else:
+    from typing_extensions import TypedDict, NotRequired
 
 class JSONRPCError(Exception):
     def __init__(self, code: int, message: str, data: Any = None):
@@ -2211,3 +2216,4 @@ class MCP(idaapi.plugin_t):
 
 def PLUGIN_ENTRY():
     return MCP()
+


### PR DESCRIPTION
Fixes Pydantic compatibility issue by using typing_extensions.TypedDict instead of typing.TypedDict on Python < 3.12, as required by Pydantic.

- Use conditional imports for TypedDict and NotRequired based on Python version
- Add typing_extensions as conditional dependency for Python < 3.12