### PR TITLE
Add filter for function listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Available functionality:
 - `get_current_address()`: Get the address currently selected by the user.
 - `get_current_function()`: Get the function currently selected by the user.
 - `convert_number(text, size)`: Convert a number (decimal, hexadecimal) to different representations.
+- `list_functions_filter(offset, count, filter)`: List matching functions in the database (paginated).
 - `list_functions(offset, count)`: List all functions in the database (paginated).
 - `list_globals_filter(offset, count, filter)`: List matching globals in the database (paginated, filtered).
 - `list_globals(offset, count)`: List all globals in the database (paginated).

--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -707,13 +707,24 @@ def pattern_filter(data: list[T], pattern: str, key: str) -> list[T]:
 
 @jsonrpc
 @idaread
+def list_functions_filter(
+    offset: Annotated[int, "Offset to start listing from (start at 0)"],
+    count: Annotated[int, "Number of functions to list (100 is a good default, 0 means remainder)"],
+    filter: Annotated[str, "Filter to apply to the list (required parameter, empty string for no filter). Case-insensitive contains or /regex/ syntax"],
+) -> Page[Function]:
+    """List matching functions in the database (paginated, filtered)"""
+    functions = [get_function(address) for address in idautils.Functions()]
+    functions = pattern_filter(functions, filter, "name")
+    return paginate(functions, offset, count)
+
+@jsonrpc
+@idaread
 def list_functions(
     offset: Annotated[int, "Offset to start listing from (start at 0)"],
     count: Annotated[int, "Number of functions to list (100 is a good default, 0 means remainder)"],
 ) -> Page[Function]:
     """List all functions in the database (paginated)"""
-    functions = [get_function(address) for address in idautils.Functions()]
-    return paginate(functions, offset, count)
+    return list_functions_filter(offset, count, "")
 
 class Global(TypedDict):
     address: str


### PR DESCRIPTION
There are `list_globals_filter`, `list_strings_filter`, but no `list_functions_filter`, I added it.
In some big binaries the function list can be long, checking all of them will consume many tokens. Sometimes we only wanna focus on functions with specific patterns.