### PR TITLE
Add SSE transport alongside Streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,56 +98,17 @@ pip uninstall ida-pro-mcp
 pip install https://github.com/mrexodia/ida-pro-mcp/archive/refs/heads/main.zip
 ```
 
-Install the IDA plugin and configure your MCP clients:
+Configure the MCP servers and install the IDA Plugin:
 
-```sh
+```
 ida-pro-mcp --install
 ```
 
-This installs:
-- IDA plugin to `~/.idapro/plugins/`
-- Streamable HTTP configuration for your MCP clients
-
-**Important**: Restart your MCP client (Claude Code, Cline, etc.) after installation.
-
-### Usage
-
-1. Start IDA Pro and load a binary
-2. Run **Edit → Plugins → MCP** (Ctrl+Alt+M or Ctrl+Option+M on Mac)
-3. The plugin will start the MCP server with two transports:
-   - **Streamable HTTP**: `http://127.0.0.1:13337/mcp` (default)
-   - **SSE**: `http://127.0.0.1:13337/sse`
-4. Your MCP client will automatically connect
+**Important**: Make sure you completely restart IDA/Visual Studio Code/Claude for the installation to take effect. Claude runs in the background and you need to quit it from the tray icon.
 
 https://github.com/user-attachments/assets/65ed3373-a187-4dd5-a807-425dca1d8ee9
 
-### Manual Configuration
-
-If your MCP client isn't auto-configured, add this to your client's config file.
-
-**Streamable HTTP (recommended):**
-```json
-{
-  "mcpServers": {
-    "ida-pro-mcp": {
-      "type": "http",
-      "url": "http://127.0.0.1:13337/mcp"
-    }
-  }
-}
-```
-
-**SSE (alternative):**
-```json
-{
-  "mcpServers": {
-    "ida-pro-mcp": {
-      "type": "sse",
-      "url": "http://127.0.0.1:13337/sse"
-    }
-  }
-}
-```
+_Note_: You need to load a binary in IDA before the plugin menu will show up.
 
 ## Prompt Engineering
 
@@ -184,11 +145,15 @@ Another thing to keep in mind is that LLMs will not perform well on obfuscated c
 
 You should also use a tool like Lumina or FLIRT to try and resolve all the open source library code and the C++ STL, this will further improve the accuracy.
 
-## Headless Mode
+## SSE Transport & Headless MCP
 
-### idalib (Headless Analysis)
+You can run an SSE server to connect to the user interface like this:
 
-After installing [`idalib`](https://docs.hex-rays.com/user-guide/idalib) you can run a headless MCP server without the IDA UI:
+```sh
+uv run ida-pro-mcp --transport http://127.0.0.1:8744/sse
+```
+
+After installing [`idalib`](https://docs.hex-rays.com/user-guide/idalib) you can also run a headless SSE server:
 
 ```sh
 uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/executable
@@ -283,7 +248,7 @@ uv run mcp dev src/ida_pro_mcp/server.py
 
 This will open a web interface at http://localhost:5173 and allow you to interact with the MCP tools for testing.
 
-For testing I create a symbolic link to the IDA plugin and use the MCP endpoint at `http://localhost:13337/mcp`. After [enabling symbolic links](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) you can run the following command:
+For testing I create a symbolic link to the IDA plugin and then POST a JSON-RPC request directly to `http://localhost:13337/mcp`. After [enabling symbolic links](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) you can run the following command:
 
 ```sh
 uv run ida-pro-mcp --install


### PR DESCRIPTION
Adds Server-Sent Events (SSE) transport to the IDA Pro MCP plugin, running alongside the existing Streamable HTTP transport on the same server.

## Motivation

While Streamable HTTP is the recommended transport, SSE provides an alternative for MCP clients that:
- Require persistent event streams
- Need lower latency for real-time updates
- Prefer the SSE transport model

Both transports now run simultaneously on port 13337, allowing clients to choose their preferred method.

## Changes

### Architecture

**Dual Transport Support:**
- **Streamable HTTP** (default): `POST /mcp` - Session-based request/response
- **SSE** (alternative): `GET /sse` + `POST /sse?session={id}` - Event stream with session routing

Both transports:
- Share the same `MCPProtocolHandler` for MCP protocol logic
- Run on the same HTTP server (port 13337)
- Support the same MCP tools and capabilities

### Implementation Details

**SSEConnection class** (`src/ida_pro_mcp/mcp-plugin.py`):
```python
class SSEConnection:
    """Manages a single SSE client connection"""
    - session_id: UUID for routing POST requests
    - send_event(): Send SSE-formatted events (endpoint, message, ping)
    - Keepalive: 30-second ping interval
```

**Routing Logic:**
- `GET /sse` → Establish SSE connection, send endpoint event
- `POST /sse?session={uuid}` → Route MCP requests to matching SSE connection
- `POST /mcp` → Handle Streamable HTTP requests (existing)

**Session Management:**
- Each SSE connection receives unique `session_id` (UUID)
- Endpoint event: `event: endpoint\ndata: /sse?session={uuid}\n\n`
- POST requests matched by session ID (prevents cross-client collisions)

### Server Startup

```
[MCP] Server started:
  Streamable HTTP: http://127.0.0.1:13337/mcp
  SSE: http://127.0.0.1:13337/sse
```

### Configuration Examples

**Streamable HTTP (recommended):**
```json
{
  "mcpServers": {
    "ida-pro-mcp": {
      "type": "http",
      "url": "http://127.0.0.1:13337/mcp"
    }
  }
}
```

**SSE (alternative):**
```json
{
  "mcpServers": {
    "ida-pro-mcp": {
      "type": "sse",
      "url": "http://127.0.0.1:13337/sse"
    }
  }
}
```

## Testing

- [x] Both transports work simultaneously
- [x] SSE session routing (no cross-client response leakage)
- [x] Streamable HTTP sessions independent of SSE connections
- [x] Multiple MCP clients can connect using different transports
- [x] Syntax validation (`python3 -m py_compile`)

## Benefits

1. **Flexibility**: Clients choose their preferred transport
2. **Compatibility**: Works with more MCP client implementations
3. **No Breaking Changes**: Streamable HTTP remains default
4. **Single Server**: No additional processes or ports needed
