### PR TITLE
fix: error caused by PySide6 in headless mode

### DIFF
--- a/src/ida_pro_mcp/mcp-plugin.py
+++ b/src/ida_pro_mcp/mcp-plugin.py
@@ -1139,7 +1139,9 @@ def is_window_active():
     """Returns whether IDA is currently active"""
     try:
         from PyQt5.QtWidgets import QApplication
-    except ImportError:
+    # When running in headless mode, PyQt5 is not available, 
+    # the NotImplementedError is raised.
+    except (ImportError, NotImplementedError):
         return False
 
     app = QApplication.instance()


### PR DESCRIPTION
When running in headless mode, the gui is not available so tool calling to `decompile_function` will fail and returns error with message "Error executing tool decompile_function: Can't import PySide6. Are you trying to use Qt without GUI?". this makes LLM agent hanging and cannot continue.

Catching the NotImplementedError in `is_window_active` helper function fixes this.

The full error message is like this:

```
Exception importing PyQt5: Can't import PySide6. Are you trying to use Qt without GUI?
Error details: Traceback (most recent call last):
  File "{...}/ida-pro-mcp/src/ida_pro_mcp/mcp-plugin.py", line 1142, in is_window_active
    from PyQt5.QtWidgets import QApplication
  File "/opt/ida-pro-9.2/python/PyQt5/__init__.py", line 6, in <module>
    utils.confirm_decision()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/ida-pro-9.2/python/PyQt5/utils.py", line 118, in confirm_decision
    raise NotImplementedError(
        "Can't import PySide6. Are you trying to use Qt without GUI?")
NotImplementedError: Can't import PySide6. Are you trying to use Qt without GUI?
```