### PR TITLE
feat: add get_output_log tool to read IDA Output window logs

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -26,6 +26,7 @@ from . import api_stack
 from . import api_debug
 from . import api_python
 from . import api_resources
+from . import api_ui
 
 # Re-export key components for external use
 from .sync import idasync, IDAError, IDASyncError, CancelledError
@@ -48,6 +49,7 @@ __all__ = [
     "api_debug",
     "api_python",
     "api_resources",
+    "api_ui",
     # Re-exported components
     "idasync",
     "IDAError",

--- a/src/ida_pro_mcp/ida_mcp/api_ui.py
+++ b/src/ida_pro_mcp/ida_mcp/api_ui.py
@@ -1,0 +1,21 @@
+"""UI API Functions - IDA UI interactions"""
+
+from typing import Annotated
+
+import ida_kernwin
+
+from .rpc import tool
+from .sync import idasync
+
+
+@tool
+@idasync
+def get_output_log(
+    lines: Annotated[int, "Number of lines to retrieve (-1 for all)"] = -1,
+) -> dict:
+    """Get IDA Output window log messages"""
+    log_lines = ida_kernwin.msg_get_lines(lines)
+    return {
+        "lines": log_lines,
+        "count": len(log_lines),
+    }


### PR DESCRIPTION
## Summary

Add a new MCP tool `get_output_log` that retrieves messages from IDA's Output window using `ida_kernwin.msg_get_lines()`.

## Changes

- Add `api_ui.py` module for UI-related API functions
- Register the new module in `__init__.py`

## Usage

```python
# Get all log lines
get_output_log()

# Get last N lines
get_output_log(lines=100)
