### PR TITLE
Gate decompiler calls for safety

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -735,6 +735,8 @@ def pattern_filter(data: list[T], pattern: str, key: str) -> list[T]:
 
 
 def refresh_decompiler_widget():
+    if not ida_hexrays.init_hexrays_plugin():
+        return
     widget = ida_kernwin.get_current_widget()
     if widget is not None:
         vu = ida_hexrays.get_widget_vdui(widget)
@@ -743,6 +745,8 @@ def refresh_decompiler_widget():
 
 
 def refresh_decompiler_ctext(fn_addr: int):
+    if not ida_hexrays.init_hexrays_plugin():
+        return
     error = ida_hexrays.hexrays_failure_t()
     cfunc: ida_hexrays.cfunc_t = ida_hexrays.decompile_func(
         fn_addr, error, ida_hexrays.DECOMP_WARNINGS


### PR DESCRIPTION
The MCP will hang if/when these are called and the decompiler is not available.

e.g. - if you try to rename things without ever using the decompiler (not a plugin that is available) it will call a refresh which then hangs the mcp.