### PR TITLE
feat: generic output size limiting middleware

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -64,6 +64,11 @@ class MCP(idaapi.plugin_t):
                 MCP_SERVER.serve(
                     self.HOST, port, request_handler=IdaMcpHttpRequestHandler
                 )
+                if TYPE_CHECKING:
+                    from .ida_mcp.rpc import set_download_base_url
+                else:
+                    from ida_mcp.rpc import set_download_base_url
+                set_download_base_url(f"http://{self.HOST}:{port}")
                 print(f"  Config: http://{self.HOST}:{port}/config.html")
                 self.mcp = MCP_SERVER
                 break

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -1,12 +1,13 @@
 import html
 import json
+import re
 import ida_netnode
 from urllib.parse import urlparse, parse_qs
 from typing import TypeVar, cast
 from http.server import HTTPServer
 
 from .sync import idaread, idawrite
-from .rpc import McpRpcRegistry, McpHttpRequestHandler, MCP_SERVER, MCP_UNSAFE
+from .rpc import McpRpcRegistry, McpHttpRequestHandler, MCP_SERVER, MCP_UNSAFE, get_cached_output
 
 
 T = TypeVar("T")
@@ -101,12 +102,21 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
 
     def do_GET(self):
         """Handles GET requests."""
-        if urlparse(self.path).path == "/config.html":
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path == "/config.html":
             if not self._check_host():
                 return
             self._handle_config_get()
-        else:
-            super().do_GET()
+            return
+
+        output_match = re.match(r"^/output/([a-f0-9-]+)\.(\w+)$", path)
+        if output_match:
+            self._handle_output_download(output_match.group(1), output_match.group(2))
+            return
+
+        super().do_GET()
 
     @property
     def server_port(self) -> int:
@@ -135,6 +145,44 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
             self.send_error(403, "Invalid Host")
             return False
         return True
