### PR TITLE
fix: correct FunctionAnalysis.asm type from list to str

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -320,7 +320,7 @@ class FunctionAnalysis(TypedDict):
     addr: str
     name: Optional[str]
     code: Optional[str]
-    asm: Optional[list]
+    asm: Optional[str]
     xto: list[Xref]
     xfrom: list[Xref]
     callees: list[dict]


### PR DESCRIPTION
# Fix: FunctionAnalysis.asm Type Mismatch

## Problem

The `FunctionAnalysis` TypedDict declared `asm` field as `Optional[list]`, but the actual implementation (`get_assembly_lines`) always returned a `str`.

This caused MCP schema validation errors when clients strictly validated response types:

```
MCP error -32602: Structured content does not match the tool's output schema: 
data.result[0].asm should be array, data.result[0].asm should be null, 
data.result[0].asm should match some schema in anyOf
```

## Root Cause

Type annotation mismatch in `utils.py`:

```python
class FunctionAnalysis(TypedDict):
    ...
    asm: Optional[list]  # Wrong - declared as list
    ...
```

But `get_assembly_lines()` returns:

```python
def get_assembly_lines(ea: int, max_chars: int = 0) -> str:
    ...
    return lines_str  # Actually returns str
```

## Fix

Changed type annotation to match actual return type:

```python
class FunctionAnalysis(TypedDict):
    ...
    asm: Optional[str]  # Correct - matches get_assembly_lines() return type
    ...
```

## Affected Functions

- `analyze_funcs()` - returns `FunctionAnalysis` with `asm` field

## Testing

```python
analyze_funcs("0x140001000", max_asm_chars=200)
```

Should now return valid response without schema validation errors.
