### PR TITLE
Add IDA Home support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IDA Pro MCP
 
-Simple [MCP Server](https://modelcontextprotocol.io/introduction) to allow vibe reversing in IDA Pro.
+Simple [MCP Server](https://modelcontextprotocol.io/introduction) to allow vibe reversing in IDA Pro & Home.
 
 https://github.com/user-attachments/assets/6ebeaa92-a9db-43fa-b756-eececce2aca0
 
@@ -10,7 +10,7 @@ The binaries and prompt for the video are available in the [mcp-reversing-datase
 
 - [Python](https://www.python.org/downloads/) (**3.11 or higher**)
   - Use `idapyswitch` to switch to the newest Python version
-- [IDA Pro](https://hex-rays.com/ida-pro) (8.3 or higher, 9 recommended), **IDA Free is not supported**
+- [IDA Pro](https://hex-rays.com/ida-pro) (8.3 or higher, 9 recommended) or [IDA Home](https://hex-rays.com/ida-home) (lacks Feeds & `idalib` support), **IDA Free is not supported**
 - Supported MCP Client (pick one you like)
   - [Amazon Q Developer CLI](https://aws.amazon.com/q/developer/)
   - [Augment Code](https://www.augmentcode.com/)


### PR DESCRIPTION
Adds mention of IDA Home as a supported alternative to IDA Pro while pointing out lack of support for `idalib` & Feeds. #155