+
+    def _handle_output_download(self, output_id: str, extension: str):
+        data = get_cached_output(output_id)
+        if data is None:
+            self.send_error(404, "Output not found or expired")
+            return
+
+        if extension == "json":
+            content = json.dumps(data, indent=2)
+        elif isinstance(data, dict) and "code" in data:
+            content = str(data["code"])
+        elif isinstance(data, list) and data and isinstance(data[0], dict):
+            content = "\n\n".join(
+                str(item.get("code", item.get("asm", item.get("lines", ""))))
+                for item in data
+            )
+        else:
+            content = json.dumps(data, indent=2)
+
+        body = content.encode("utf-8")
+
+        content_type_map = {
+            "json": "application/json",
+            "c": "text/x-c",
+            "asm": "text/plain",
+            "txt": "text/plain",
+        }
+        content_type = content_type_map.get(extension, "text/plain")
+
+        self.send_response(200)
+        self.send_header("Content-Type", f"{content_type}; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header(
+            "Content-Disposition", f'attachment; filename="{output_id}.{extension}"'
+        )
+        self.send_cors_headers()
+        self.end_headers()
+        self.wfile.write(body)
 
     def _send_html(self, status: int, text: str):
         """

--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -1,9 +1,112 @@
-from typing import Callable
+import json
+import os
+from typing import Any, Callable, Optional
 from .zeromcp import McpRpcRegistry, McpServer, McpToolError, McpHttpRequestHandler
 
 MCP_SERVER = McpServer("ida-pro-mcp")
 MCP_UNSAFE: set[str] = set()
 TESTS: dict[str, tuple[Callable, str]] = {}
+
+OUTPUT_LIMIT_MAX_CHARS = 50000
+_output_cache: dict[str, Any] = {}
+_download_base_url: str = os.environ.get("IDA_MCP_URL", "http://127.0.0.1:13337")
+
+
+def set_download_base_url(url: str) -> None:
+    global _download_base_url
+    _download_base_url = url.rstrip("/")
+
+
+def get_download_base_url() -> str:
+    return _download_base_url
+
+
+def _generate_output_id() -> str:
+    import uuid
+    return str(uuid.uuid4())
+
+
+OUTPUT_LIMIT_PREVIEW_ITEMS = 10
+OUTPUT_LIMIT_PREVIEW_STR_LEN = 1000
+
+
+def _truncate_value(value: Any, depth: int = 0) -> Any:
+    if depth > 5:
+        return value
+
+    if isinstance(value, str) and len(value) > OUTPUT_LIMIT_PREVIEW_STR_LEN:
+        return value[:OUTPUT_LIMIT_PREVIEW_STR_LEN] + f"... [{len(value)} chars total]"
+
+    if isinstance(value, list):
+        truncated_list = [_truncate_value(item, depth + 1) for item in value[:OUTPUT_LIMIT_PREVIEW_ITEMS]]
+        if len(value) > OUTPUT_LIMIT_PREVIEW_ITEMS:
+            truncated_list.append({"_truncated": f"... and {len(value) - OUTPUT_LIMIT_PREVIEW_ITEMS} more items"})
+        return truncated_list
+
+    if isinstance(value, dict):
+        return {k: _truncate_value(v, depth + 1) for k, v in value.items()}
+
+    return value
+
+
+def _add_download_info(result: Any, output_id: str, total_chars: int) -> Any:
+    download_url = f"{_download_base_url}/output/{output_id}.json"
+    info = {
+        "_output_truncated": True,
+        "_total_chars": total_chars,
+        "_output_id": output_id,
+        "_download_url": download_url,
+        "_download_hint": f"Output truncated. Run: curl -o .ida-mcp/{output_id}.json {download_url}",
+    }
+
+    if isinstance(result, dict):
+        return {**result, **info}
+
+    if isinstance(result, list) and result:
+        result = list(result)
+        if isinstance(result[0], dict):
+            result[0] = {**result[0], **info}
+        else:
+            result.insert(0, info)
+        return result
+
+    return {"_preview": result, **info}
+
+
+_original_mcp_tools_call = MCP_SERVER.registry.methods["tools/call"]
+
+
+def _patched_mcp_tools_call(name: str, arguments: Optional[dict] = None, _meta: Optional[dict] = None) -> dict:
+    response = _original_mcp_tools_call(name, arguments, _meta)
+
+    if response.get("isError"):
+        return response
+
+    structured = response.get("structuredContent")
+    if structured is None:
+        return response
+
+    serialized = json.dumps(structured)
+    if len(serialized) <= OUTPUT_LIMIT_MAX_CHARS:
+        return response
+    output_id = _generate_output_id()
+    _output_cache[output_id] = structured
+
+    preview = _truncate_value(structured)
+    preview = _add_download_info(preview, output_id, len(serialized))
+
+    return {
+        "content": [{"type": "text", "text": json.dumps(preview, indent=2)}],
+        "structuredContent": preview if isinstance(preview, dict) else {"result": preview},
+        "isError": False,
+    }
+
+
+MCP_SERVER.registry.methods["tools/call"] = _patched_mcp_tools_call
+
+
+def get_cached_output(output_id: str) -> Optional[Any]:
+    return _output_cache.get(output_id)
 
 
 def test(expression: str = "") -> Callable[[Callable], Callable]:

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -74,6 +74,8 @@ def main():
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread (this one) does not fake any
     # work from @idaread, so we deadlock.
+    from ida_pro_mcp.ida_mcp.rpc import set_download_base_url
+    set_download_base_url(f"http://{args.host}:{args.port}")
     MCP_SERVER.serve(host=args.host, port=args.port, background=False)
 
 


### PR DESCRIPTION
# Generic Output Size Limiting for All MCP Tools

## Problem

LLMs have limited context windows (~200-400k tokens). Some MCP tools can return millions of characters in a single call, causing context overflow.

Previous approach required adding parameters to each tool individually — rejected as "case-by-case instead of generic".

## Solution

Middleware that intercepts ALL tool responses and automatically:
1. Detects large outputs (>50k chars)
2. Creates preview with truncated arrays (10 items) and strings (1000 chars)
3. Caches full output on server
4. Provides download URL for AI to retrieve full data via curl

**Generic solution — no changes needed to individual tools.**

## How It Works

```mermaid
flowchart LR
    A[MCP Tool] --> B[Middleware]
    B --> C{Size > 50k?}
    C -->|No| D[Client]
    C -->|Yes| E[Cache Full Output]
    E --> F[Preview + Download URL]
    F --> D
    G[HTTP /output/id.json] --> H[Full Output]
```

### Example Response

```json
[
  {
    "data": [
      {"addr": "0x1000", "name": "main"},
      {"addr": "0x2000", "name": "init"},
      {"_truncated": "... and 4990 more items"}
    ],
    "_output_truncated": true,
    "_total_chars": 204791,
    "_output_id": "abc-123-uuid",
    "_download_url": "http://127.0.0.1:13337/output/abc-123-uuid.json",
    "_download_hint": "Output truncated. Run: curl -o .ida-mcp/abc-123-uuid.json http://..."
  }
]
```

AI sees hint → runs curl → downloads full output to `.ida-mcp/` → uses IDE search/grep.

## Changes

### rpc.py
- `_patched_mcp_tools_call` middleware patching `MCP_SERVER.registry.methods["tools/call"]`
- `_truncate_value()` — recursive preview generator (10 items, 1000 chars)
- `_add_download_info()` — adds download metadata to response
- `set_download_base_url()` for dynamic URL configuration
- Fallback to `IDA_MCP_URL` environment variable
- In-memory cache `_output_cache` for full outputs

### http.py
- `/output/{output_id}.{extension}` endpoint
- Supports .json, .c, .asm, .txt extensions
- `get_cached_output()` retrieves from cache

### ida_mcp.py & idalib_server.py
- Call `set_download_base_url()` on server start with actual host:port

## Remote MCP Support

Download URL is dynamically set based on server address:

| Scenario | Download URL |
|----------|--------------|
| Local IDA | `http://127.0.0.1:13337/output/{id}.json` |
| Remote IDA | `http://<server-ip>:<port>/output/{id}.json` |
| Custom | `$IDA_MCP_URL/output/{id}.json` |

Works for remote MCP — same address client uses to connect.

## Configuration

| Constant | Default | Description |
|----------|---------|-------------|
| `OUTPUT_LIMIT_MAX_CHARS` | 50000 | Threshold to trigger truncation |
| `OUTPUT_LIMIT_PREVIEW_ITEMS` | 10 | Max array items in preview |
| `OUTPUT_LIMIT_PREVIEW_STR_LEN` | 1000 | Max string length in preview |

## Benefits

- All 71 tools covered automatically
- Schema always valid (preserves original structure)
- Works for remote MCP
- Zero tool modifications needed
- New tools automatically covered
- AI can download full output and use native IDE search

## Related Issues

- Closes #182
- Addresses #127
