### PR TITLE
Fix IDA database closing on idalib server shutdown

### DIFF
--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -164,9 +164,6 @@ def main():
     # SOLUTION: Register our signal handlers BEFORE calling mcp.run(). When a signal
     # arrives, our handlers execute first, allowing us to close the IDA database
     # cleanly before the process terminates.
-    #
-    # The atexit handler provides backup cleanup for normal (non-signal) exits,
-    # though it won't be called when exiting via signal handlers.
     def cleanup_and_exit(signum, frame):
         logger.info("Closing IDA database...")
         idapro.close_database()
@@ -175,9 +172,6 @@ def main():
 
     signal.signal(signal.SIGINT, cleanup_and_exit)
     signal.signal(signal.SIGTERM, cleanup_and_exit)
-
-    # Backup cleanup handler for normal exits
-    atexit.register(lambda: idapro.close_database())
 
     # NOTE: npx @modelcontextprotocol/inspector for debugging
     logger.info("MCP Server availabile at: http://%s:%d/sse", mcp.settings.host, mcp.settings.port)


### PR DESCRIPTION
The IDA database was not being properly closed when the MCP server received SIGINT (Ctrl+C) or SIGTERM signals, leaving the `.id0`, `id1`, `.nam`, `.til` files and there might be potential data loss. 

The original code attempted to handle this with a `try-except KeyboardInterrupt` block, but this never executed.

This occurred because uvicorn re-raises signals after graceful shutdown, immediately terminating the process before cleanup code could execute.

Solution: Install signal handlers for SIGINT/SIGTERM that close the database before exiting. Also added atexit handler as backup for normal exits.