### PR TITLE
Feature: Reduce context token usage

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -38,7 +38,7 @@ def handle_enabled_tools(registry: McpRpcRegistry, config_key: str):
     """Changed to registry to enable configured tools, returns original tools."""
     original_tools = registry.methods.copy()
     enabled_tools = config_json_get(
-        config_key, {name: True for name in original_tools.keys()}
+        config_key, {name: name not in MCP_UNSAFE for name in original_tools.keys()}
     )
     new_tools = [name for name in original_tools if name not in enabled_tools]
 
@@ -48,7 +48,7 @@ def handle_enabled_tools(registry: McpRpcRegistry, config_key: str):
             enabled_tools.pop(name)
 
     if new_tools:
-        enabled_tools.update({name: True for name in new_tools})
+        enabled_tools.update({name: name not in MCP_UNSAFE for name in new_tools})
         config_json_set(config_key, enabled_tools)
 
     registry.methods = {


### PR DESCRIPTION
This is a proof of concept. It has been observed that when using MCP (like this project), the session context limit is reached rapidly. One of the reasons for this is that the instructions take a significant context, which is also expensive. This PR aims to remove those instructions that are disabled by default. 

---
This pull request updates the logic for enabling tools in the `handle_enabled_tools` function to improve safety by automatically disabling tools considered unsafe (as defined by `MCP_UNSAFE`). The changes ensure that only safe tools are enabled by default, both when reading from and updating the configuration.

**Tool enablement and safety improvements:**

* Updated the default enabled state for tools in the `enabled_tools` dictionary to be `True` only if the tool is not listed in `MCP_UNSAFE`, increasing default safety.
* Changed the logic for updating newly added tools so that their enabled state also depends on whether they are in `MCP_UNSAFE`, preventing unsafe tools from being enabled by default.