### PR TITLE
fix(jsonrpc): Better union type mismatch output & workaround MCP Clients submitting str instead of object

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
@@ -283,11 +283,19 @@ class JsonRpcRegistry:
                 if origin in (Union, UnionType):
                     type_matched = False
 
-                    # Try to parse str as JSON for non-str unions
+                    # HACK: Try to parse str as JSON for non-str unions
+                    # 
+                    # When JSON schema says one field is "object", Claude Code
+                    # (and maybe other MCP clients) can't (or won't) detect
+                    # that the field is actually a dict/list. Instead, they
+                    # treat the field as a string containing JSON object.
+                    #
+                    # To work around this, if the expected type is a Union
+                    # that does not include str, and the provided value is
+                    # a str, we try to parse it as JSON first.
                     if type(str) not in args and isinstance(value, str):
                         try:
                             value = json.loads(value)
-                            print(f"[MCP] Note: parsed param {param_name} from string as JSON")
                         except json.JSONDecodeError:
                             pass
 


### PR DESCRIPTION
I ended up still adding a generic workaround, to try to convert string to JSON object when checking type. This is because:

- Many RPC endpoints use union type, fixing each and every of them is actually more work than expected
- Some of them already have `| str`
  https://github.com/mrexodia/ida-pro-mcp/blob/8d407ca9b80e75bbba5430e5e0e297241134fbea/src/ida_pro_mcp/ida_mcp/api_core.py#L205-L214
  some don't but call `normalize_dict_list`
  https://github.com/mrexodia/ida-pro-mcp/blob/8d407ca9b80e75bbba5430e5e0e297241134fbea/src/ida_pro_mcp/ida_mcp/api_types.py#L66-L76
  some don't even call the utility function
  https://github.com/mrexodia/ida-pro-mcp/blob/8d407ca9b80e75bbba5430e5e0e297241134fbea/src/ida_pro_mcp/ida_mcp/api_analysis.py#L360-L363
  Adding `| str` and calling `normalize_dict_list` won't prevent future endpoints from this type of error
- Adding that causes linter errors (`normalize_dict_list` returns `list[dict[Unknown]]`)

Still, I reworded the union type error to be more specific and informational.

Fixes #226 