### PR TITLE
Fix Python 3.9 compatibility for IDA 9.2

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from itertools import islice
 import struct
 from typing import Annotated, Optional

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -1,5 +1,7 @@
 """Core API Functions - IDB metadata and basic queries"""
 
+from __future__ import annotations
+
 import re
 import time
 from typing import Annotated

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -8,6 +8,8 @@ This module provides comprehensive debugging functionality including:
 - Call stack inspection
 """
 
+from __future__ import annotations
+
 import os
 from typing import Annotated
 

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -4,6 +4,8 @@ This module provides batch operations for reading and writing memory at various
 granularities (bytes, integers, strings) and patching binary data.
 """
 
+from __future__ import annotations
+
 import re
 
 from typing import Annotated

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import idaapi
 import idautils
 import idc

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -4,6 +4,8 @@ This module provides batch operations for managing stack frame variables,
 including reading, creating, and deleting stack variables in functions.
 """
 
+from __future__ import annotations
+
 from typing import Annotated
 import ida_typeinf
 import ida_frame

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Annotated
 
 import ida_typeinf

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import json
 import re
@@ -69,15 +71,14 @@ DEFAULT_CORS_POLICY = "local"
 
 def get_cors_policy(port: int) -> str:
     """Retrieve the current CORS policy from configuration."""
-    match config_json_get("cors_policy", DEFAULT_CORS_POLICY):
-        case "unrestricted":
-            return "*"
-        case "local":
-            return "127.0.0.1 localhost"
-        case "direct":
-            return f"http://127.0.0.1:{port} http://localhost:{port}"
-        case _:
-            return "*"
+    policy = config_json_get("cors_policy", DEFAULT_CORS_POLICY)
+    if policy == "unrestricted":
+        return "*"
+    if policy == "local":
+        return "127.0.0.1 localhost"
+    if policy == "direct":
+        return f"http://127.0.0.1:{port} http://localhost:{port}"
+    return "*"
 
 
 ORIGINAL_TOOLS = handle_enabled_tools(MCP_SERVER.tools, "enabled_tools")
@@ -89,13 +90,13 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         self.update_cors_policy()
 
     def update_cors_policy(self):
-        match config_json_get("cors_policy", DEFAULT_CORS_POLICY):
-            case "unrestricted":
-                self.mcp_server.cors_allowed_origins = "*"
-            case "local":
-                self.mcp_server.cors_allowed_origins = self.mcp_server.cors_localhost
-            case "direct":
-                self.mcp_server.cors_allowed_origins = None
+        policy = config_json_get("cors_policy", DEFAULT_CORS_POLICY)
+        if policy == "unrestricted":
+            self.mcp_server.cors_allowed_origins = "*"
+        elif policy == "local":
+            self.mcp_server.cors_allowed_origins = self.mcp_server.cors_localhost
+        elif policy == "direct":
+            self.mcp_server.cors_allowed_origins = None
 
     def do_POST(self):
         """Handles POST requests."""

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import queue
 import functools

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import fnmatch
 import json
 import os
@@ -9,14 +11,16 @@ from typing import (
     Annotated,
     Any,
     Callable,
-    Generic,
     Literal,
-    NotRequired,
     Optional,
     TypedDict,
-    TypeVar,
     overload,
 )
+
+try:
+    from typing import NotRequired
+except ImportError:
+    from typing_extensions import NotRequired
 
 import ida_funcs
 import ida_hexrays
@@ -402,11 +406,8 @@ class BasicBlock(TypedDict):
     predecessors: list[str]
 
 
-T = TypeVar("T")
-
-
-class Page(TypedDict, Generic[T]):
-    data: list[T]
+class Page(TypedDict):
+    data: list[Any]
     next_offset: Optional[int]
 
 

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
@@ -1,20 +1,41 @@
+from __future__ import annotations
+
 import json
 import inspect
 import os
 import threading
 import time
 import traceback
-from typing import Any, Callable, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, is_typeddict
-from types import UnionType
+from typing import Any, Callable, get_type_hints, get_origin, get_args, Optional, Union, TypedDict
 
-JsonRpcId: TypeAlias = str | int | float | None
+try:
+    from types import UnionType
+except ImportError:
+    UnionType = None
+
+try:
+    from typing import NotRequired, is_typeddict
+except ImportError:
+    try:
+        from typing_extensions import NotRequired, is_typeddict
+    except ImportError:
+        class _NotRequiredFallback:
+            pass
+        NotRequired = _NotRequiredFallback
+
+        def is_typeddict(tp):
+            return hasattr(tp, "__annotations__") and hasattr(tp, "__total__")
+
+_UNION_ORIGINS = (Union, UnionType) if UnionType is not None else (Union,)
+
+JsonRpcId = Union[str, int, float, None]
 
 # Thread-local storage for current request context (ID + cancel event)
 _current_request = threading.local()
 
 # Global pending requests for cancellation
 _pending_requests_lock = threading.Lock()
-_pending_requests: dict[int | str, threading.Event] = {}
+_pending_requests: dict[Union[int, str], threading.Event] = {}
 
 
 def get_current_request_id() -> JsonRpcId:
@@ -22,12 +43,12 @@ def get_current_request_id() -> JsonRpcId:
     return getattr(_current_request, "id", None)
 
 
-def get_current_cancel_event() -> threading.Event | None:
+def get_current_cancel_event() -> Optional[threading.Event]:
     """Get the cancel event for the currently executing request."""
     return getattr(_current_request, "cancel_event", None)
 
 
-def register_pending_request(request_id: int | str) -> threading.Event:
+def register_pending_request(request_id: Union[int, str]) -> threading.Event:
     """Register a request as pending and return its cancel event."""
     event = threading.Event()
     with _pending_requests_lock:
@@ -36,14 +57,14 @@ def register_pending_request(request_id: int | str) -> threading.Event:
     return event
 
 
-def unregister_pending_request(request_id: int | str) -> None:
+def unregister_pending_request(request_id: Union[int, str]) -> None:
     """Unregister a pending request."""
     with _pending_requests_lock:
         _pending_requests.pop(request_id, None)
     _current_request.cancel_event = None
 
 
-def cancel_request(request_id: int | str) -> bool:
+def cancel_request(request_id: Union[int, str]) -> bool:
     """Signal cancellation for a pending request. Returns True if request was found."""
     with _pending_requests_lock:
         event = _pending_requests.get(request_id)
@@ -71,7 +92,7 @@ _LOG_SKIP_METHODS = {
     for m in os.getenv("IDA_MCP_LOG_SKIP_METHODS", "tools/call").split(",")
     if m.strip()
 }
-JsonRpcParams: TypeAlias = dict[str, Any] | list[Any] | None
+JsonRpcParams = Optional[Union[dict[str, Any], list[Any]]]
 
 class JsonRpcRequest(TypedDict):
     jsonrpc: str
@@ -107,11 +128,11 @@ class JsonRpcRegistry:
         self._cache: dict[Callable, tuple[inspect.Signature, dict, list[str]]] = {}
         self.redact_exceptions = False
 
-    def method(self, func: Callable, name: str | None = None) -> Callable:
+    def method(self, func: Callable, name: Optional[str] = None) -> Callable:
         self.methods[name or func.__name__] = func # type: ignore
         return func
 
-    def dispatch(self, request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:
+    def dispatch(self, request: Union[dict, str, bytes, bytearray]) -> Optional[JsonRpcResponse]:
         try:
             if not isinstance(request, dict):
                 request = json.loads(request)
@@ -192,7 +213,7 @@ class JsonRpcRegistry:
             }
         return {
             "code": -32603,
-            "message": "\n".join(traceback.format_exception(e)).strip() + "\n\nPlease report a bug!",
+            "message": "\n".join(traceback.format_exception(type(e), e, e.__traceback__)).strip() + "\n\nPlease report a bug!",
         }
 
     def _call(self, method: str, params: Any) -> Any:
@@ -204,7 +225,13 @@ class JsonRpcRegistry:
         # Check for cached reflection data
         if func not in self._cache:
             sig = inspect.signature(func)
-            hints = get_type_hints(func)
+            try:
+                hints = get_type_hints(func)
+            except TypeError as e:
+                if "unsupported operand type(s) for |" in str(e):
+                    hints = dict(getattr(func, "__annotations__", {}) or {})
+                else:
+                    raise
             hints.pop("return", None)
 
             # Determine required vs optional parameters
@@ -266,6 +293,11 @@ class JsonRpcRegistry:
                 # Has type hint, validate
                 expected_type = hints[param_name]
 
+                # Python 3.9 fallback path when annotations are unevaluated strings
+                if isinstance(expected_type, str):
+                    validated_params[param_name] = value
+                    continue
+
                 # Inline type validation
                 origin = get_origin(expected_type)
                 args = get_args(expected_type)
@@ -274,13 +306,13 @@ class JsonRpcRegistry:
                 if value is None:
                     if expected_type is not type(None):
                         # Check if None is allowed in a Union
-                        if not (origin in (Union, UnionType) and type(None) in args):
+                        if not (origin in _UNION_ORIGINS and type(None) in args):
                             raise JsonRpcException(-32602, f"Invalid params: {param_name} cannot be null")
                     validated_params[param_name] = None
                     continue
 
                 # Handle Union types (int | str, Optional[int], etc.)
-                if origin in (Union, UnionType):
+                if origin in _UNION_ORIGINS:
                     type_matched = False
 
                     # HACK: Try to parse str as JSON for non-str unions
@@ -370,7 +402,7 @@ class JsonRpcRegistry:
         else:
             raise JsonRpcException(-32602, "Invalid params: must be array or object")
 
-    def _error(self, request_id: JsonRpcId, code: int, message: str, data: Any = None) -> JsonRpcResponse | None:
+    def _error(self, request_id: JsonRpcId, code: int, message: str, data: Any = None) -> Optional[JsonRpcResponse]:
         error: JsonRpcError = {
             "code": code,
             "message": message,

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import sys
 import time
@@ -9,12 +11,42 @@ import inspect
 import threading
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
-from typing import Any, Callable, Union, Annotated, BinaryIO, NotRequired, get_origin, get_args, get_type_hints, is_typeddict
-from types import UnionType
+from typing import Any, Callable, Union, Annotated, BinaryIO, get_origin, get_args, get_type_hints
+try:
+    from types import UnionType
+except ImportError:
+    UnionType = None
 from urllib.parse import urlparse, parse_qs
 from io import BufferedIOBase
 
+try:
+    from typing import NotRequired, is_typeddict
+except ImportError:
+    try:
+        from typing_extensions import NotRequired, is_typeddict
+    except ImportError:
+        class _NotRequiredFallback:
+            pass
+        NotRequired = _NotRequiredFallback
+
+        def is_typeddict(tp):
+            return hasattr(tp, "__annotations__") and hasattr(tp, "__total__")
+
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, get_current_request_id, register_pending_request, unregister_pending_request, cancel_request
+
+_UNION_ORIGINS = (Union, UnionType) if UnionType is not None else (Union,)
+
+
+def _safe_get_type_hints(obj: Any, *, include_extras: bool = False) -> dict[str, Any]:
+    """Best-effort get_type_hints that tolerates Python 3.9 PEP 604 eval failures."""
+    try:
+        return get_type_hints(obj, include_extras=include_extras)
+    except TypeError as e:
+        if "unsupported operand type(s) for |" not in str(e):
+            raise
+    except Exception:
+        pass
+    return dict(getattr(obj, "__annotations__", {}) or {})
 
 class McpToolError(Exception):
     def __init__(self, message: str):
@@ -121,26 +153,26 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             pass
 
     def do_GET(self):
-        match urlparse(self.path).path:
-            case "/sse":
-                self._handle_sse_get()
-            case "/mcp":
-                self.send_error(405, "Method Not Allowed")
-            case _:
-                self.send_error(404, "Not Found")
+        path = urlparse(self.path).path
+        if path == "/sse":
+            self._handle_sse_get()
+        elif path == "/mcp":
+            self.send_error(405, "Method Not Allowed")
+        else:
+            self.send_error(404, "Not Found")
 
     def do_POST(self):
         body = self._read_body()
         if body is None:
             return
 
-        match urlparse(self.path).path:
-            case "/sse":
-                self._handle_sse_post(body)
-            case "/mcp":
-                self._handle_mcp_post(body)
-            case _:
-                self.send_error(404, "Not Found")
+        path = urlparse(self.path).path
+        if path == "/sse":
+            self._handle_sse_post(body)
+        elif path == "/mcp":
+            self._handle_mcp_post(body)
+        else:
+            self.send_error(404, "Not Found")
 
     def do_OPTIONS(self):
         """Handle CORS preflight requests"""
@@ -656,7 +688,7 @@ class McpServer:
 
     def _generate_prompt_schema(self, func_name: str, func: Callable) -> dict:
         """Generate MCP prompt schema from a function"""
-        hints = get_type_hints(func, include_extras=True)
+        hints = _safe_get_type_hints(func, include_extras=True)
         hints.pop("return", None)
         sig = inspect.signature(func)
 
@@ -704,7 +736,7 @@ class McpServer:
             return self._type_to_json_schema(get_args(py_type)[0])
 
         # Union[Ts..], Optional[T] and T1 | T2
-        if origin in (Union, UnionType):
+        if origin in _UNION_ORIGINS:
             return {"anyOf": [self._type_to_json_schema(t) for t in get_args(py_type)]}
 
         # list[T]
@@ -740,7 +772,7 @@ class McpServer:
 
     def _typed_dict_to_schema(self, typed_dict_class) -> dict:
         """Convert TypedDict to JSON schema"""
-        hints = get_type_hints(typed_dict_class, include_extras=True)
+        hints = _safe_get_type_hints(typed_dict_class, include_extras=True)
         required_keys = getattr(typed_dict_class, '__required_keys__', set(hints.keys()))
 
         return {
@@ -755,7 +787,7 @@ class McpServer:
 
     def _generate_tool_schema(self, func_name: str, func: Callable) -> dict:
         """Generate MCP tool schema from a function"""
-        hints = get_type_hints(func, include_extras=True)
+        hints = _safe_get_type_hints(func, include_extras=True)
         return_type = hints.pop("return", None)
         sig = inspect.signature(func)
 


### PR DESCRIPTION
What I changed:
- Added " from __future__ import annotations "to modules that use modern type hints.
- Replaced " match/case " blocks with `if/elif`.
- Added fallbacks for "NotRequired" , "is_typeddict", and " UnionType" for Python 3.9.
- Fixed "traceback.format_exception usage to a Python 3.9-compatible call.
- Added safer "get_type_hints"handling so tool/schema generation does not crash on Python 3.9.
- Fixed the "TypedDict + Generic" definition that breaks on Python 3.9.



Files updated
- src/ida_pro_mcp/ida_mcp/http.py
- src/ida_pro_mcp/ida_mcp/sync.py
- src/ida_pro_mcp/ida_mcp/utils.py
- src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
- src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
- src/ida_pro_mcp/ida_mcp/api_analysis.py
- src/ida_pro_mcp/ida_mcp/api_core.py
- src/ida_pro_mcp/ida_mcp/api_debug.py
- src/ida_pro_mcp/ida_mcp/api_memory.py
- src/ida_pro_mcp/ida_mcp/api_modify.py
- src/ida_pro_mcp/ida_mcp/api_stack.py
- src/ida_pro_mcp/ida_mcp/api_types.py