### PR TITLE
Fix “find_bytes” and “find” return empty results on IDA Pro 9.0

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -139,11 +139,17 @@ def py_eval(
                 # Execute all statements except the last
                 if len(tree.body) > 1:
                     exec_tree = ast.Module(body=tree.body[:-1], type_ignores=[])
-                    exec(compile(exec_tree, "<string>", "exec"), exec_globals, exec_locals)
+                    exec(
+                        compile(exec_tree, "<string>", "exec"),
+                        exec_globals,
+                        exec_locals,
+                    )
                     exec_globals.update(exec_locals)
                 # Eval only the last expression
                 eval_tree = ast.Expression(body=tree.body[-1].value)
-                result_value = str(eval(compile(eval_tree, "<string>", "eval"), exec_globals))
+                result_value = str(
+                    eval(compile(eval_tree, "<string>", "eval"), exec_globals)
+                )
             else:
                 # All statements (no trailing expression)
                 exec(code, exec_globals, exec_locals)


### PR DESCRIPTION
## Problem

The `find_bytes` tool in `ida_mcp/api_analysis.py` always returned 0 matches when searching for function byte patterns (e.g. `48 8B ?? ??`) in IDA Pro 9.0, regardless of the binary being analyzed.

## Root Causes

### 1. `ida_bytes.bin_search` does not exist in IDA 9.0

The original code (and the first fix attempt) called `ida_bytes.bin_search()`, which is **not available** in IDA Pro 9.0. The recommended IDA 9.0 API for binary search is:

```python
ida_bytes.find_bytes(
    bs: bytes | bytearray | str,
    range_start: int,
    range_size: int | None = None,
    range_end: int | None = BADADDR,
    mask: bytes | bytearray | None = None,
    flags: int | None = BIN_SEARCH_FORWARD | BIN_SEARCH_NOSHOW,
    radix: int | None = 16,
    strlit_encoding: int | str | None = PBSENC_DEF1BPU
) -> int
```

This function accepts:
- A **string** pattern like `"48 8B ? ?"` (with `?` as byte wildcard), or
- Raw **bytes** with a **mask** for exact control.

### 2. `parse_binpat_str` return-value check was unreliable

The original code used `ida_bytes.parse_binpat_str()` + `compiled_binpat_vec_t` and checked the return value with `if err:`, which had ambiguous truth semantics across IDA versions (see prior analysis).

### 3. `except Exception: pass` silently swallowed all errors

The bare `except Exception: pass` hid the `AttributeError: module 'ida_bytes' has no attribute 'bin_search'`, making the root cause invisible to the caller. The result was always 0 matches with no error message.

### 4. Same issue in the `find` tool

The `find` function's `string` search and `immediate` search also called `ida_bytes.bin_search()` directly, making them equally broken on IDA 9.0.

## Fix

### New helper: `_raw_bin_search()`

Added a version-compatible helper that abstracts binary search across IDA versions:

```python
def _raw_bin_search(ea, max_ea, data, mask, flags=0) -> int:
```

Resolution order:
1. **`ida_bytes.find_bytes()`** — IDA 9.0+ high-level API (bytes + mask)
2. **`ida_bytes.bin_search()`** — Older IDA low-level 6-param API
3. **`RuntimeError`** — If neither API is available

### `find_bytes` tool

Completely rewired the search logic:
- Removed `compiled_binpat_vec_t` and `parse_binpat_str` entirely.
- Primary path (IDA 9.0+): Normalizes `??` to `?` in the pattern string, then calls `ida_bytes.find_bytes(pattern_str, ...)` directly.
- Fallback path (older IDA): Parses to raw `bytes` + `mask`, calls `ida_bytes.bin_search()`.
- Fixed exception handling: `except Exception as e:` now propagates error messages in the result dict.

### `find` tool — `string` and `immediate` search types

Replaced all direct `ida_bytes.bin_search()` calls with `_raw_bin_search()`, which provides the same version-compatibility fallback chain.

## IDA Pattern Format Note

IDA's native pattern format uses a **single `?`** per wildcard byte (e.g. `"48 8B ? ? 90"`), while many reverse engineering tools use `??`. The `find_bytes` tool now normalizes `??` to `?` before passing to `ida_bytes.find_bytes()`.

## Files Modified

- `ida_mcp/api_analysis.py`:
  - Added `_raw_bin_search()` helper (after line 43)
  - Rewrote `find_bytes` tool search logic
  - Updated `find` tool's `string` search to use `_raw_bin_search()`
  - Updated `find` tool's `immediate` search to use `_raw_bin_search()`

## Before / After fix comparison

Before fix:

<img width="1740" height="470" alt="image" src="https://github.com/user-attachments/assets/51b31662-37b2-49f2-afeb-4d55f9241b28" />

After fix:

<img width="1734" height="345" alt="image" src="https://github.com/user-attachments/assets/a94cea44-f980-4a50-9a7f-7418b3b716fa" />
