### PR TITLE
fix: replace bare except with except Exception in config save

### DIFF
--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -720,7 +720,7 @@ def install_mcp_servers(*, stdio: bool = False, uninstall=False, quiet=False):
                 else:
                     json.dump(config, f, indent=2)
             os.replace(temp_path, config_path)
-        except:
+        except Exception:
             os.unlink(temp_path)
             raise
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in config file save. The cleanup (`os.unlink`) should only trigger on write/serialization errors, not `KeyboardInterrupt` or `SystemExit`.