### PR TITLE
Improve MCP conversation ergonomics with richer query, type, rename, and runtime workflows

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -18,18 +18,30 @@ from .sync import idasync, tool_timeout, IDAError
 from .utils import (
     parse_address,
     normalize_list_input,
+    normalize_dict_list,
     get_function,
     get_prototype,
+    paginate,
+    pattern_filter,
     get_stack_frame_variables_internal,
     decompile_function_safe,
     get_assembly_lines,
     get_all_xrefs,
     get_all_comments,
+    Function,
+    get_callers,
+    get_callees,
+    extract_function_strings,
+    extract_function_constants,
     Argument,
     DisassemblyFunction,
     Xref,
     BasicBlock,
     StructFieldQuery,
+    XrefQuery,
+    InsnPattern,
+    FuncProfileQuery,
+    AnalyzeBatchQuery,
 )
 from . import compat
 
@@ -156,6 +168,195 @@ def _resolve_immediate_insn_start(
     return None
 
 
+def _clamp_int(value: object, default: int, minimum: int, maximum: int) -> int:
+    try:
+        i = int(value)
+    except Exception:
+        i = default
+    if i < minimum:
+        return minimum
+    if i > maximum:
+        return maximum
+    return i
+
+
+def _parse_optional_int(value: object, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            return int(s, 0)
+        except Exception as e:
+            raise ValueError(f"{field} must be an integer") from e
+    try:
+        return int(value)
+    except Exception as e:
+        raise ValueError(f"{field} must be an integer") from e
+
+
+def _resolve_function_start(query: object) -> tuple[int | None, str | None]:
+    q = str(query or "").strip()
+    if not q:
+        return None, "Function query is required"
+
+    ea = idaapi.BADADDR
+    try:
+        ea = parse_address(q)
+    except Exception:
+        ea = idaapi.get_name_ea(idaapi.BADADDR, q)
+
+    if ea == idaapi.BADADDR:
+        return None, f"Failed to resolve function: {q}"
+
+    func = idaapi.get_func(ea)
+    if not func:
+        return None, f"Not a function: {q}"
+    return func.start_ea, None
+
+
+def _limit_items(items: list, limit: int) -> tuple[list, bool]:
+    if limit < 0:
+        limit = 0
+    if len(items) <= limit:
+        return items, False
+    return items[:limit], True
+
+
+def _disasm_lines_limited(func: ida_funcs.func_t, max_insns: int) -> tuple[list[str], bool]:
+    lines: list[str] = []
+    truncated = False
+    for item_ea in idautils.FuncItems(func.start_ea):
+        if len(lines) >= max_insns:
+            truncated = True
+            break
+        line = ida_lines.generate_disasm_line(item_ea, 0)
+        instruction = ida_lines.tag_remove(line) if line else ""
+        lines.append(f"{item_ea:x}  {instruction}")
+    return lines, truncated
+
+
+def _collect_basic_blocks_limited(
+    func: ida_funcs.func_t, max_blocks: int
+) -> tuple[list[BasicBlock], bool]:
+    blocks: list[BasicBlock] = []
+    truncated = False
+    for block in idaapi.FlowChart(func):
+        if len(blocks) >= max_blocks:
+            truncated = True
+            break
+        blocks.append(
+            BasicBlock(
+                start=hex(block.start_ea),
+                end=hex(block.end_ea),
+                size=block.end_ea - block.start_ea,
+                type=block.type,
+                successors=[hex(s.start_ea) for s in block.succs()],
+                predecessors=[hex(p.start_ea) for p in block.preds()],
+            )
+        )
+    return blocks, truncated
+
+
+def _collect_callees_for_function(func: ida_funcs.func_t) -> list[dict]:
+    callees: dict[int, dict] = {}
+    for item_ea in idautils.FuncItems(func.start_ea):
+        for target in idautils.CodeRefsFrom(item_ea, 0):
+            callee = idaapi.get_func(target)
+            if not callee:
+                continue
+            callee_start = callee.start_ea
+            if callee_start in callees:
+                continue
+            callees[callee_start] = {
+                "addr": hex(callee_start),
+                "name": ida_funcs.get_func_name(callee_start) or "<unnamed>",
+            }
+    return list(callees.values())
+
+
+def _collect_callers_for_function(func: ida_funcs.func_t) -> list[dict]:
+    callers: dict[int, dict] = {}
+    for caller_site in idautils.CodeRefsTo(func.start_ea, 0):
+        caller = idaapi.get_func(caller_site)
+        if not caller:
+            continue
+        caller_start = caller.start_ea
+        if caller_start in callers:
+            continue
+
+        insn = idaapi.insn_t()
+        idaapi.decode_insn(insn, caller_site)
+        if insn.itype not in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]:
+            continue
+
+        callers[caller_start] = {
+            "addr": hex(caller_start),
+            "name": ida_funcs.get_func_name(caller_start) or "<unnamed>",
+        }
+    return list(callers.values())
+
+
+def _profile_function(
+    start_ea: int,
+    include_lists: bool,
+    max_items: int,
+    include_prototype: bool,
+) -> dict:
+    func = idaapi.get_func(start_ea)
+    if not func:
+        return {"addr": hex(start_ea), "error": "Function not found"}
+
+    name = ida_funcs.get_func_name(func.start_ea) or "<unnamed>"
+    size_int = func.end_ea - func.start_ea
+    has_type = ida_nalt.get_tinfo(ida_typeinf.tinfo_t(), func.start_ea)
+
+    instruction_count = sum(1 for _ in idautils.FuncItems(func.start_ea))
+    basic_block_count = sum(1 for _ in idaapi.FlowChart(func))
+    callers = _collect_callers_for_function(func)
+    callees = _collect_callees_for_function(func)
+    strings = extract_function_strings(func.start_ea)
+    constants = extract_function_constants(func.start_ea)
+
+    out = {
+        "addr": hex(func.start_ea),
+        "name": name,
+        "size": hex(size_int),
+        "size_int": size_int,
+        "instruction_count": instruction_count,
+        "basic_block_count": basic_block_count,
+        "caller_count": len(callers),
+        "callee_count": len(callees),
+        "string_ref_count": len(strings),
+        "constant_count": len(constants),
+        "has_type": has_type,
+        "prototype": None,
+        "error": None,
+    }
+
+    if include_prototype:
+        out["prototype"] = get_prototype(func)
+
+    if include_lists:
+        callers_limited, callers_truncated = _limit_items(callers, max_items)
+        callees_limited, callees_truncated = _limit_items(callees, max_items)
+        strings_limited, strings_truncated = _limit_items(strings, max_items)
+        constants_limited, constants_truncated = _limit_items(constants, max_items)
+
+        out["callers"] = callers_limited
+        out["callers_truncated"] = callers_truncated
+        out["callees"] = callees_limited
+        out["callees_truncated"] = callees_truncated
+        out["strings"] = strings_limited
+        out["strings_truncated"] = strings_truncated
+        out["constants"] = constants_limited
+        out["constants_truncated"] = constants_truncated
+
+    return out
+
+
 # ============================================================================
 # Code Analysis & Decompilation
 # ============================================================================
@@ -167,7 +368,7 @@ def _resolve_immediate_insn_start(
 def decompile(
     addr: Annotated[str, "Function address or name to decompile"],
 ) -> dict:
-    """Decompile function to pseudocode"""
+    """Decompile function(s) at address(es); returns pseudocode and per-item errors."""
     try:
         try:
             start = parse_address(addr)
@@ -201,7 +402,7 @@ def disasm(
         bool, "Compute total instruction count (default: false)"
     ] = False,
 ) -> dict:
-    """Disassemble function to assembly instructions"""
+    """Disassemble function with offset/max_instructions pagination and optional total count."""
 
     # Enforce max limit
     if max_instructions <= 0 or max_instructions > 50000:
@@ -340,6 +541,329 @@ def disasm(
 
 
 # ============================================================================
+# Batch Analysis & Profiling
+# ============================================================================
+
+
+@tool
+@idasync
+@tool_timeout(120.0)
+def func_profile(
+    queries: Annotated[
+        list[FuncProfileQuery] | FuncProfileQuery | str,
+        "Function profiling query (supports name/address filters + pagination)",
+    ],
+) -> list[dict]:
+    """Profile functions with summary metrics and optional sampled details."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "query": s,
+            "offset": 0,
+            "count": 50,
+            "sort_by": "addr",
+            "descending": False,
+            "include_lists": False,
+            "max_items": 25,
+            "include_prototype": False,
+        },
+    )
+
+    results: list[dict] = []
+    for query in queries:
+        q = str(query.get("query", "*") or "*").strip()
+        filter_pattern = str(query.get("filter", "") or "")
+        offset = _clamp_int(query.get("offset", 0), 0, 0, 2_000_000_000)
+        count = _clamp_int(query.get("count", 50), 50, 0, 1000)
+        sort_by = str(query.get("sort_by", "addr") or "addr")
+        descending = bool(query.get("descending", False))
+        include_lists = bool(query.get("include_lists", False))
+        max_items = _clamp_int(query.get("max_items", 25), 25, 0, 1000)
+        include_prototype = bool(query.get("include_prototype", False))
+
+        # Resolve candidate function starts.
+        candidates: list[dict] = []
+        if q not in ("", "*"):
+            start_ea, err = _resolve_function_start(q)
+            if err is not None or start_ea is None:
+                results.append(
+                    {
+                        "query": q,
+                        "data": [],
+                        "next_offset": None,
+                        "error": err or "Failed to resolve function",
+                    }
+                )
+                continue
+            fn = idaapi.get_func(start_ea)
+            if fn:
+                candidates.append(
+                    {
+                        "start_ea": fn.start_ea,
+                        "addr": hex(fn.start_ea),
+                        "name": ida_funcs.get_func_name(fn.start_ea) or "<unnamed>",
+                        "size_int": fn.end_ea - fn.start_ea,
+                        "size": hex(fn.end_ea - fn.start_ea),
+                    }
+                )
+        else:
+            for start_ea in idautils.Functions():
+                fn = idaapi.get_func(start_ea)
+                if not fn:
+                    continue
+                candidates.append(
+                    {
+                        "start_ea": fn.start_ea,
+                        "addr": hex(fn.start_ea),
+                        "name": ida_funcs.get_func_name(fn.start_ea) or "<unnamed>",
+                        "size_int": fn.end_ea - fn.start_ea,
+                        "size": hex(fn.end_ea - fn.start_ea),
+                    }
+                )
+
+        if filter_pattern:
+            candidates = pattern_filter(candidates, filter_pattern, "name")
+
+        if sort_by == "name":
+            candidates.sort(key=lambda f: f["name"].lower(), reverse=descending)
+        elif sort_by == "size":
+            candidates.sort(key=lambda f: f["size_int"], reverse=descending)
+        else:
+            candidates.sort(key=lambda f: f["start_ea"], reverse=descending)
+
+        page = paginate(candidates, offset, count)
+        profiled: list[dict] = []
+        for item in page["data"]:
+            profiled.append(
+                _profile_function(
+                    int(item["start_ea"]),
+                    include_lists=include_lists,
+                    max_items=max_items,
+                    include_prototype=include_prototype,
+                )
+            )
+
+        for item in profiled:
+            item.pop("size_int", None)
+
+        results.append(
+            {
+                "query": q,
+                "data": profiled,
+                "next_offset": page["next_offset"],
+                "error": None,
+            }
+        )
+
+    return results
+
+
+@tool
+@idasync
+@tool_timeout(120.0)
+def analyze_batch(
+    queries: Annotated[
+        list[AnalyzeBatchQuery] | AnalyzeBatchQuery | str,
+        "Comprehensive per-function analysis with selectable sections",
+    ],
+) -> list[dict]:
+    """Run comprehensive analysis over one or more target functions."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "query": s,
+            "include_decompile": True,
+            "include_disasm": False,
+            "include_xrefs": True,
+            "include_callers": True,
+            "include_callees": True,
+            "include_strings": True,
+            "include_constants": True,
+            "include_basic_blocks": True,
+            "include_proto": True,
+            "max_disasm_insns": 300,
+            "max_callers": 100,
+            "max_callees": 100,
+            "max_strings": 100,
+            "max_constants": 200,
+            "max_blocks": 500,
+        },
+    )
+
+    results: list[dict] = []
+    for query in queries:
+        q = str(query.get("query", "") or query.get("addr", "") or "").strip()
+        if not q:
+            results.append(
+                {
+                    "query": q,
+                    "addr": None,
+                    "name": None,
+                    "analysis": None,
+                    "error": "Function query is required",
+                }
+            )
+            continue
+
+        start_ea, err = _resolve_function_start(q)
+        if err is not None or start_ea is None:
+            results.append(
+                {
+                    "query": q,
+                    "addr": None,
+                    "name": None,
+                    "analysis": None,
+                    "error": err or "Failed to resolve function",
+                }
+            )
+            continue
+
+        try:
+            fn = idaapi.get_func(start_ea)
+            if not fn:
+                raise RuntimeError(f"Function not found: {q}")
+
+            fn_name = ida_funcs.get_func_name(fn.start_ea) or "<unnamed>"
+            size_int = fn.end_ea - fn.start_ea
+
+            include_decompile = bool(query.get("include_decompile", True))
+            include_disasm = bool(query.get("include_disasm", False))
+            include_xrefs = bool(query.get("include_xrefs", True))
+            include_callers = bool(query.get("include_callers", True))
+            include_callees = bool(query.get("include_callees", True))
+            include_strings = bool(query.get("include_strings", True))
+            include_constants = bool(query.get("include_constants", True))
+            include_basic_blocks = bool(query.get("include_basic_blocks", True))
+            include_proto = bool(query.get("include_proto", True))
+
+            max_disasm_insns = _clamp_int(
+                query.get("max_disasm_insns", 300), 300, 0, 50_000
+            )
+            max_callers = _clamp_int(query.get("max_callers", 100), 100, 0, 5000)
+            max_callees = _clamp_int(query.get("max_callees", 100), 100, 0, 5000)
+            max_strings = _clamp_int(query.get("max_strings", 100), 100, 0, 5000)
+            max_constants = _clamp_int(
+                query.get("max_constants", 200), 200, 0, 10000
+            )
+            max_blocks = _clamp_int(query.get("max_blocks", 500), 500, 0, 10000)
+
+            analysis: dict = {
+                "size": hex(size_int),
+                "prototype": None,
+                "decompile": None,
+                "decompile_error": None,
+                "disasm": None,
+                "xrefs": None,
+                "callers": None,
+                "caller_count": 0,
+                "callers_truncated": False,
+                "callees": None,
+                "callee_count": 0,
+                "callees_truncated": False,
+                "strings": None,
+                "string_ref_count": 0,
+                "strings_truncated": False,
+                "constants": None,
+                "constant_count": 0,
+                "constants_truncated": False,
+                "basic_blocks": None,
+                "basic_block_count": 0,
+                "basic_blocks_truncated": False,
+            }
+
+            if include_proto:
+                analysis["prototype"] = get_prototype(fn)
+
+            if include_decompile:
+                code = decompile_function_safe(fn.start_ea)
+                analysis["decompile"] = code
+                if code is None:
+                    analysis["decompile_error"] = "Decompilation failed"
+
+            if include_disasm:
+                lines, disasm_truncated = _disasm_lines_limited(fn, max_disasm_insns)
+                analysis["disasm"] = {
+                    "lines": lines,
+                    "instruction_count": len(lines),
+                    "truncated": disasm_truncated,
+                }
+
+            if include_xrefs:
+                xrefs = get_all_xrefs(fn.start_ea)
+                xrefs_to = list(xrefs.get("to", []))
+                xrefs_from = list(xrefs.get("from", []))
+                xrefs_to, xto_trunc = _limit_items(xrefs_to, 200)
+                xrefs_from, xfrom_trunc = _limit_items(xrefs_from, 200)
+                analysis["xrefs"] = {
+                    "to": xrefs_to,
+                    "from": xrefs_from,
+                    "to_truncated": xto_trunc,
+                    "from_truncated": xfrom_trunc,
+                    "to_count": len(xrefs.get("to", [])),
+                    "from_count": len(xrefs.get("from", [])),
+                }
+
+            if include_callers:
+                callers = get_callers(hex(fn.start_ea), limit=max_callers)
+                analysis["caller_count"] = len(callers)
+                analysis["callers"] = callers
+                analysis["callers_truncated"] = (
+                    max_callers > 0 and len(callers) >= max_callers
+                )
+
+            if include_callees:
+                all_callees = get_callees(hex(fn.start_ea))
+                limited_callees, callees_truncated = _limit_items(all_callees, max_callees)
+                analysis["callee_count"] = len(all_callees)
+                analysis["callees"] = limited_callees
+                analysis["callees_truncated"] = callees_truncated
+
+            if include_strings:
+                all_strings = extract_function_strings(fn.start_ea)
+                limited_strings, strings_truncated = _limit_items(all_strings, max_strings)
+                analysis["string_ref_count"] = len(all_strings)
+                analysis["strings"] = limited_strings
+                analysis["strings_truncated"] = strings_truncated
+
+            if include_constants:
+                all_constants = extract_function_constants(fn.start_ea)
+                limited_constants, constants_truncated = _limit_items(
+                    all_constants, max_constants
+                )
+                analysis["constant_count"] = len(all_constants)
+                analysis["constants"] = limited_constants
+                analysis["constants_truncated"] = constants_truncated
+
+            if include_basic_blocks:
+                blocks, blocks_truncated = _collect_basic_blocks_limited(fn, max_blocks)
+                analysis["basic_block_count"] = len(blocks)
+                analysis["basic_blocks"] = blocks
+                analysis["basic_blocks_truncated"] = blocks_truncated
+
+            results.append(
+                {
+                    "query": q,
+                    "addr": hex(fn.start_ea),
+                    "name": fn_name,
+                    "analysis": analysis,
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            results.append(
+                {
+                    "query": q,
+                    "addr": hex(start_ea),
+                    "name": None,
+                    "analysis": None,
+                    "error": str(e),
+                }
+            )
+
+    return results
+
+
+# ============================================================================
 # Cross-Reference Analysis
 # ============================================================================
 
@@ -350,7 +874,7 @@ def xrefs_to(
     addrs: Annotated[list[str] | str, "Addresses to find cross-references to"],
     limit: Annotated[int, "Max xrefs per address (default: 100, max: 1000)"] = 100,
 ) -> list[dict]:
-    """Get cross-references to specified addresses"""
+    """Return xrefs to address(es), capped per target with truncation flag."""
     addrs = normalize_list_input(addrs)
 
     if limit <= 0 or limit > 1000:
@@ -376,6 +900,139 @@ def xrefs_to(
             results.append({"addr": addr, "xrefs": xrefs, "more": more})
         except Exception as e:
             results.append({"addr": addr, "xrefs": None, "error": str(e)})
+
+    return results
+
+
+@tool
+@idasync
+def xref_query(
+    queries: Annotated[
+        list[XrefQuery] | XrefQuery | str,
+        "Generic xref query with direction/type filters and pagination",
+    ],
+) -> list[dict]:
+    """Query xrefs with direction/type filters and pagination."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "query": s,
+            "direction": "both",
+            "xref_type": "any",
+            "offset": 0,
+            "count": 200,
+            "include_fn": True,
+            "dedup": True,
+            "sort_by": "addr",
+            "descending": False,
+        },
+    )
+
+    results: list[dict] = []
+    for query in queries:
+        q = str(query.get("query", "")).strip()
+        direction = str(query.get("direction", "both") or "both").lower()
+        xref_type = str(query.get("xref_type", "any") or "any").lower()
+        offset = _clamp_int(query.get("offset", 0), 0, 0, 2_000_000_000)
+        count = _clamp_int(query.get("count", 200), 200, 0, 5000)
+        include_fn = bool(query.get("include_fn", True))
+        dedup = bool(query.get("dedup", True))
+        sort_by = str(query.get("sort_by", "addr") or "addr")
+        descending = bool(query.get("descending", False))
+
+        if direction not in {"to", "from", "both"}:
+            direction = "both"
+        if xref_type not in {"any", "code", "data"}:
+            xref_type = "any"
+
+        try:
+            if not q:
+                raise ValueError("query is required")
+            try:
+                target = parse_address(q)
+            except Exception:
+                target = idaapi.get_name_ea(idaapi.BADADDR, q)
+                if target == idaapi.BADADDR:
+                    raise ValueError(f"Failed to resolve address/name: {q}")
+
+            rows: list[dict] = []
+            if direction in {"to", "both"}:
+                for xr in idautils.XrefsTo(target, 0):
+                    kind = "code" if xr.iscode else "data"
+                    if xref_type != "any" and kind != xref_type:
+                        continue
+                    row = {
+                        "direction": "to",
+                        "addr": hex(xr.frm),
+                        "from": hex(xr.frm),
+                        "to": hex(target),
+                        "type": kind,
+                    }
+                    if include_fn:
+                        row["fn"] = get_function(xr.frm, raise_error=False)
+                    rows.append(row)
+
+            if direction in {"from", "both"}:
+                for xr in idautils.XrefsFrom(target, 0):
+                    kind = "code" if xr.iscode else "data"
+                    if xref_type != "any" and kind != xref_type:
+                        continue
+                    row = {
+                        "direction": "from",
+                        "addr": hex(xr.to),
+                        "from": hex(target),
+                        "to": hex(xr.to),
+                        "type": kind,
+                    }
+                    if include_fn:
+                        row["fn"] = get_function(xr.to, raise_error=False)
+                    rows.append(row)
+
+            if dedup:
+                seen = set()
+                deduped = []
+                for row in rows:
+                    key = (row["direction"], row["from"], row["to"], row["type"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    deduped.append(row)
+                rows = deduped
+
+            if sort_by == "type":
+                rows.sort(
+                    key=lambda r: (str(r.get("type", "")), int(str(r["addr"]), 16)),
+                    reverse=descending,
+                )
+            else:
+                rows.sort(key=lambda r: int(str(r["addr"]), 16), reverse=descending)
+
+            page = paginate(rows, offset, count)
+            results.append(
+                {
+                    "query": q,
+                    "resolved_addr": hex(target),
+                    "direction": direction,
+                    "xref_type": xref_type,
+                    "data": page["data"],
+                    "next_offset": page["next_offset"],
+                    "total": len(rows),
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            results.append(
+                {
+                    "query": q,
+                    "resolved_addr": None,
+                    "direction": direction,
+                    "xref_type": xref_type,
+                    "data": [],
+                    "next_offset": None,
+                    "total": 0,
+                    "error": str(e),
+                }
+            )
 
     return results
 
@@ -478,7 +1135,7 @@ def callees(
     addrs: Annotated[list[str] | str, "Function addresses to get callees for"],
     limit: Annotated[int, "Max callees per function (default: 200, max: 500)"] = 200,
 ) -> list[dict]:
-    """Get functions called by the specified functions"""
+    """Return unique callees per function, capped by limit."""
     addrs = normalize_list_input(addrs)
 
     if limit <= 0 or limit > 500:
@@ -563,7 +1220,7 @@ def find_bytes(
     limit: Annotated[int, "Max matches per pattern (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
 ) -> list[dict]:
-    """Search for byte patterns in the binary (supports wildcards with ??)"""
+    """Search byte patterns (supports ??) with offset/limit pagination."""
     patterns = normalize_list_input(patterns)
 
     # Enforce max limit
@@ -651,7 +1308,7 @@ def basic_blocks(
     ] = 1000,
     offset: Annotated[int, "Skip first N blocks (default: 0)"] = 0,
 ) -> list[dict]:
-    """Get control flow graph basic blocks for functions"""
+    """Return function CFG blocks with offset/max_blocks pagination."""
     addrs = normalize_list_input(addrs)
 
     # Enforce max limit
@@ -735,7 +1392,7 @@ def find(
     limit: Annotated[int, "Max matches per target (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
 ) -> list[dict]:
-    """Search for patterns in the binary (strings, immediate values, or references)"""
+    """Search strings/immediates/refs for targets with offset/limit pagination."""
     if not isinstance(targets, list):
         targets = [targets]
 
@@ -1102,6 +1759,131 @@ def _scan_insn_ranges(
     return matches, more, scanned, truncated, next_start
 
 
+@tool
+@idasync
+def insn_query(
+    queries: Annotated[
+        list[InsnPattern] | InsnPattern | str,
+        "Instruction query with mnemonic/operand filters and scoped scan",
+    ],
+) -> list[dict]:
+    """Query instructions with mnemonic/operand filters and scoped scans."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "mnem": s,
+            "offset": 0,
+            "count": 100,
+            "max_scan_insns": 200000,
+            "allow_broad": False,
+            "include_fn": False,
+            "include_disasm": False,
+        },
+    )
+
+    results: list[dict] = []
+    for pattern in queries:
+        mnem = str(pattern.get("mnem", "") or "").strip().lower()
+        if mnem == "*":
+            mnem = ""
+
+        offset = _clamp_int(pattern.get("offset", 0), 0, 0, 2_000_000_000)
+        count = _clamp_int(pattern.get("count", 100), 100, 0, 5000)
+        max_scan_insns = _clamp_int(
+            pattern.get("max_scan_insns", 200000), 200000, 1, 2_000_000
+        )
+        allow_broad = bool(pattern.get("allow_broad", False))
+        include_fn = bool(pattern.get("include_fn", False))
+        include_disasm = bool(pattern.get("include_disasm", False))
+
+        summary = {
+            "mnem": mnem or None,
+            "op0": pattern.get("op0"),
+            "op1": pattern.get("op1"),
+            "op2": pattern.get("op2"),
+            "op_any": pattern.get("op_any"),
+            "func": pattern.get("func"),
+            "segment": pattern.get("segment"),
+            "start": pattern.get("start"),
+            "end": pattern.get("end"),
+            "offset": offset,
+            "count": count,
+            "max_scan_insns": max_scan_insns,
+            "allow_broad": allow_broad,
+        }
+
+        try:
+            op0_val = _parse_optional_int(pattern.get("op0"), "op0")
+            op1_val = _parse_optional_int(pattern.get("op1"), "op1")
+            op2_val = _parse_optional_int(pattern.get("op2"), "op2")
+            any_val = _parse_optional_int(pattern.get("op_any"), "op_any")
+
+            ranges, range_error = _resolve_insn_scan_ranges(pattern, allow_broad)
+            if range_error:
+                raise ValueError(range_error)
+
+            addresses, more, scanned, truncated, next_start = _scan_insn_ranges(
+                ranges,
+                mnem,
+                op0_val,
+                op1_val,
+                op2_val,
+                any_val,
+                count,
+                offset,
+                max_scan_insns,
+            )
+
+            rows = []
+            for addr_s in addresses:
+                ea = int(addr_s, 16)
+                row = {"addr": addr_s}
+                if include_disasm:
+                    line = ida_lines.generate_disasm_line(ea, 0)
+                    row["disasm"] = ida_lines.tag_remove(line) if line else ""
+                if include_fn:
+                    row["fn"] = get_function(ea, raise_error=False)
+                rows.append(row)
+
+            summary["op0"] = op0_val
+            summary["op1"] = op1_val
+            summary["op2"] = op2_val
+            summary["op_any"] = any_val
+
+            results.append(
+                {
+                    "query": summary,
+                    "ranges": [
+                        {"start": hex(start_ea), "end": hex(end_ea)}
+                        for start_ea, end_ea in ranges
+                    ],
+                    "matches": rows,
+                    "count": len(rows),
+                    "cursor": {"next": offset + count} if more else {"done": True},
+                    "scanned": scanned,
+                    "truncated": truncated,
+                    "next_start": hex(next_start) if next_start is not None else None,
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            results.append(
+                {
+                    "query": summary,
+                    "ranges": [],
+                    "matches": [],
+                    "count": 0,
+                    "cursor": {"done": True},
+                    "scanned": 0,
+                    "truncated": False,
+                    "next_start": None,
+                    "error": str(e),
+                }
+            )
+
+    return results
+
+
 # ============================================================================
 # Export Operations
 # ============================================================================
@@ -1115,7 +1897,7 @@ def export_funcs(
         str, "Export format: json (default), c_header, or prototypes"
     ] = "json",
 ) -> dict:
-    """Export function data in various formats"""
+    """Export function data for addresses in json/c_header/prototypes formats."""
     addrs = normalize_list_input(addrs)
     results = []
 
@@ -1188,7 +1970,7 @@ def callgraph(
         int, "Max edges per function (default: 200, max: 5000)"
     ] = 200,
 ) -> list[dict]:
-    """Build call graph starting from root functions"""
+    """Build bounded callgraph from roots with depth/node/edge limits."""
     roots = normalize_list_input(roots)
     if max_depth < 0:
         max_depth = 0

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -4,15 +4,40 @@ import re
 import time
 from typing import Annotated
 
+import ida_auto
 import idaapi
+import ida_funcs
+import ida_hexrays
 import idautils
+import ida_loader
 import ida_nalt
+import ida_typeinf
+import idc
 
 from .rpc import tool
 from .sync import idasync
+from .utils import (
+    ConvertedNumber,
+    EntityQuery,
+    Function,
+    FunctionQuery,
+    Global,
+    Import,
+    ListQuery,
+    NumberConversion,
+    Page,
+    ImportQuery,
+    get_function,
+    normalize_dict_list,
+    normalize_list_input,
+    parse_address,
+    paginate,
+    pattern_filter,
+)
 
 # Cached strings list: [(ea, text), ...]
 _strings_cache: list[tuple[int, str]] | None = None
+_server_started_at = time.time()
 
 
 def _get_strings_cache() -> list[tuple[int, str]]:
@@ -35,22 +60,6 @@ def init_caches():
     strings = _get_strings_cache()
     t1 = time.perf_counter()
     print(f"[MCP] Cached {len(strings)} strings in {(t1 - t0) * 1000:.0f}ms")
-
-
-from .utils import (
-    Function,
-    ConvertedNumber,
-    Global,
-    Import,
-    Page,
-    NumberConversion,
-    ListQuery,
-    normalize_list_input,
-    normalize_dict_list,
-    get_function,
-    paginate,
-    pattern_filter,
-)
 
 
 # ============================================================================
@@ -77,6 +86,233 @@ def _parse_func_query(query: str) -> int:
             pass
 
     return idaapi.BADADDR
+
+
+def _coerce_sort_number(value, default: int = 0) -> int:
+    """Parse decimal or prefixed string numbers used by generic entity rows."""
+    if value in (None, ""):
+        return default
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value), 0)
+    except (TypeError, ValueError):
+        return default
+
+
+def _collect_imports() -> list[Import]:
+    """Collect all imports in the current database."""
+    all_imports: list[Import] = []
+    nimps = ida_nalt.get_import_module_qty()
+
+    for i in range(nimps):
+        module_name = ida_nalt.get_import_module_name(i)
+        if not module_name:
+            module_name = "<unnamed>"
+
+        def imp_cb(ea, symbol_name, ordinal, acc):
+            if not symbol_name:
+                symbol_name = f"#{ordinal}"
+            acc += [Import(addr=hex(ea), imported_name=symbol_name, module=module_name)]
+            return True
+
+        def imp_cb_w_context(ea, symbol_name, ordinal):
+            return imp_cb(ea, symbol_name, ordinal, all_imports)
+
+        ida_nalt.enum_import_names(i, imp_cb_w_context)
+
+    return all_imports
+
+
+def _segment_name_for_ea(ea: int) -> str | None:
+    seg = idaapi.getseg(ea)
+    if not seg:
+        return None
+    try:
+        return idaapi.get_segm_name(seg)
+    except Exception:
+        return None
+
+
+def _primary_text_key(kind: str) -> str:
+    if kind == "strings":
+        return "text"
+    return "name"
+
+
+def _collect_entities(kind: str) -> list[dict]:
+    if kind == "functions":
+        rows: list[dict] = []
+        for ea in idautils.Functions():
+            fn = idaapi.get_func(ea)
+            if not fn:
+                continue
+            size_int = fn.end_ea - fn.start_ea
+            rows.append(
+                {
+                    "kind": "function",
+                    "addr": hex(fn.start_ea),
+                    "name": ida_funcs.get_func_name(fn.start_ea) or "<unnamed>",
+                    "size": hex(size_int),
+                    "size_int": size_int,
+                    "segment": _segment_name_for_ea(fn.start_ea),
+                    "has_type": bool(ida_nalt.get_tinfo(ida_typeinf.tinfo_t(), fn.start_ea)),
+                }
+            )
+        return rows
+
+    if kind == "globals":
+        rows = []
+        for ea, name in idautils.Names():
+            if idaapi.get_func(ea) or name is None:
+                continue
+            rows.append(
+                {
+                    "kind": "global",
+                    "addr": hex(ea),
+                    "name": name,
+                    "size": idc.get_item_size(ea),
+                    "segment": _segment_name_for_ea(ea),
+                }
+            )
+        return rows
+
+    if kind == "imports":
+        rows = []
+        for imp in _collect_imports():
+            rows.append(
+                {
+                    "kind": "import",
+                    "addr": imp["addr"],
+                    "name": imp["imported_name"],
+                    "module": imp["module"],
+                }
+            )
+        return rows
+
+    if kind == "strings":
+        rows = []
+        for ea, text in _get_strings_cache():
+            rows.append(
+                {
+                    "kind": "string",
+                    "addr": hex(ea),
+                    "text": text,
+                    "length": len(text),
+                    "segment": _segment_name_for_ea(ea),
+                }
+            )
+        return rows
+
+    if kind == "names":
+        rows = []
+        imports_by_ea = {int(imp["addr"], 16): imp for imp in _collect_imports()}
+        for ea, name in idautils.Names():
+            is_function = bool(idaapi.get_func(ea))
+            is_import = ea in imports_by_ea
+            rows.append(
+                {
+                    "kind": "name",
+                    "addr": hex(ea),
+                    "name": name,
+                    "segment": _segment_name_for_ea(ea),
+                    "is_function": is_function,
+                    "is_import": is_import,
+                }
+            )
+        return rows
+
+    return []
+
+
+def _apply_projection(items: list[dict], fields: list[str] | None) -> list[dict]:
+    if not fields:
+        return items
+    normalized = [str(f).strip() for f in fields if str(f).strip()]
+    if not normalized:
+        return items
+    keep = set(normalized)
+    keep.add("kind")
+    projected = []
+    for item in items:
+        projected.append({k: v for k, v in item.items() if k in keep})
+    return projected
+
+
+def _build_health_payload() -> dict:
+    auto_is_ok = getattr(ida_auto, "auto_is_ok", None)
+    auto_analysis_ready = bool(auto_is_ok()) if callable(auto_is_ok) else None
+
+    hexrays_ready = False
+    try:
+        hexrays_ready = bool(ida_hexrays.init_hexrays_plugin())
+    except Exception:
+        hexrays_ready = False
+
+    idb_path = None
+    try:
+        idb_path = idc.get_idb_path()
+    except Exception:
+        idb_path = None
+
+    return {
+        "status": "ok",
+        "uptime_sec": round(time.time() - _server_started_at, 3),
+        "idb_path": idb_path,
+        "module": ida_nalt.get_root_filename(),
+        "input_path": ida_nalt.get_input_file_path(),
+        "imagebase": hex(idaapi.get_imagebase()),
+        "auto_analysis_ready": auto_analysis_ready,
+        "hexrays_ready": hexrays_ready,
+        "strings_cache_ready": _strings_cache is not None,
+        "strings_cache_size": len(_strings_cache) if _strings_cache is not None else 0,
+    }
+
+
+@tool
+@idasync
+def server_health() -> dict:
+    """Health/ready probe for MCP server and current IDB state."""
+    return _build_health_payload()
+
+
+@tool
+@idasync
+def server_warmup(
+    wait_auto_analysis: Annotated[bool, "Wait for auto analysis queue"] = True,
+    build_caches: Annotated[bool, "Build core caches (currently strings)"] = True,
+    init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler plugin"] = True,
+) -> dict:
+    """Warm up IDA subsystems to reduce first-call latency and transient failures."""
+    steps = []
+
+    if wait_auto_analysis:
+        t0 = time.perf_counter()
+        ida_auto.auto_wait()
+        steps.append({"step": "auto_wait", "ok": True, "ms": round((time.perf_counter() - t0) * 1000, 2)})
+
+    if build_caches:
+        t0 = time.perf_counter()
+        init_caches()
+        steps.append({"step": "init_caches", "ok": True, "ms": round((time.perf_counter() - t0) * 1000, 2)})
+
+    if init_hexrays:
+        t0 = time.perf_counter()
+        ok = bool(ida_hexrays.init_hexrays_plugin())
+        steps.append(
+            {
+                "step": "init_hexrays",
+                "ok": ok,
+                "ms": round((time.perf_counter() - t0) * 1000, 2),
+                "error": None if ok else "Hex-Rays unavailable",
+            }
+        )
+
+    return {
+        "ok": all(bool(step.get("ok")) for step in steps),
+        "steps": steps,
+        "health": _build_health_payload(),
+    }
 
 
 @tool
@@ -199,7 +435,7 @@ def list_funcs(
         "List functions with optional filtering and pagination",
     ],
 ) -> list[Page[Function]]:
-    """List functions"""
+    """List functions with optional filtering and offset/count pagination."""
     queries = normalize_dict_list(
         queries, lambda s: {"offset": 0, "count": 50, "filter": s}
     )
@@ -223,13 +459,104 @@ def list_funcs(
 
 @tool
 @idasync
+def func_query(
+    queries: Annotated[
+        list[FunctionQuery] | FunctionQuery | str,
+        "Richer function query (size/type/name filters + pagination)",
+    ],
+) -> list[dict]:
+    """Query functions with richer filtering than list_funcs."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "filter": s,
+            "offset": 0,
+            "count": 50,
+            "sort_by": "addr",
+            "descending": False,
+        },
+    )
+
+    all_functions: list[dict] = []
+    for addr in idautils.Functions():
+        fn = idaapi.get_func(addr)
+        if not fn:
+            continue
+        size_int = fn.end_ea - fn.start_ea
+        fn_name = ida_funcs.get_func_name(fn.start_ea) or "<unnamed>"
+        has_type = ida_nalt.get_tinfo(ida_typeinf.tinfo_t(), fn.start_ea)
+        all_functions.append(
+            {
+                "addr": hex(fn.start_ea),
+                "name": fn_name,
+                "size": hex(size_int),
+                "size_int": size_int,
+                "has_type": has_type,
+            }
+        )
+
+    def apply_name_regex(items: list[dict], expr: str) -> list[dict]:
+        if not expr:
+            return items
+        try:
+            compiled = re.compile(expr)
+        except re.error:
+            return []
+        return [item for item in items if compiled.search(item["name"])]
+
+    results = []
+    for query in queries:
+        offset = query.get("offset", 0)
+        count = query.get("count", 50)
+        sort_by = query.get("sort_by", "addr")
+        descending = bool(query.get("descending", False))
+        if sort_by not in ("addr", "name", "size"):
+            sort_by = "addr"
+
+        filtered = all_functions
+        name_filter = query.get("filter", "")
+        if name_filter:
+            filtered = pattern_filter(filtered, name_filter, "name")
+
+        name_regex = query.get("name_regex", "")
+        if name_regex:
+            filtered = apply_name_regex(filtered, name_regex)
+
+        min_size = query.get("min_size")
+        if min_size is not None:
+            filtered = [f for f in filtered if f["size_int"] >= int(min_size)]
+
+        max_size = query.get("max_size")
+        if max_size is not None:
+            filtered = [f for f in filtered if f["size_int"] <= int(max_size)]
+
+        if "has_type" in query:
+            require_type = bool(query.get("has_type"))
+            filtered = [f for f in filtered if bool(f["has_type"]) is require_type]
+
+        if sort_by == "name":
+            filtered.sort(key=lambda f: f["name"].lower(), reverse=descending)
+        elif sort_by == "size":
+            filtered.sort(key=lambda f: f["size_int"], reverse=descending)
+        else:
+            filtered.sort(key=lambda f: int(f["addr"], 16), reverse=descending)
+
+        page = paginate(filtered, offset, count)
+        page["data"] = [{k: v for k, v in item.items() if k != "size_int"} for item in page["data"]]
+        results.append(page)
+
+    return results
+
+
+@tool
+@idasync
 def list_globals(
     queries: Annotated[
         list[ListQuery] | ListQuery | str,
         "List global variables with optional filtering and pagination",
     ],
 ) -> list[Page[Global]]:
-    """List globals"""
+    """List globals with optional filtering and offset/count pagination."""
     queries = normalize_dict_list(
         queries, lambda s: {"offset": 0, "count": 50, "filter": s}
     )
@@ -256,31 +583,175 @@ def list_globals(
 
 @tool
 @idasync
+def entity_query(
+    queries: Annotated[
+        list[EntityQuery] | EntityQuery | str,
+        "Generic entity query with filtering, projection, and pagination",
+    ],
+) -> list[dict]:
+    """Query IDB entities with typed filters, projection, and pagination."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {"kind": s, "offset": 0, "count": 100, "sort_by": "addr"},
+    )
+    results: list[dict] = []
+
+    for query in queries:
+        kind = str(query.get("kind", "functions") or "functions").lower()
+        if kind not in {"functions", "globals", "imports", "strings", "names"}:
+            results.append(
+                {
+                    "kind": kind,
+                    "data": [],
+                    "next_offset": None,
+                    "total": 0,
+                    "error": f"Unsupported kind: {kind}",
+                }
+            )
+            continue
+
+        rows = _collect_entities(kind)
+        primary_key = _primary_text_key(kind)
+        filter_pattern = str(query.get("filter", "") or "")
+        if filter_pattern:
+            rows = pattern_filter(rows, filter_pattern, primary_key)
+
+        regex = str(query.get("regex", "") or "")
+        if regex:
+            try:
+                compiled = re.compile(regex)
+                rows = [row for row in rows if compiled.search(str(row.get(primary_key, "")))]
+            except re.error:
+                rows = []
+
+        segment_filter = str(query.get("segment", "") or "")
+        if segment_filter and kind in {"functions", "globals", "strings", "names"}:
+            rows = pattern_filter(rows, segment_filter, "segment")
+
+        module_filter = str(query.get("module", "") or "")
+        if module_filter and kind == "imports":
+            rows = pattern_filter(rows, module_filter, "module")
+
+        min_addr = query.get("min_addr")
+        if min_addr not in (None, ""):
+            try:
+                min_ea = parse_address(min_addr)
+                rows = [row for row in rows if int(str(row["addr"]), 16) >= min_ea]
+            except Exception:
+                rows = []
+
+        max_addr = query.get("max_addr")
+        if max_addr not in (None, ""):
+            try:
+                max_ea = parse_address(max_addr)
+                rows = [row for row in rows if int(str(row["addr"]), 16) <= max_ea]
+            except Exception:
+                rows = []
+
+        sort_by = str(query.get("sort_by", "addr") or "addr")
+        descending = bool(query.get("descending", False))
+        if sort_by == "addr":
+            rows.sort(key=lambda row: int(str(row.get("addr", "0x0")), 16), reverse=descending)
+        elif sort_by in {"size", "length"}:
+            rows.sort(
+                key=lambda row: row.get("size_int", _coerce_sort_number(row.get(sort_by, 0))),
+                reverse=descending,
+            )
+        else:
+            rows.sort(key=lambda row: str(row.get(sort_by, "")).lower(), reverse=descending)
+
+        offset = int(query.get("offset", 0) or 0)
+        count = int(query.get("count", 100) or 100)
+        page = paginate(rows, offset, count)
+        data = [{k: v for k, v in item.items() if k != "size_int"} for item in page["data"]]
+
+        fields_raw = query.get("fields")
+        fields = None
+        if fields_raw is not None:
+            if isinstance(fields_raw, str):
+                fields = normalize_list_input(fields_raw)
+            elif isinstance(fields_raw, list):
+                fields = [str(f) for f in fields_raw]
+            else:
+                fields = [str(fields_raw)]
+        data = _apply_projection(data, fields)
+
+        results.append(
+            {
+                "kind": kind,
+                "data": data,
+                "next_offset": page["next_offset"],
+                "total": len(rows),
+                "error": None,
+            }
+        )
+
+    return results
+
+
+@tool
+@idasync
 def imports(
-    offset: Annotated[int, "Offset"],
-    count: Annotated[int, "Count (0=all)"],
+    offset: Annotated[int, "Starting pagination index (default: 0)"],
+    count: Annotated[int, "Maximum rows (0 returns all imports)"],
 ) -> Page[Import]:
-    """List imports"""
-    nimps = ida_nalt.get_import_module_qty()
+    """List imports with module names using offset/count pagination."""
+    return paginate(_collect_imports(), offset, count)
 
-    rv = []
-    for i in range(nimps):
-        module_name = ida_nalt.get_import_module_name(i)
-        if not module_name:
-            module_name = "<unnamed>"
 
-        def imp_cb(ea, symbol_name, ordinal, acc):
-            if not symbol_name:
-                symbol_name = f"#{ordinal}"
-            acc += [Import(addr=hex(ea), imported_name=symbol_name, module=module_name)]
-            return True
+@tool
+@idasync
+def imports_query(
+    queries: Annotated[
+        list[ImportQuery] | ImportQuery | str,
+        "Import query with import/module filters and pagination",
+    ],
+) -> list[dict]:
+    """Query imports with richer filtering than imports(offset,count)."""
+    queries = normalize_dict_list(
+        queries, lambda s: {"filter": s, "offset": 0, "count": 100}
+    )
+    all_imports = _collect_imports()
+    results = []
 
-        def imp_cb_w_context(ea, symbol_name, ordinal):
-            return imp_cb(ea, symbol_name, ordinal, rv)
+    for query in queries:
+        filtered = all_imports
+        name_filter = query.get("filter", "")
+        module_filter = query.get("module", "")
 
-        ida_nalt.enum_import_names(i, imp_cb_w_context)
+        if name_filter:
+            filtered = pattern_filter(filtered, name_filter, "imported_name")
+        if module_filter:
+            filtered = pattern_filter(filtered, module_filter, "module")
 
-    return paginate(rv, offset, count)
+        results.append(
+            paginate(filtered, query.get("offset", 0), query.get("count", 100))
+        )
+
+    return results
+
+
+@tool
+@idasync
+def idb_save(
+    path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
+) -> dict:
+    """Save active IDB to disk, optionally to a provided path."""
+    try:
+        save_path = path.strip() if path else ""
+        if not save_path:
+            save_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        if not save_path:
+            return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
+
+        ok = bool(ida_loader.save_database(save_path, 0))
+        return {
+            "ok": ok,
+            "path": save_path,
+            "error": None if ok else "save_database returned false",
+        }
+    except Exception as e:
+        return {"ok": False, "path": path or None, "error": str(e)}
 
 
 @tool
@@ -290,7 +761,7 @@ def find_regex(
     limit: Annotated[int, "Max matches (default: 30, max: 500)"] = 30,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
 ) -> dict:
-    """Search strings with case-insensitive regex patterns"""
+    """Search strings by case-insensitive regex with offset/limit pagination."""
     if limit <= 0:
         limit = 30
     if limit > 500:

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -162,7 +162,7 @@ def list_breakpoints():
 @tool
 @idasync
 def dbg_start():
-    """Start debugger"""
+    """Start debugger session for current target."""
     if len(list_breakpoints()) == 0:
         for i in range(ida_entry.get_entry_qty()):
             ordinal = ida_entry.get_entry_ordinal(i)
@@ -182,7 +182,7 @@ def dbg_start():
 @tool
 @idasync
 def dbg_exit():
-    """Exit debugger"""
+    """Terminate active debugger session."""
     dbg_ensure_running()
     if idaapi.exit_process():
         return
@@ -194,7 +194,7 @@ def dbg_exit():
 @tool
 @idasync
 def dbg_continue() -> str:
-    """Continue debugger"""
+    """Resume execution in active debugger session."""
     dbg_ensure_running()
     if idaapi.continue_process():
         ip = ida_dbg.get_ip_val()
@@ -208,9 +208,9 @@ def dbg_continue() -> str:
 @tool
 @idasync
 def dbg_run_to(
-    addr: Annotated[str, "Address"],
+    addr: Annotated[str, "Target execution address (hex or decimal)"],
 ):
-    """Run to address"""
+    """Run debuggee until target address is reached."""
     dbg_ensure_running()
     ea = parse_address(addr)
     if idaapi.run_to(ea):
@@ -225,7 +225,7 @@ def dbg_run_to(
 @tool
 @idasync
 def dbg_step_into():
-    """Step into"""
+    """Execute one instruction, stepping into calls."""
     dbg_ensure_running()
     if idaapi.step_into():
         ip = ida_dbg.get_ip_val()
@@ -239,7 +239,7 @@ def dbg_step_into():
 @tool
 @idasync
 def dbg_step_over():
-    """Step over"""
+    """Execute one instruction, stepping over calls."""
     dbg_ensure_running()
     if idaapi.step_over():
         ip = ida_dbg.get_ip_val()
@@ -258,7 +258,7 @@ def dbg_step_over():
 @tool
 @idasync
 def dbg_bps():
-    """List breakpoints"""
+    """List breakpoints with address and enabled status."""
     return list_breakpoints()
 
 
@@ -269,7 +269,7 @@ def dbg_bps():
 def dbg_add_bp(
     addrs: Annotated[list[str] | str, "Address(es) to add breakpoints at"],
 ) -> list[dict]:
-    """Add breakpoints"""
+    """Add breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
 
@@ -299,7 +299,7 @@ def dbg_add_bp(
 def dbg_delete_bp(
     addrs: Annotated[list[str] | str, "Address(es) to delete breakpoints from"],
 ) -> list[dict]:
-    """Delete breakpoints"""
+    """Delete breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
 
@@ -321,7 +321,7 @@ def dbg_delete_bp(
 @tool
 @idasync
 def dbg_toggle_bp(items: list[BreakpointOp] | BreakpointOp) -> list[dict]:
-    """Enable/disable breakpoints"""
+    """Enable or disable existing breakpoints in batch."""
 
     items = normalize_dict_list(items)
 
@@ -357,7 +357,7 @@ def dbg_toggle_bp(items: list[BreakpointOp] | BreakpointOp) -> list[dict]:
 @tool
 @idasync
 def dbg_regs_all() -> list[ThreadRegisters]:
-    """Get all registers"""
+    """Return full register sets for all debugger threads."""
     result: list[ThreadRegisters] = []
     dbg = dbg_ensure_running()
     for thread_index in range(ida_dbg.get_thread_qty()):
@@ -373,7 +373,7 @@ def dbg_regs_all() -> list[ThreadRegisters]:
 def dbg_regs_remote(
     tids: Annotated[list[int] | int, "Thread ID(s) to get registers for"],
 ) -> list[dict]:
-    """Get thread registers"""
+    """Return full register sets for specified thread IDs."""
     if isinstance(tids, int):
         tids = [tids]
 
@@ -401,7 +401,7 @@ def dbg_regs_remote(
 @tool
 @idasync
 def dbg_regs() -> ThreadRegisters:
-    """Get current thread registers"""
+    """Return full registers for current debugger thread."""
     dbg = dbg_ensure_running()
     tid = ida_dbg.get_current_thread()
     return _get_registers_for_thread(dbg, tid)
@@ -458,7 +458,7 @@ def dbg_regs_named_remote(
         str, "Comma-separated register names (e.g., 'RAX, RBX, RCX')"
     ],
 ) -> ThreadRegisters:
-    """Get specific thread registers"""
+    """Return selected registers for a specific thread ID."""
     dbg = dbg_ensure_running()
     if thread_id not in [
         ida_dbg.getn_thread(i) for i in range(ida_dbg.get_thread_qty())
@@ -494,7 +494,7 @@ def dbg_regs_named(
 @tool
 @idasync
 def dbg_stacktrace() -> list[dict[str, str]]:
-    """Get call stack"""
+    """Return current call stack with module and symbol context."""
     callstack = []
     try:
         tid = ida_dbg.get_current_thread()
@@ -546,7 +546,7 @@ def dbg_stacktrace() -> list[dict[str, str]]:
 @tool
 @idasync
 def dbg_read(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
-    """Read debug memory"""
+    """Read debuggee memory from one or more regions."""
 
     regions = normalize_dict_list(regions)
     dbg_ensure_running()
@@ -590,7 +590,7 @@ def dbg_read(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
 @tool
 @idasync
 def dbg_write(regions: list[MemoryPatch] | MemoryPatch) -> list[dict]:
-    """Write debug memory"""
+    """Write bytes to debuggee memory regions."""
 
     regions = normalize_dict_list(regions)
     dbg_ensure_running()

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -188,8 +188,7 @@ def get_global_value(
         list[str] | str, "Global variable addresses or names to read values from"
     ],
 ) -> list[dict]:
-    """Read global variable values by address or name
-    (auto-detects hex addresses vs names)"""
+    """Read global variable values by address or symbol name."""
     from .utils import looks_like_address
 
     queries = normalize_list_input(queries)

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -16,6 +16,7 @@ from .utils import (
     decompile_checked,
     refresh_decompiler_ctext,
     CommentOp,
+    CommentAppendOp,
     AsmPatchOp,
     FunctionRename,
     GlobalRename,
@@ -116,6 +117,76 @@ def set_comments(items: list[CommentOp] | CommentOp):
 
 @tool
 @idasync
+def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
+    """Append comments at addresses, deduping exact text by default."""
+    if isinstance(items, dict):
+        items = [items]
+
+    results = []
+    for item in items:
+        addr_str = item.get("addr", "")
+        comment = item.get("comment", "")
+        scope = str(item.get("scope", "auto") or "auto").lower()
+        dedupe = bool(item.get("dedupe", True))
+
+        try:
+            ea = parse_address(addr_str)
+            if scope not in {"auto", "func", "line"}:
+                results.append({"addr": addr_str, "error": f"Unsupported scope: {scope}"})
+                continue
+
+            fn = idaapi.get_func(ea)
+            use_func_comment = scope == "func" or (scope == "auto" and fn is not None and fn.start_ea == ea)
+
+            if use_func_comment:
+                if fn is None:
+                    results.append({"addr": addr_str, "error": f"No function found at {hex(ea)}"})
+                    continue
+                target_ea = fn.start_ea
+                current = idc.get_func_cmt(target_ea, False) or ""
+                new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
+                if skipped:
+                    results.append({"addr": addr_str, "ok": True, "scope": "func", "skipped": True})
+                    continue
+                if not idc.set_func_cmt(target_ea, new_comment, False):
+                    results.append(
+                        {"addr": addr_str, "error": f"Failed to set function comment at {hex(target_ea)}"}
+                    )
+                    continue
+                results.append({"addr": addr_str, "ok": True, "scope": "func", "appended": True})
+                continue
+
+            current = idaapi.get_cmt(ea, False) or ""
+            new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
+            if skipped:
+                results.append({"addr": addr_str, "ok": True, "scope": "line", "skipped": True})
+                continue
+            if not idaapi.set_cmt(ea, new_comment, False):
+                results.append({"addr": addr_str, "error": f"Failed to set disassembly comment at {hex(ea)}"})
+                continue
+            results.append({"addr": addr_str, "ok": True, "scope": "line", "appended": True})
+        except Exception as e:
+            results.append({"addr": addr_str, "error": str(e)})
+
+    return results
+
+
+def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> tuple[str, bool]:
+    normalized_new = new_text.strip()
+    if dedupe and normalized_new:
+        existing_entries = [line.strip() for line in current.splitlines()]
+        if normalized_new in existing_entries:
+            return current, True
+    if not current:
+        return new_text, False
+    if not new_text:
+        return current, False
+    joiner = "" if current.endswith("\n") else "\n"
+    return f"{current}{joiner}{new_text}", False
+
+
+@tool
+@idasync
 def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[dict]:
     """Patch assembly instructions at addresses"""
     if isinstance(items, dict):
@@ -158,14 +229,24 @@ def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[dict]:
 
 @tool
 @idasync
-def rename(batch: RenameBatch) -> dict:
-    """Unified rename operation for functions, globals, locals, and stack variables"""
+def rename(batch: RenameBatch | dict) -> dict:
+    """Batch-rename funcs/globals/locals/stack vars with dry-run options."""
+
+    if not isinstance(batch, dict):
+        return {"error": "batch must be a dict"}
+
+    stop_on_error = bool(batch.get("stop_on_error", False))
+    dry_run = bool(batch.get("dry_run", False))
+    allow_overwrite = bool(batch.get("allow_overwrite", False))
 
     def _normalize_items(items):
-        """Convert single item or None to list"""
         if items is None:
             return []
-        return [items] if isinstance(items, dict) else items
+        if isinstance(items, dict):
+            return [items]
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+        return []
 
     def _has_user_name(ea: int) -> bool:
         flags = idaapi.get_flags(ea)
@@ -182,11 +263,33 @@ def rename(batch: RenameBatch) -> dict:
             pass
         return False
 
+    def _set_name_checked(ea: int, new_name: str) -> tuple[bool, str | None]:
+        conflict_ea = idaapi.get_name_ea(idaapi.BADADDR, new_name)
+        if (
+            conflict_ea != idaapi.BADADDR
+            and conflict_ea != ea
+            and not allow_overwrite
+        ):
+            return False, f"Name already exists at {hex(conflict_ea)}"
+
+        if dry_run:
+            return True, None
+
+        flags = idaapi.SN_CHECK
+        if allow_overwrite:
+            flags = idaapi.SN_CHECK | int(getattr(idaapi, "SN_FORCE", 0))
+        ok = idaapi.set_name(ea, new_name, flags)
+        if not ok:
+            return False, "Rename failed"
+        return True, None
+
     def _place_func_in_vibe_dir(ea: int) -> tuple[bool, str | None]:
+        if dry_run:
+            return True, None
+
         tree = ida_dirtree.get_std_dirtree(ida_dirtree.DIRTREE_FUNCS)
         if tree is None:
             return False, "Function dirtree not available"
-
         if not tree.load():
             return False, "Failed to load function dirtree"
 
@@ -211,201 +314,403 @@ def rename(batch: RenameBatch) -> dict:
 
         return True, None
 
-    def _rename_funcs(items: list[FunctionRename]) -> list[dict]:
-        results = []
+    def _rename_funcs(items: list[FunctionRename]) -> tuple[list[dict], bool]:
+        results: list[dict] = []
+        halted = False
         for item in items:
             try:
-                ea = parse_address(item["addr"])
-                had_user_name = _has_user_name(ea)
-                success = idaapi.set_name(ea, item["name"], idaapi.SN_CHECK)
-                if success:
-                    func = idaapi.get_func(ea)
-                    if func:
-                        refresh_decompiler_ctext(func.start_ea)
-                    if not had_user_name and func:
-                        placed, place_error = _place_func_in_vibe_dir(func.start_ea)
-                    else:
-                        placed, place_error = None, None
-                results.append(
-                    {
-                        "addr": item["addr"],
-                        "name": item["name"],
-                        "ok": success,
-                        "error": None if success else "Rename failed",
-                        "dir": "vibe" if success and placed else None,
-                        "dir_error": place_error if success else None,
+                addr_text = item.get("addr") or item.get("func_addr") or item.get("func")
+                new_name = item.get("name") or item.get("new") or item.get("new_name")
+                if not addr_text or not new_name:
+                    result = {
+                        "addr": addr_text,
+                        "name": new_name,
+                        "ok": False,
+                        "error": "Function rename requires addr + name",
                     }
-                )
-            except Exception as e:
-                results.append({"addr": item.get("addr"), "error": str(e)})
-        return results
-
-    def _rename_globals(items: list[GlobalRename]) -> list[dict]:
-        results = []
-        for item in items:
-            try:
-                ea = idaapi.get_name_ea(idaapi.BADADDR, item["old"])
-                if ea == idaapi.BADADDR:
-                    results.append(
-                        {
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": f"Global '{item['old']}' not found",
-                        }
-                    )
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
-                success = idaapi.set_name(ea, item["new"], idaapi.SN_CHECK)
-                results.append(
-                    {
-                        "old": item["old"],
-                        "new": item["new"],
-                        "ok": success,
-                        "error": None if success else "Rename failed",
-                    }
-                )
-            except Exception as e:
-                results.append({"old": item.get("old"), "error": str(e)})
-        return results
 
-    def _rename_locals(items: list[LocalRename]) -> list[dict]:
-        results = []
-        for item in items:
-            try:
-                func = idaapi.get_func(parse_address(item["func_addr"]))
+                ea = parse_address(addr_text)
+                func = idaapi.get_func(ea)
                 if not func:
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": "No function found",
-                        }
-                    )
+                    result = {
+                        "addr": addr_text,
+                        "name": new_name,
+                        "ok": False,
+                        "error": "Function not found",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
-                success = ida_hexrays.rename_lvar(
-                    func.start_ea, item["old"], item["new"]
-                )
-                if success:
+
+                old_name = idaapi.get_name(func.start_ea) or None
+                had_user_name = _has_user_name(func.start_ea)
+                success, error = _set_name_checked(func.start_ea, str(new_name))
+
+                placed, place_error = None, None
+                if success and not had_user_name:
+                    placed, place_error = _place_func_in_vibe_dir(func.start_ea)
+                if success and not dry_run:
                     refresh_decompiler_ctext(func.start_ea)
-                results.append(
-                    {
-                        "func_addr": item["func_addr"],
-                        "old": item["old"],
-                        "new": item["new"],
-                        "ok": success,
-                        "error": None if success else "Rename failed",
-                    }
-                )
-            except Exception as e:
-                results.append({"func_addr": item.get("func_addr"), "error": str(e)})
-        return results
 
-    def _rename_stack(items: list[StackRename]) -> list[dict]:
-        results = []
+                result = {
+                    "addr": addr_text,
+                    "old": old_name,
+                    "name": str(new_name),
+                    "ok": success,
+                    "error": error,
+                    "dir": "vibe" if success and placed else None,
+                    "dir_error": place_error if success else None,
+                    "dry_run": dry_run,
+                }
+                results.append(result)
+                if not success and stop_on_error:
+                    halted = True
+                    break
+            except Exception as e:
+                results.append({"addr": item.get("addr"), "ok": False, "error": str(e)})
+                if stop_on_error:
+                    halted = True
+                    break
+        return results, halted
+
+    def _rename_globals(items: list[GlobalRename]) -> tuple[list[dict], bool]:
+        results: list[dict] = []
+        halted = False
         for item in items:
             try:
-                func = idaapi.get_func(parse_address(item["func_addr"]))
+                addr_text = item.get("addr")
+                old_name = item.get("old") or item.get("old_name")
+                new_name = item.get("new") or item.get("new_name")
+
+                # Backward-compatible forms:
+                # 1) {addr, name} => rename by address
+                # 2) {name, new_name} => old=name, new=new_name
+                if new_name is None and addr_text is not None and item.get("name"):
+                    new_name = item.get("name")
+                if old_name is None and new_name is not None and item.get("name") and not addr_text:
+                    old_name = item.get("name")
+
+                if not new_name:
+                    result = {
+                        "old": old_name,
+                        "new": None,
+                        "ok": False,
+                        "error": "Global rename requires target and new name",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
+                    continue
+
+                ea = idaapi.BADADDR
+                if addr_text:
+                    ea = parse_address(str(addr_text))
+                    old_name = old_name or (idaapi.get_name(ea) or None)
+                elif old_name:
+                    ea = idaapi.get_name_ea(idaapi.BADADDR, str(old_name))
+
+                if ea == idaapi.BADADDR:
+                    result = {
+                        "old": old_name,
+                        "new": str(new_name),
+                        "ok": False,
+                        "error": f"Global '{old_name}' not found",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
+                    continue
+
+                success, error = _set_name_checked(ea, str(new_name))
+                result = {
+                    "addr": hex(ea),
+                    "old": old_name,
+                    "new": str(new_name),
+                    "ok": success,
+                    "error": error,
+                    "dry_run": dry_run,
+                }
+                results.append(result)
+                if not success and stop_on_error:
+                    halted = True
+                    break
+            except Exception as e:
+                results.append({"old": item.get("old"), "ok": False, "error": str(e)})
+                if stop_on_error:
+                    halted = True
+                    break
+        return results, halted
+
+    def _rename_locals(items: list[LocalRename]) -> tuple[list[dict], bool]:
+        results: list[dict] = []
+        halted = False
+        for item in items:
+            try:
+                func_addr = item.get("func_addr") or item.get("func")
+                old_name = item.get("old") or item.get("name")
+                new_name = item.get("new") or item.get("new_name")
+                if not func_addr or not old_name or not new_name:
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "Local rename requires func_addr + old + new",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
+                    continue
+
+                func = idaapi.get_func(parse_address(func_addr))
                 if not func:
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": "No function found",
-                        }
-                    )
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "No function found",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
+                    continue
+
+                success = True
+                error = None
+                if not dry_run:
+                    success = ida_hexrays.rename_lvar(func.start_ea, old_name, new_name)
+                    if success:
+                        refresh_decompiler_ctext(func.start_ea)
+                if not success:
+                    error = "Rename failed"
+
+                result = {
+                    "func_addr": func_addr,
+                    "old": old_name,
+                    "new": new_name,
+                    "ok": success,
+                    "error": error,
+                    "dry_run": dry_run,
+                }
+                results.append(result)
+                if not success and stop_on_error:
+                    halted = True
+                    break
+            except Exception as e:
+                results.append({"func_addr": item.get("func_addr"), "ok": False, "error": str(e)})
+                if stop_on_error:
+                    halted = True
+                    break
+        return results, halted
+
+    def _rename_stack(items: list[StackRename]) -> tuple[list[dict], bool]:
+        results: list[dict] = []
+        halted = False
+        for item in items:
+            try:
+                func_addr = item.get("func_addr") or item.get("func")
+                old_name = item.get("old") or item.get("name")
+                new_name = item.get("new") or item.get("new_name")
+                if not func_addr or not old_name or not new_name:
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "Stack rename requires func_addr + old + new",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
+                    continue
+
+                func = idaapi.get_func(parse_address(func_addr))
+                if not func:
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "No function found",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
 
                 frame_tif = ida_typeinf.tinfo_t()
                 if not ida_frame.get_func_frame(frame_tif, func):
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": "No frame",
-                        }
-                    )
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "No frame",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
 
-                idx, udm = frame_tif.get_udm(item["old"])
+                idx, udm = frame_tif.get_udm(old_name)
                 if not udm:
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": f"'{item['old']}' not found",
-                        }
-                    )
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": f"'{old_name}' not found",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
 
                 tid = frame_tif.get_udm_tid(idx)
                 if ida_frame.is_special_frame_member(tid):
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": "Special frame member",
-                        }
-                    )
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "Special frame member",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
 
                 udm = ida_typeinf.udm_t()
                 frame_tif.get_udm_by_tid(udm, tid)
                 offset = udm.offset // 8
                 if ida_frame.is_funcarg_off(func, offset):
-                    results.append(
-                        {
-                            "func_addr": item["func_addr"],
-                            "old": item["old"],
-                            "new": item["new"],
-                            "ok": False,
-                            "error": "Argument member",
-                        }
-                    )
+                    result = {
+                        "func_addr": func_addr,
+                        "old": old_name,
+                        "new": new_name,
+                        "ok": False,
+                        "error": "Argument member",
+                    }
+                    results.append(result)
+                    if stop_on_error:
+                        halted = True
+                        break
                     continue
 
-                sval = ida_frame.soff_to_fpoff(func, offset)
-                success = ida_frame.define_stkvar(func, item["new"], sval, udm.type)
-                results.append(
-                    {
-                        "func_addr": item["func_addr"],
-                        "old": item["old"],
-                        "new": item["new"],
-                        "ok": success,
-                        "error": None if success else "Rename failed",
-                    }
-                )
+                success = True
+                error = None
+                if not dry_run:
+                    sval = ida_frame.soff_to_fpoff(func, offset)
+                    success = ida_frame.define_stkvar(func, new_name, sval, udm.type)
+                if not success:
+                    error = "Rename failed"
+
+                result = {
+                    "func_addr": func_addr,
+                    "old": old_name,
+                    "new": new_name,
+                    "ok": success,
+                    "error": error,
+                    "dry_run": dry_run,
+                }
+                results.append(result)
+                if not success and stop_on_error:
+                    halted = True
+                    break
             except Exception as e:
-                results.append({"func_addr": item.get("func_addr"), "error": str(e)})
-        return results
+                results.append({"func_addr": item.get("func_addr"), "ok": False, "error": str(e)})
+                if stop_on_error:
+                    halted = True
+                    break
+        return results, halted
+    data_items = []
+    data_items.extend(_normalize_items(batch.get("data")))
+    data_items.extend(_normalize_items(batch.get("global")))
+    data_items.extend(_normalize_items(batch.get("globals")))
 
-    # Process each category
-    result = {}
-    if "func" in batch:
-        result["func"] = _rename_funcs(_normalize_items(batch["func"]))
-    if "data" in batch:
-        result["data"] = _rename_globals(_normalize_items(batch["data"]))
-    if "local" in batch:
-        result["local"] = _rename_locals(_normalize_items(batch["local"]))
-    if "stack" in batch:
-        result["stack"] = _rename_stack(_normalize_items(batch["stack"]))
+    requested = {
+        "func": "func" in batch,
+        "data": any(key in batch for key in ("data", "global", "globals")),
+        "local": "local" in batch,
+        "stack": "stack" in batch,
+        "global_alias": any(key in batch for key in ("global", "globals")),
+    }
 
+    result: dict = {}
+    stopped = False
+    stopped_at = None
+
+    if requested["func"]:
+        result["func"], halted = _rename_funcs(_normalize_items(batch.get("func")))
+        if halted:
+            stopped = True
+            stopped_at = "func"
+
+    if requested["data"] and not stopped:
+        result["data"], halted = _rename_globals(data_items)
+        if requested["global_alias"]:
+            result["global"] = list(result["data"])
+        if halted:
+            stopped = True
+            stopped_at = "data"
+
+    if requested["local"] and not stopped:
+        result["local"], halted = _rename_locals(_normalize_items(batch.get("local")))
+        if halted:
+            stopped = True
+            stopped_at = "local"
+
+    if requested["stack"] and not stopped:
+        result["stack"], halted = _rename_stack(_normalize_items(batch.get("stack")))
+        if halted:
+            stopped = True
+            stopped_at = "stack"
+
+    total = 0
+    ok = 0
+    failed = 0
+    for key in ("func", "data", "local", "stack"):
+        for item in result.get(key, []):
+            total += 1
+            if item.get("ok"):
+                ok += 1
+            else:
+                failed += 1
+
+    result["summary"] = {
+        "total": total,
+        "ok": ok,
+        "failed": failed,
+        "dry_run": dry_run,
+        "allow_overwrite": allow_overwrite,
+        "stop_on_error": stop_on_error,
+        "stopped": stopped,
+        "stopped_at": stopped_at,
+    }
     return result
 
 
 @tool
 @idasync
 def define_func(items: list[DefineOp] | DefineOp) -> list[dict]:
-    """Define function(s) at address(es). IDA auto-determines bounds unless end address specified."""
+    """Define functions; IDA infers bounds unless end is provided."""
     if isinstance(items, dict):
         items = [items]
 

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -34,10 +34,7 @@ from .utils import parse_address, get_function
 def py_eval(
     code: Annotated[str, "Python code"],
 ) -> dict:
-    """Execute Python code in IDA context.
-    Returns dict with result/stdout/stderr.
-    Has access to all IDA API modules.
-    Supports Jupyter-style evaluation."""
+    """Execute Python in IDA context and return result/stdout/stderr."""
     # Capture stdout/stderr
     stdout_capture = io.StringIO()
     stderr_capture = io.StringIO()

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -30,7 +30,7 @@ from .utils import (
 @tool
 @idasync
 def stack_frame(addrs: Annotated[list[str] | str, "Address(es)"]) -> list[dict]:
-    """Get stack vars"""
+    """Return stack variables for function address(es)."""
     addrs = normalize_list_input(addrs)
     results = []
 
@@ -50,7 +50,7 @@ def stack_frame(addrs: Annotated[list[str] | str, "Address(es)"]) -> list[dict]:
 def declare_stack(
     items: list[StackVarDecl] | StackVarDecl,
 ):
-    """Create stack vars"""
+    """Create stack variables from typed stack declarations."""
     items = normalize_dict_list(items)
     results = []
     for item in items:
@@ -95,7 +95,7 @@ def declare_stack(
 def delete_stack(
     items: list[StackVarDelete] | StackVarDelete,
 ):
-    """Delete stack vars"""
+    """Delete stack variables by name or offset."""
 
     items = normalize_dict_list(items)
     results = []

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 
+import idc
 import ida_typeinf
 import ida_hexrays
 import ida_nalt
@@ -12,12 +13,18 @@ from .sync import idasync
 from .utils import (
     normalize_list_input,
     normalize_dict_list,
+    paginate,
+    pattern_filter,
     parse_address,
     get_type_by_name,
     parse_decls_ctypes,
     my_modifier_t,
     StructRead,
     TypeEdit,
+    TypeInspectQuery,
+    TypeQuery,
+    TypeApplyBatch,
+    EnumUpsert,
 )
 from . import compat
 
@@ -32,7 +39,7 @@ from . import compat
 def declare_type(
     decls: Annotated[list[str] | str, "C type declarations"],
 ) -> list[dict]:
-    """Declare types"""
+    """Declare C type definitions in local type library."""
     decls = normalize_list_input(decls)
     results = []
 
@@ -54,6 +61,152 @@ def declare_type(
     return results
 
 
+@tool
+@idasync
+def enum_upsert(
+    queries: Annotated[
+        list[EnumUpsert] | EnumUpsert,
+        "Create enums if missing and upsert enum members without destructive replacement",
+    ],
+) -> list[dict]:
+    """Create or extend local enums in an idempotent way."""
+    queries = normalize_dict_list(queries)
+    results = []
+
+    for query in queries:
+        enum_name = str(query.get("name", "") or "").strip()
+        members = normalize_dict_list(query.get("members"))
+        bitfield = bool(query.get("bitfield", False))
+
+        if not enum_name:
+            results.append({"name": enum_name, "error": "Enum name is required"})
+            continue
+        if not members or members == [{}]:
+            results.append({"name": enum_name, "error": "At least one enum member is required"})
+            continue
+
+        try:
+            enum_id = idc.get_enum(enum_name)
+            created = enum_id == idc.BADADDR
+            if created:
+                enum_id = idc.add_enum(idc.BADADDR, enum_name, 0)
+                if enum_id == idc.BADADDR:
+                    results.append({"name": enum_name, "error": f"Failed to create enum: {enum_name}"})
+                    continue
+
+            if bool(idc.is_bf(enum_id)) != bitfield and not created:
+                results.append(
+                    {
+                        "name": enum_name,
+                        "enum_id": hex(enum_id),
+                        "error": f"Enum bitfield mismatch for {enum_name}",
+                    }
+                )
+                continue
+            idc.set_enum_bf(enum_id, bitfield)
+
+            member_results = []
+            created_count = 0
+            skipped_count = 0
+            conflict_count = 0
+            for member in members:
+                member_name = str(member.get("name", "") or "").strip()
+                raw_value = member.get("value")
+                if not member_name:
+                    member_results.append({"name": member_name, "error": "Member name is required"})
+                    conflict_count += 1
+                    continue
+                try:
+                    value = _parse_enum_value(raw_value)
+                except Exception as exc:
+                    member_results.append({"name": member_name, "error": str(exc)})
+                    conflict_count += 1
+                    continue
+
+                existing_member_id = idc.get_enum_member_by_name(member_name)
+                if existing_member_id != idc.BADADDR:
+                    existing_enum = idc.get_enum_member_enum(existing_member_id)
+                    existing_value = idc.get_enum_member_value(existing_member_id)
+                    if existing_enum == enum_id and existing_value == value:
+                        member_results.append(
+                            {"name": member_name, "value": value, "ok": True, "skipped": True}
+                        )
+                        skipped_count += 1
+                        continue
+                    member_results.append(
+                        {
+                            "name": member_name,
+                            "value": value,
+                            "error": (
+                                f"Member name conflict: {member_name} already exists with value "
+                                f"{existing_value} in enum {idc.get_enum_name(existing_enum) or hex(existing_enum)}"
+                            ),
+                        }
+                    )
+                    conflict_count += 1
+                    continue
+
+                existing_const = idc.get_enum_member(enum_id, value, 0, -1)
+                if existing_const != -1:
+                    existing_name = idc.get_enum_member_name(existing_const) or ""
+                    if existing_name == member_name:
+                        member_results.append(
+                            {"name": member_name, "value": value, "ok": True, "skipped": True}
+                        )
+                        skipped_count += 1
+                        continue
+                    member_results.append(
+                        {
+                            "name": member_name,
+                            "value": value,
+                            "error": f"Enum value conflict: {value} already belongs to {existing_name}",
+                        }
+                    )
+                    conflict_count += 1
+                    continue
+
+                rc = idc.add_enum_member(enum_id, member_name, value, -1)
+                if rc != 0:
+                    member_results.append(
+                        {"name": member_name, "value": value, "error": f"Failed to add enum member: rc={rc}"}
+                    )
+                    conflict_count += 1
+                    continue
+                member_results.append({"name": member_name, "value": value, "ok": True, "created": True})
+                created_count += 1
+
+            results.append(
+                {
+                    "name": enum_name,
+                    "enum_id": hex(enum_id),
+                    "ok": conflict_count == 0,
+                    "created": created,
+                    "bitfield": bitfield,
+                    "members": member_results,
+                    "summary": {
+                        "created": created_count,
+                        "skipped": skipped_count,
+                        "conflicts": conflict_count,
+                    },
+                }
+            )
+        except Exception as exc:
+            results.append({"name": enum_name, "error": str(exc)})
+
+    return results
+
+
+def _parse_enum_value(value: int | str | None) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("Enum member value is required")
+        return int(text, 0)
+    raise ValueError(f"Invalid enum member value: {value!r}")
+
+
 # ============================================================================
 # Structure Operations
 # ============================================================================
@@ -62,15 +215,7 @@ def declare_type(
 @tool
 @idasync
 def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
-    """Reads struct type definition and parses actual memory values at the
-    given address as instances of that struct type.
-
-    If struct name is not provided, attempts to auto-detect from address.
-    Auto-detection only works if IDA already has type information applied
-    at that address
-
-    Returns struct layout with actual memory values for each field.
-    """
+    """Read struct fields from memory at address; auto-detect type when possible."""
 
     queries = normalize_dict_list(queries)
 
@@ -225,7 +370,7 @@ def search_structs(
         str, "Case-insensitive substring to search for in structure names"
     ],
 ) -> list[dict]:
-    """Search structs"""
+    """Search local structs/unions by name pattern."""
     results = []
     limit = compat.get_ordinal_limit()
 
@@ -257,6 +402,51 @@ def search_structs(
     return results
 
 
+def _type_kind(tif: ida_typeinf.tinfo_t) -> str:
+    try:
+        if tif.is_enum():
+            return "enum"
+    except Exception:
+        pass
+    try:
+        if tif.is_typedef():
+            return "typedef"
+    except Exception:
+        pass
+    try:
+        if tif.is_func():
+            return "func"
+    except Exception:
+        pass
+    try:
+        if tif.is_ptr():
+            return "ptr"
+    except Exception:
+        pass
+
+    try:
+        if tif.is_udt():
+            udt = ida_typeinf.udt_type_data_t()
+            if tif.get_udt_details(udt) and udt.is_union:
+                return "union"
+            return "struct"
+    except Exception:
+        pass
+
+    return "other"
+
+
+def _type_matches_kind(kind: str, tif: ida_typeinf.tinfo_t) -> bool:
+    if kind == "any":
+        return True
+    if kind == "udt":
+        try:
+            return bool(tif.is_udt())
+        except Exception:
+            return False
+    return _type_kind(tif) == kind
+
+
 # ============================================================================
 # Type Inference & Application
 # ============================================================================
@@ -264,135 +454,519 @@ def search_structs(
 
 @tool
 @idasync
-def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
-    """Apply types (function/global/local/stack)"""
+def type_query(
+    queries: Annotated[
+        list[TypeQuery] | TypeQuery | str,
+        "Type catalog query with filtering, pagination, and optional relationships",
+    ],
+) -> list[dict]:
+    """Query local types with structured filters/projection-friendly output."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {
+            "filter": s,
+            "kind": "any",
+            "offset": 0,
+            "count": 100,
+            "sort_by": "name",
+            "descending": False,
+            "include_decl": True,
+            "include_members": False,
+            "max_members": 64,
+            "include_relationships": False,
+        },
+    )
 
-    def parse_addr_type(s: str) -> dict:
-        # Support "addr:typename" format (auto-detects kind)
-        if ":" in s:
-            parts = s.split(":", 1)
-            return {"addr": parts[0].strip(), "ty": parts[1].strip()}
-        # Just typename without address (invalid)
-        return {"ty": s.strip()}
+    # Build one local catalog and page/filter it per query.
+    catalog: list[dict] = []
+    limit = ida_typeinf.get_ordinal_limit()
+    for ordinal in range(1, limit):
+        tif = ida_typeinf.tinfo_t()
+        if not tif.get_numbered_type(None, ordinal):
+            continue
+        name = tif.get_type_name()
+        if not name:
+            continue
+        catalog.append(
+            {
+                "ordinal": ordinal,
+                "name": name,
+                "size": tif.get_size(),
+                "kind": _type_kind(tif),
+                "_tif": tif,
+            }
+        )
 
-    edits = normalize_dict_list(edits, parse_addr_type)
-    results = []
+    results: list[dict] = []
+    for query in queries:
+        filter_pattern = str(query.get("filter", "") or "")
+        kind = str(query.get("kind", "any") or "any").lower()
+        if kind not in {"any", "struct", "union", "enum", "typedef", "func", "ptr", "udt"}:
+            kind = "any"
 
-    for edit in edits:
-        try:
-            # Auto-detect kind if not provided
-            kind = edit.get("kind")
-            if not kind:
-                if "signature" in edit:
-                    kind = "function"
-                elif "variable" in edit:
-                    kind = "local"
-                elif "addr" in edit:
-                    # Check if address points to a function
+        offset = int(query.get("offset", 0) or 0)
+        count = int(query.get("count", 100) or 100)
+        sort_by = str(query.get("sort_by", "name") or "name")
+        descending = bool(query.get("descending", False))
+        include_decl = bool(query.get("include_decl", True))
+        include_members = bool(query.get("include_members", False))
+        max_members = int(query.get("max_members", 64) or 64)
+        include_relationships = bool(query.get("include_relationships", False))
+
+        if max_members < 0:
+            max_members = 0
+        if max_members > 4096:
+            max_members = 4096
+
+        filtered: list[dict] = []
+        for row in catalog:
+            tif = row.get("_tif")
+            if not isinstance(tif, ida_typeinf.tinfo_t):
+                continue
+            if not _type_matches_kind(kind, tif):
+                continue
+            filtered.append(row)
+
+        if filter_pattern:
+            filtered = pattern_filter(filtered, filter_pattern, "name")
+
+        if sort_by == "size":
+            filtered.sort(key=lambda r: int(r.get("size", 0) or 0), reverse=descending)
+        elif sort_by == "ordinal":
+            filtered.sort(key=lambda r: int(r.get("ordinal", 0) or 0), reverse=descending)
+        else:
+            filtered.sort(key=lambda r: str(r.get("name", "")).lower(), reverse=descending)
+
+        output_rows: list[dict] = []
+        for row in filtered:
+            tif = row["_tif"]
+            out = {
+                "ordinal": row["ordinal"],
+                "name": row["name"],
+                "size": row["size"],
+                "kind": row["kind"],
+            }
+
+            if include_decl:
+                out["declaration"] = str(tif)
+
+            if include_members:
+                members = []
+                member_count = 0
+                members_truncated = False
+                if tif.is_udt():
+                    udt = ida_typeinf.udt_type_data_t()
+                    if tif.get_udt_details(udt):
+                        member_count = len(udt)
+                        for idx, member in enumerate(udt):
+                            if idx >= max_members:
+                                members_truncated = True
+                                break
+                            members.append(
+                                {
+                                    "name": member.name,
+                                    "offset": hex(member.begin() // 8),
+                                    "size": member.type.get_size(),
+                                    "type": member.type._print(),
+                                }
+                            )
+                out["member_count"] = member_count
+                out["members"] = members
+                out["members_truncated"] = members_truncated
+
+            if include_relationships:
+                related: set[str] = set()
+                if tif.is_udt():
+                    udt = ida_typeinf.udt_type_data_t()
+                    if tif.get_udt_details(udt):
+                        for member in udt:
+                            rel_name = member.type.get_type_name() or str(member.type)
+                            if rel_name:
+                                related.add(rel_name)
+                if tif.is_ptr():
+                    pointed = ida_typeinf.tinfo_t()
                     try:
-                        addr = parse_address(edit["addr"])
-                        func = idaapi.get_func(addr)
-                        if func and "name" in edit and "ty" in edit:
-                            kind = "stack"
-                        else:
-                            kind = "global"
+                        if tif.get_pointed_object(pointed):
+                            rel_name = pointed.get_type_name() or str(pointed)
+                            if rel_name:
+                                related.add(rel_name)
                     except Exception:
-                        kind = "global"
-                else:
-                    kind = "global"
+                        pass
 
-            if kind == "function":
-                func = idaapi.get_func(parse_address(edit["addr"]))
-                if not func:
-                    results.append({"edit": edit, "error": "Function not found"})
-                    continue
+                related_list = sorted(related)
+                out["related_count"] = len(related_list)
+                out["related_types"] = related_list[:256]
+                out["related_truncated"] = len(related_list) > 256
 
-                tif = ida_typeinf.tinfo_t(edit["signature"], None, ida_typeinf.PT_SIL)
-                if not tif.is_func():
-                    results.append({"edit": edit, "error": "Not a function type"})
-                    continue
+            output_rows.append(out)
 
-                success = ida_typeinf.apply_tinfo(
-                    func.start_ea, tif, ida_typeinf.PT_SIL
-                )
-                results.append(
-                    {
-                        "edit": edit,
-                        "ok": success,
-                        "error": None if success else "Failed to apply type",
-                    }
-                )
-
-            elif kind == "global":
-                ea = idaapi.get_name_ea(idaapi.BADADDR, edit.get("name", ""))
-                if ea == idaapi.BADADDR:
-                    ea = parse_address(edit["addr"])
-
-                tif = get_type_by_name(edit["ty"])
-                success = ida_typeinf.apply_tinfo(ea, tif, ida_typeinf.PT_SIL)
-                results.append(
-                    {
-                        "edit": edit,
-                        "ok": success,
-                        "error": None if success else "Failed to apply type",
-                    }
-                )
-
-            elif kind == "local":
-                func = idaapi.get_func(parse_address(edit["addr"]))
-                if not func:
-                    results.append({"edit": edit, "error": "Function not found"})
-                    continue
-
-                new_tif = ida_typeinf.tinfo_t(edit["ty"], None, ida_typeinf.PT_SIL)
-                modifier = my_modifier_t(edit["variable"], new_tif)
-                success = ida_hexrays.modify_user_lvars(func.start_ea, modifier)
-                results.append(
-                    {
-                        "edit": edit,
-                        "ok": success,
-                        "error": None if success else "Failed to apply type",
-                    }
-                )
-
-            elif kind == "stack":
-                func = idaapi.get_func(parse_address(edit["addr"]))
-                if not func:
-                    results.append({"edit": edit, "error": "No function found"})
-                    continue
-
-                frame_tif = ida_typeinf.tinfo_t()
-                if not ida_frame.get_func_frame(frame_tif, func):
-                    results.append({"edit": edit, "error": "No frame"})
-                    continue
-
-                idx, udm = frame_tif.get_udm(edit["name"])
-                if not udm:
-                    results.append({"edit": edit, "error": f"{edit['name']} not found"})
-                    continue
-
-                tid = frame_tif.get_udm_tid(idx)
-                udm = ida_typeinf.udm_t()
-                frame_tif.get_udm_by_tid(udm, tid)
-                offset = udm.offset // 8
-
-                tif = get_type_by_name(edit["ty"])
-                success = ida_frame.set_frame_member_type(func, offset, tif)
-                results.append(
-                    {
-                        "edit": edit,
-                        "ok": success,
-                        "error": None if success else "Failed to set type",
-                    }
-                )
-
-            else:
-                results.append({"edit": edit, "error": f"Unknown kind: {kind}"})
-
-        except Exception as e:
-            results.append({"edit": edit, "error": str(e)})
+        page = paginate(output_rows, offset, count)
+        results.append(
+            {
+                "kind": kind,
+                "data": page["data"],
+                "next_offset": page["next_offset"],
+                "total": len(output_rows),
+                "error": None,
+            }
+        )
 
     return results
+
+
+@tool
+@idasync
+def type_inspect(
+    queries: Annotated[
+        list[TypeInspectQuery] | TypeInspectQuery | str,
+        "Inspect named types and optionally include member layout",
+    ],
+) -> list[dict]:
+    """Inspect named types (size/kind/declaration/members)."""
+    queries = normalize_dict_list(
+        queries,
+        lambda s: {"name": s, "include_members": False, "max_members": 128},
+    )
+    results = []
+
+    for query in queries:
+        name = (query.get("name") or "").strip()
+        include_members = bool(query.get("include_members", False))
+        max_members = int(query.get("max_members", 128) or 128)
+        if max_members < 0:
+            max_members = 0
+        if max_members > 4096:
+            max_members = 4096
+
+        if not name:
+            results.append(
+                {
+                    "name": name,
+                    "exists": False,
+                    "error": "Type name is required",
+                }
+            )
+            continue
+
+        try:
+            tif = ida_typeinf.tinfo_t()
+            if not tif.get_named_type(None, name):
+                results.append(
+                    {"name": name, "exists": False, "error": f"Type not found: {name}"}
+                )
+                continue
+
+            info = {
+                "name": name,
+                "exists": True,
+                "declaration": str(tif),
+                "size": tif.get_size(),
+                "is_func": tif.is_func(),
+                "is_ptr": tif.is_ptr(),
+                "is_enum": tif.is_enum(),
+                "is_udt": tif.is_udt(),
+                "members": None,
+                "member_count": 0,
+                "error": None,
+            }
+
+            if include_members and tif.is_udt():
+                udt = ida_typeinf.udt_type_data_t()
+                if tif.get_udt_details(udt):
+                    info["member_count"] = len(udt)
+                    members = []
+                    for idx, member in enumerate(udt):
+                        if idx >= max_members:
+                            break
+                        members.append(
+                            {
+                                "name": member.name,
+                                "offset": hex(member.begin() // 8),
+                                "size": member.type.get_size(),
+                                "type": member.type._print(),
+                            }
+                        )
+                    info["members"] = members
+
+            results.append(info)
+        except Exception as e:
+            results.append(
+                {
+                    "name": name,
+                    "exists": False,
+                    "error": str(e),
+                }
+            )
+
+    return results
+
+
+def _parse_addr_type_shorthand(s: str) -> dict:
+    # Support "addr:typename" shorthand.
+    if ":" in s:
+        addr, ty = s.split(":", 1)
+        return {"addr": addr.strip(), "ty": ty.strip()}
+    return {"ty": s.strip()}
+
+
+def _resolve_type_text(edit: dict) -> str:
+    return str(
+        edit.get("ty")
+        or edit.get("type")
+        or edit.get("decl")
+        or edit.get("declaration")
+        or ""
+    ).strip()
+
+
+def _parse_type_tinfo(type_text: str) -> ida_typeinf.tinfo_t:
+    text = type_text.strip()
+    if not text:
+        raise ValueError("Type text is required")
+
+    # Fast path for common type aliases and named types.
+    try:
+        return get_type_by_name(text)
+    except Exception:
+        pass
+
+    flags = ida_typeinf.PT_SIL | ida_typeinf.PT_TYP
+    parse_decl = getattr(ida_typeinf, "parse_decl", None)
+    if callable(parse_decl):
+        candidates = [text]
+        if not text.endswith(";"):
+            candidates.append(text + ";")
+        for candidate in candidates:
+            tif = ida_typeinf.tinfo_t()
+            try:
+                if parse_decl(tif, None, candidate, flags):
+                    return tif
+            except Exception:
+                continue
+
+    # Legacy constructor fallback.
+    try:
+        tif = ida_typeinf.tinfo_t(text, None, ida_typeinf.PT_SIL)
+        empty = getattr(tif, "empty", None)
+        if callable(empty):
+            if not empty():
+                return tif
+        else:
+            return tif
+    except Exception:
+        pass
+
+    raise ValueError(f"Unable to parse type: {text}")
+
+
+def _parse_function_tinfo(signature_text: str) -> ida_typeinf.tinfo_t:
+    text = signature_text.strip()
+    if not text:
+        raise ValueError("Function signature is required")
+
+    flags = ida_typeinf.PT_SIL | ida_typeinf.PT_TYP
+    parse_decl = getattr(ida_typeinf, "parse_decl", None)
+    if callable(parse_decl):
+        candidates = [text]
+        if not text.endswith(";"):
+            candidates.append(text + ";")
+        for candidate in candidates:
+            tif = ida_typeinf.tinfo_t()
+            try:
+                if parse_decl(tif, None, candidate, flags) and tif.is_func():
+                    return tif
+            except Exception:
+                continue
+
+    try:
+        tif = ida_typeinf.tinfo_t(text, None, ida_typeinf.PT_SIL)
+        if tif.is_func():
+            return tif
+    except Exception:
+        pass
+
+    raise ValueError(f"Not a function type: {text}")
+
+
+def _infer_type_edit_kind(edit: dict) -> str:
+    kind = str(edit.get("kind") or "").strip().lower()
+    if kind:
+        return kind
+    if edit.get("signature"):
+        return "function"
+    if edit.get("variable"):
+        return "local"
+
+    if "addr" in edit and "name" in edit and _resolve_type_text(edit):
+        # Heuristic: addr + frame name usually indicates stack variable updates.
+        try:
+            fn = idaapi.get_func(parse_address(edit["addr"]))
+            if fn:
+                frame_tif = ida_typeinf.tinfo_t()
+                if ida_frame.get_func_frame(frame_tif, fn):
+                    _, udm = frame_tif.get_udm(str(edit["name"]))
+                    if udm:
+                        return "stack"
+        except Exception:
+            pass
+
+    return "global"
+
+
+def _apply_type_edit(edit: dict) -> dict:
+    try:
+        kind = _infer_type_edit_kind(edit)
+        type_text = _resolve_type_text(edit)
+
+        if kind == "function":
+            addr_text = str(edit.get("addr", "")).strip()
+            if not addr_text:
+                return {"edit": edit, "kind": kind, "error": "Function address is required"}
+            func = idaapi.get_func(parse_address(addr_text))
+            if not func:
+                return {"edit": edit, "kind": kind, "error": "Function not found"}
+
+            signature = str(edit.get("signature") or type_text).strip()
+            tif = _parse_function_tinfo(signature)
+            ok = ida_typeinf.apply_tinfo(func.start_ea, tif, ida_typeinf.PT_SIL)
+            return {
+                "edit": edit,
+                "kind": kind,
+                "ok": ok,
+                "error": None if ok else "Failed to apply function type",
+            }
+
+        if kind == "global":
+            ea = idaapi.BADADDR
+            name = str(edit.get("name", "")).strip()
+            if name:
+                ea = idaapi.get_name_ea(idaapi.BADADDR, name)
+            if ea == idaapi.BADADDR:
+                addr_text = str(edit.get("addr", "")).strip()
+                if not addr_text:
+                    return {
+                        "edit": edit,
+                        "kind": kind,
+                        "error": "Global requires name or address",
+                    }
+                ea = parse_address(addr_text)
+
+            tif = _parse_type_tinfo(type_text)
+            ok = ida_typeinf.apply_tinfo(ea, tif, ida_typeinf.PT_SIL)
+            return {
+                "edit": edit,
+                "kind": kind,
+                "ok": ok,
+                "error": None if ok else "Failed to apply global type",
+            }
+
+        if kind == "local":
+            addr_text = str(edit.get("addr", "")).strip()
+            var_name = str(edit.get("variable", "")).strip()
+            if not addr_text:
+                return {"edit": edit, "kind": kind, "error": "Function address is required"}
+            if not var_name:
+                return {"edit": edit, "kind": kind, "error": "Local variable name is required"}
+
+            func = idaapi.get_func(parse_address(addr_text))
+            if not func:
+                return {"edit": edit, "kind": kind, "error": "Function not found"}
+
+            new_tif = _parse_type_tinfo(type_text)
+            modifier = my_modifier_t(var_name, new_tif)
+            ok = ida_hexrays.modify_user_lvars(func.start_ea, modifier)
+            return {
+                "edit": edit,
+                "kind": kind,
+                "ok": ok,
+                "error": None if ok else "Failed to apply local variable type",
+            }
+
+        if kind == "stack":
+            addr_text = str(edit.get("addr", "")).strip()
+            stack_name = str(edit.get("name", "")).strip()
+            if not addr_text:
+                return {"edit": edit, "kind": kind, "error": "Function address is required"}
+            if not stack_name:
+                return {"edit": edit, "kind": kind, "error": "Stack variable name is required"}
+
+            func = idaapi.get_func(parse_address(addr_text))
+            if not func:
+                return {"edit": edit, "kind": kind, "error": "No function found"}
+
+            frame_tif = ida_typeinf.tinfo_t()
+            if not ida_frame.get_func_frame(frame_tif, func):
+                return {"edit": edit, "kind": kind, "error": "No frame available"}
+
+            idx, udm = frame_tif.get_udm(stack_name)
+            if not udm:
+                return {
+                    "edit": edit,
+                    "kind": kind,
+                    "error": f"Stack variable not found: {stack_name}",
+                }
+
+            tid = frame_tif.get_udm_tid(idx)
+            udm = ida_typeinf.udm_t()
+            frame_tif.get_udm_by_tid(udm, tid)
+            offset = udm.offset // 8
+
+            tif = _parse_type_tinfo(type_text)
+            ok = ida_frame.set_frame_member_type(func, offset, tif)
+            return {
+                "edit": edit,
+                "kind": kind,
+                "ok": ok,
+                "error": None if ok else "Failed to set stack member type",
+            }
+
+        return {"edit": edit, "kind": kind, "error": f"Unknown kind: {kind}"}
+    except Exception as e:
+        return {"edit": edit, "error": str(e)}
+
+
+@tool
+@idasync
+def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
+    """Apply types (function/global/local/stack)"""
+    normalized_edits = normalize_dict_list(edits, _parse_addr_type_shorthand)
+    return [_apply_type_edit(edit) for edit in normalized_edits]
+
+
+@tool
+@idasync
+def type_apply_batch(
+    batch: Annotated[
+        TypeApplyBatch | list[TypeEdit] | TypeEdit,
+        "Batch type edits with optional stop_on_error behavior",
+    ],
+) -> dict:
+    """Apply multiple type edits and return aggregate status."""
+    if isinstance(batch, dict) and "edits" in batch:
+        normalized_edits = normalize_dict_list(
+            batch.get("edits", []), _parse_addr_type_shorthand
+        )
+        stop_on_error = bool(batch.get("stop_on_error", False))
+    else:
+        normalized_edits = normalize_dict_list(batch, _parse_addr_type_shorthand)
+        stop_on_error = False
+
+    results: list[dict] = []
+    for edit in normalized_edits:
+        result = _apply_type_edit(edit)
+        results.append(result)
+        if stop_on_error and result.get("error"):
+            break
+
+    failed = sum(1 for r in results if r.get("error"))
+    applied = sum(1 for r in results if r.get("ok"))
+    return {
+        "ok": failed == 0,
+        "applied": applied,
+        "failed": failed,
+        "stopped": stop_on_error and failed > 0,
+        "results": results,
+    }
 
 
 @tool
@@ -400,7 +974,7 @@ def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
 def infer_types(
     addrs: Annotated[list[str] | str, "Addresses to infer types for"],
 ) -> list[dict]:
-    """Infer types"""
+    """Infer and apply likely types at target addresses."""
     addrs = normalize_list_input(addrs)
     results = []
 

--- a/src/ida_pro_mcp/ida_mcp/framework.py
+++ b/src/ida_pro_mcp/ida_mcp/framework.py
@@ -227,6 +227,13 @@ def assert_is_list(value: Any, min_length: int = 0) -> None:
     )
 
 
+def assert_has_keys(mapping: Any, *keys: str) -> None:
+    """Assert mapping contains the requested keys."""
+    assert isinstance(mapping, dict), f"Expected dict, got {type(mapping).__name__}"
+    missing = [key for key in keys if key not in mapping]
+    assert not missing, f"Missing keys: {', '.join(repr(key) for key in missing)}"
+
+
 def _assert_shape(value: Any, schema: Any, path: str) -> None:
     if isinstance(schema, OptionalShape):
         if value is None:

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
@@ -3,6 +3,7 @@
 from ..framework import (
     test,
     skip_test,
+    assert_has_keys,
     assert_valid_address,
     assert_non_empty,
     assert_is_list,
@@ -18,7 +19,11 @@ from ..framework import (
 from ..api_analysis import (
     decompile,
     disasm,
+    func_profile,
+    analyze_batch,
     xrefs_to,
+    xref_query,
+    insn_query,
     xrefs_to_field,
     callees,
     find_bytes,
@@ -245,6 +250,59 @@ def test_xrefs_to_invalid():
 
 
 @test()
+def test_xref_query():
+    """xref_query returns paged xref results for a function"""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = xref_query(
+        {
+            "query": fn_addr,
+            "direction": "both",
+            "xref_type": "any",
+            "offset": 0,
+            "count": 10,
+            "include_fn": True,
+        }
+    )
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "query", "resolved_addr", "data", "next_offset", "total", "error")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "direction", "addr", "from", "to", "type")
+
+
+@test()
+def test_insn_query_function_scope():
+    """insn_query supports scoped instruction search with pagination"""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = insn_query({"func": fn_addr, "count": 8, "include_disasm": True})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "query", "matches", "count", "scanned", "cursor", "error")
+    assert page.get("error") is None
+    if page["matches"]:
+        assert_has_keys(page["matches"][0], "addr", "disasm")
+
+
+@test()
+def test_insn_query_requires_scope_by_default():
+    """insn_query rejects broad scans unless allow_broad is set"""
+    result = insn_query({"mnem": "call"})
+    assert_is_list(result, min_length=1)
+    assert result[0].get("error") is not None
+
+
+# ============================================================================
+# Tests for xrefs_to_field
+# ============================================================================
+
+
+@test()
 def test_xrefs_to_field_nonexistent_struct():
     """xrefs_to_field reports a missing-struct error."""
     result = xrefs_to_field({"struct": "NonExistentStruct", "field": "nonexistent"})
@@ -431,14 +489,15 @@ def test_export_funcs_invalid_address():
 
 @test(binary="crackme03.elf")
 def test_callgraph_main_contains_expected_nodes():
-    """callgraph(main) includes main, check_pw and imported callees."""
+    """callgraph(main) includes the local crackme call edge to check_pw."""
     result = callgraph(CRACKME_MAIN)
     assert_is_list(result, min_length=1)
     entry = result[0]
     assert_is_list(entry["nodes"], min_length=1)
     assert_is_list(entry["edges"], min_length=1)
     names = {node["name"] for node in entry["nodes"]}
-    assert {"main", "check_pw", ".puts", ".printf"}.issubset(names)
+    assert {"main", "check_pw"}.issubset(names)
+    assert any(edge["from"] == CRACKME_MAIN and edge["to"] == CRACKME_CHECK_PW for edge in entry["edges"])
     for node in entry["nodes"]:
         assert_valid_address(node["addr"])
         assert node["depth"] >= 0
@@ -465,3 +524,74 @@ def test_callgraph_invalid_root():
     result = callgraph(get_unmapped_address())
     assert_is_list(result, min_length=1)
     assert_error(result[0])
+
+
+# ============================================================================
+# Tests for func_profile / analyze_batch
+# ============================================================================
+
+
+@test()
+def test_func_profile():
+    """func_profile returns function profile metrics"""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = func_profile({"query": fn_addr, "include_lists": False})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset", "error")
+    if page["data"]:
+        r = page["data"][0]
+        assert_has_keys(
+            r,
+            "addr",
+            "name",
+            "size",
+            "instruction_count",
+            "basic_block_count",
+            "caller_count",
+            "callee_count",
+            "has_type",
+            "error",
+        )
+
+
+@test()
+def test_analyze_batch():
+    """analyze_batch returns structured analysis for a function"""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = analyze_batch(
+        {
+            "query": fn_addr,
+            "include_disasm": True,
+            "max_disasm_insns": 16,
+            "include_strings": True,
+            "max_strings": 16,
+            "include_constants": True,
+            "max_constants": 16,
+            "include_basic_blocks": True,
+            "max_blocks": 16,
+        }
+    )
+    assert_is_list(result, min_length=1)
+    r = result[0]
+    assert_has_keys(r, "query", "addr", "name", "analysis", "error")
+    if r["analysis"] is not None:
+        a = r["analysis"]
+        assert_has_keys(
+            a,
+            "size",
+            "decompile",
+            "disasm",
+            "xrefs",
+            "caller_count",
+            "callee_count",
+            "string_ref_count",
+            "constant_count",
+            "basic_block_count",
+        )

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
@@ -3,6 +3,7 @@
 from ..framework import (
     test,
     skip_test,
+    assert_has_keys,
     assert_valid_address,
     assert_non_empty,
     assert_is_list,
@@ -20,8 +21,13 @@ from ..api_core import (
     lookup_funcs,
     int_convert,
     list_funcs,
+    func_query,
     list_globals,
+    entity_query,
     imports,
+    imports_query,
+    server_health,
+    server_warmup,
     find_regex,
 )
 
@@ -231,6 +237,28 @@ def test_list_funcs_pagination():
 
 
 @test()
+def test_func_query():
+    """func_query returns richer function entries"""
+    result = func_query({})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "addr", "name", "size", "has_type")
+
+
+@test()
+def test_func_query_filters():
+    """func_query supports size/type filters"""
+    result = func_query({"min_size": 0, "max_size": 0xFFFFFFFF, "has_type": False})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset")
+    for fn in page["data"]:
+        assert fn["has_type"] is False
+
+
+@test()
 def test_list_globals_returns_non_empty_results_for_all_query():
     """list_globals('*') returns at least one global item."""
     page = list_globals({"filter": "*", "offset": 0, "count": 50})[0]
@@ -294,3 +322,147 @@ def test_find_regex_matches_known_correct_strings():
     assert by_addr.get("0x201f") == "Yes, %s is correct!\n"
     assert by_addr.get("0x2034") == "No, %s is not correct.\n"
     assert result["n"] >= 2
+
+
+@test()
+def test_func_query():
+    """func_query returns richer function entries"""
+    result = func_query({})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "addr", "name", "size", "has_type")
+
+
+@test()
+def test_func_query_filters():
+    """func_query supports size/type filters"""
+    result = func_query({"min_size": 0, "max_size": 0xFFFFFFFF, "has_type": False})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset")
+    for fn in page["data"]:
+        assert fn["has_type"] is False
+
+
+@test()
+def test_func_query_multi_query_preserves_size_sort_state():
+    """func_query should not mutate shared rows across multiple queries in one call."""
+    result = func_query(
+        [
+            {"offset": 0, "count": 1},
+            {"offset": 0, "count": 10, "sort_by": "size", "descending": True},
+        ]
+    )
+    assert_is_list(result, min_length=2)
+    second_page = result[1]
+    assert_has_keys(second_page, "data", "next_offset")
+    sizes = [int(str(item["size"]), 0) for item in second_page["data"]]
+    assert sizes == sorted(sizes, reverse=True)
+
+
+# ============================================================================
+# Tests for entity_query / health / warmup
+# ============================================================================
+
+
+@test()
+def test_entity_query_functions_projection():
+    """entity_query supports generic function query + field projection"""
+    result = entity_query(
+        {
+            "kind": "functions",
+            "filter": "*",
+            "fields": ["addr", "name"],
+            "offset": 0,
+            "count": 5,
+        }
+    )
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "kind", "data", "next_offset", "total", "error")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "kind", "addr", "name")
+
+
+@test()
+def test_entity_query_functions_sort_by_size():
+    """entity_query sorts function rows by numeric size, including hex string sizes."""
+    result = entity_query(
+        {
+            "kind": "functions",
+            "filter": "*",
+            "sort_by": "size",
+            "descending": True,
+            "offset": 0,
+            "count": 10,
+        }
+    )
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "kind", "data", "next_offset", "total", "error")
+    sizes = [int(str(item["size"]), 0) for item in page["data"]]
+    assert sizes == sorted(sizes, reverse=True)
+
+
+@test()
+def test_server_health():
+    """server_health returns readiness payload"""
+    result = server_health()
+    assert_has_keys(
+        result,
+        "status",
+        "uptime_sec",
+        "module",
+        "imagebase",
+        "strings_cache_ready",
+        "hexrays_ready",
+    )
+
+
+@test()
+def test_server_warmup():
+    """server_warmup runs warmup steps and returns health"""
+    result = server_warmup(
+        wait_auto_analysis=False, build_caches=False, init_hexrays=False
+    )
+    assert_has_keys(result, "ok", "steps", "health")
+    assert_is_list(result["steps"])
+@test()
+def test_imports():
+    """imports returns import list with proper structure"""
+    page = imports(0, 100)
+    assert_has_keys(page, "data", "next_offset")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "addr", "imported_name", "module")
+
+
+@test()
+def test_imports_pagination():
+    """imports respects pagination parameters"""
+    page = imports(0, 5)
+    assert len(page["data"]) <= 5
+
+
+@test()
+def test_imports_query():
+    """imports_query supports filtered import listing"""
+    result = imports_query({"filter": "*", "offset": 0, "count": 10})
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert_has_keys(page, "data", "next_offset")
+    if page["data"]:
+        assert_has_keys(page["data"][0], "addr", "imported_name", "module")
+
+
+# ============================================================================
+# Tests for find_regex
+# ============================================================================
+
+
+@test()
+def test_find_regex():
+    """find_regex can search for patterns"""
+    result = find_regex(".*")
+    assert_has_keys(result, "matches", "cursor")

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
@@ -10,6 +10,7 @@ from ..framework import (
     get_named_address,
 )
 from ..api_modify import (
+    append_comments,
     set_comments,
     patch_asm,
     rename,
@@ -24,6 +25,16 @@ from ..api_core import lookup_funcs
 CRACKME_MAIN = "0x123e"
 CRACKME_PATCH_ASM_ADDR = "0x125e"
 CRACKME_FRAME_DUMMY = "0x11a0"
+TYPED_FIXTURE_IMMEDIATE_1234 = "0x1013e44"
+TYPED_FIXTURE_USE_WRAPPER = "0x1013dc0"
+TYPED_FIXTURE_LOCAL_NAME = "rhs_handle"
+
+
+def _require_any_function() -> str:
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+    return fn_addr
 
 
 def _plain_hex_bytes(text: str) -> str:
@@ -57,7 +68,7 @@ def test_set_comment_interior_address_roundtrip():
     """set_comments also succeeds for an interior instruction address inside a function."""
     import idaapi
 
-    addr = 0x1013E44
+    addr = int(TYPED_FIXTURE_IMMEDIATE_1234, 16)
     original = idaapi.get_cmt(addr, False) or ""
     try:
         result = set_comments({"addr": hex(addr), "comment": "__INNER_COMMENT__"})
@@ -69,6 +80,71 @@ def test_set_comment_interior_address_roundtrip():
 
     restored = idaapi.get_cmt(addr, False) or ""
     assert restored == original
+
+
+@test()
+def test_append_comment_function_dedupes():
+    """append_comments appends once to a function comment and skips exact duplicates."""
+    import idc
+
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    addr = int(fn_addr, 16)
+    original = idc.get_func_cmt(addr, False) or ""
+    try:
+        first = append_comments({"addr": fn_addr, "comment": "__APPEND_COMMENT__", "scope": "func"})
+        second = append_comments({"addr": fn_addr, "comment": "__APPEND_COMMENT__", "scope": "func"})
+        assert_is_list(first, min_length=1)
+        assert first[0].get("ok") is True
+        assert first[0].get("appended") is True
+        assert_is_list(second, min_length=1)
+        assert second[0].get("ok") is True
+        assert second[0].get("skipped") is True
+        updated = idc.get_func_cmt(addr, False) or ""
+        assert updated.count("__APPEND_COMMENT__") == 1
+    finally:
+        idc.set_func_cmt(addr, original, False)
+
+
+@test()
+def test_append_comment_function_dedupe_does_not_skip_substrings():
+    """append_comments should only dedupe exact existing entries, not substrings."""
+    import idc
+
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    addr = int(fn_addr, 16)
+    original = idc.get_func_cmt(addr, False) or ""
+    try:
+        idc.set_func_cmt(addr, "foobar", False)
+        result = append_comments({"addr": fn_addr, "comment": "foo", "scope": "func"})
+        assert_is_list(result, min_length=1)
+        assert result[0].get("ok") is True
+        assert result[0].get("appended") is True
+        updated = idc.get_func_cmt(addr, False) or ""
+        assert updated == "foobar\nfoo"
+    finally:
+        idc.set_func_cmt(addr, original, False)
+
+
+@test(binary="typed_fixture.elf")
+def test_append_comment_interior_address_roundtrip():
+    """append_comments appends to an interior line comment when scoped to line."""
+    import idaapi
+
+    addr = int(TYPED_FIXTURE_IMMEDIATE_1234, 16)
+    original = idaapi.get_cmt(addr, False) or ""
+    try:
+        result = append_comments({"addr": hex(addr), "comment": "__LINE_APPEND__", "scope": "line"})
+        assert_is_list(result, min_length=1)
+        assert result[0].get("ok") is True
+        assert "__LINE_APPEND__" in (idaapi.get_cmt(addr, False) or "")
+    finally:
+        idaapi.set_cmt(addr, original, False)
 
 
 @test(binary="typed_fixture.elf")
@@ -103,7 +179,7 @@ def test_patch_asm_roundtrip():
 @test(binary="typed_fixture.elf")
 def test_patch_asm_invalid_instruction_reports_error():
     """patch_asm reports assembly failures without crashing or partially succeeding."""
-    result = patch_asm({"addr": "0x1013e44", "asm": "not an instruction"})
+    result = patch_asm({"addr": TYPED_FIXTURE_IMMEDIATE_1234, "asm": "not an instruction"})
     assert_is_list(result, min_length=1)
     assert_error(result[0], contains="Failed to assemble")
 
@@ -155,6 +231,37 @@ def test_rename_data_roundtrip():
 
 
 @test()
+def test_rename_dry_run_summary():
+    """rename supports dry_run and returns summary counters"""
+    result = rename({"func": [{"addr": _require_any_function(), "name": "__test_dry_run__"}], "dry_run": True})
+    assert isinstance(result, dict)
+    assert "func" in result
+    assert "summary" in result
+    assert result["summary"]["dry_run"] is True
+    assert_is_list(result["func"], min_length=1)
+    assert result["func"][0].get("dry_run") is True
+
+
+@test()
+def test_rename_stop_on_error():
+    """rename can stop on first error"""
+    result = rename(
+        {
+            "func": [
+                {"addr": "0x0", "name": "__invalid__"},
+                {"addr": _require_any_function(), "name": "__should_not_run__"},
+            ],
+            "stop_on_error": True,
+        }
+    )
+    assert isinstance(result, dict)
+    assert "func" in result
+    assert "summary" in result
+    assert len(result["func"]) == 1
+    assert result["summary"]["stopped"] is True
+
+
+@test()
 def test_rename_local_error_handling():
     """rename(local=...) reports a structured error for a missing local variable."""
     fn_addr = get_any_function()
@@ -184,7 +291,7 @@ def test_rename_local_roundtrip():
         result = rename(
             {
                 "local": [
-                    {"func_addr": "0x1013dc0", "old": "rhs_handle", "new": "rhs_value"}
+                    {"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": TYPED_FIXTURE_LOCAL_NAME, "new": "rhs_value"}
                 ]
             }
         )
@@ -196,7 +303,7 @@ def test_rename_local_roundtrip():
         rename(
             {
                 "local": [
-                    {"func_addr": "0x1013dc0", "old": "rhs_value", "new": "rhs_handle"}
+                    {"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "rhs_value", "new": TYPED_FIXTURE_LOCAL_NAME}
                 ]
             }
         )
@@ -211,18 +318,18 @@ def test_rename_stack_roundtrip():
         result = rename(
             {
                 "stack": [
-                    {"func_addr": "0x1013dc0", "old": "rhs_handle", "new": "rhs_stack"}
+                    {"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": TYPED_FIXTURE_LOCAL_NAME, "new": "rhs_stack"}
                 ]
             }
         )
         assert result["stack"][0]["ok"] is True
-        names = {var["name"] for var in stack_frame("0x1013dc0")[0]["vars"]}
+        names = {var["name"] for var in stack_frame(TYPED_FIXTURE_USE_WRAPPER)[0]["vars"]}
         assert "rhs_stack" in names
     finally:
         rename(
             {
                 "stack": [
-                    {"func_addr": "0x1013dc0", "old": "rhs_stack", "new": "rhs_handle"}
+                    {"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "rhs_stack", "new": TYPED_FIXTURE_LOCAL_NAME}
                 ]
             }
         )
@@ -231,7 +338,7 @@ def test_rename_stack_roundtrip():
 @test(binary="typed_fixture.elf")
 def test_rename_stack_missing_member_error():
     """rename(stack=...) reports missing frame members explicitly."""
-    result = rename({"stack": [{"func_addr": "0x1013dc0", "old": "nope", "new": "x"}]})
+    result = rename({"stack": [{"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "nope", "new": "x"}]})
     assert result["stack"][0]["ok"] is False
     assert_error(result["stack"][0], contains="not found")
 
@@ -240,7 +347,7 @@ def test_rename_stack_missing_member_error():
 def test_rename_stack_special_member_error():
     """rename(stack=...) rejects special frame members like saved registers/return address."""
     result = rename(
-        {"stack": [{"func_addr": "0x1013dc0", "old": "__return_address", "new": "x"}]}
+        {"stack": [{"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "__return_address", "new": "x"}]}
     )
     assert result["stack"][0]["ok"] is False
     assert_error(result["stack"][0], contains="Special frame member")

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
@@ -15,9 +15,13 @@ from ..framework import (
 )
 from ..api_types import (
     declare_type,
+    enum_upsert,
     read_struct,
     search_structs,
+    type_query,
+    type_inspect,
     set_type,
+    type_apply_batch,
     infer_types,
 )
 
@@ -25,6 +29,13 @@ from ..api_types import (
 TEST_STRUCT_NAME = "__TestStruct__"
 NAME_RESOLUTION_STRUCT = "__NameResolutionTest__"
 CRACKME_DSO_HANDLE = "0x4008"
+TYPE_APPLY_SIGNATURE = "int"
+TYPED_FIXTURE_SUM_POINT = "0x1013c10"
+TYPED_FIXTURE_USE_WRAPPER = "0x1013dc0"
+TYPED_FIXTURE_G_POINT = "0x1069f70"
+TYPED_FIXTURE_G_WRAPPER = "0x1069f80"
+TYPED_FIXTURE_INFER_FALLBACK = "0x1069fa4"
+TYPED_FIXTURE_LOCAL_NAME = "rhs_handle"
 
 
 def create_test_struct(name: str = TEST_STRUCT_NAME) -> bool:
@@ -50,6 +61,13 @@ def create_test_struct(name: str = TEST_STRUCT_NAME) -> bool:
 
     search_result = search_structs(name)
     return bool(search_result and any(s["name"] == name for s in search_result))
+
+
+def _require_any_function() -> str:
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+    return fn_addr
 
 
 @test()
@@ -96,7 +114,7 @@ def test_read_struct_returns_named_members():
 @test(binary="typed_fixture.elf")
 def test_read_struct_wrapper_values():
     """read_struct reads the deterministic Wrapper global contents from the typed fixture."""
-    result = read_struct({"addr": "0x1069f80", "struct": "Wrapper"})
+    result = read_struct({"addr": TYPED_FIXTURE_G_WRAPPER, "struct": "Wrapper"})
     assert_is_list(result, min_length=1)
     entry = result[0]
     assert_ok(entry, "members")
@@ -193,6 +211,120 @@ def test_search_structs_exact_wrapper_match():
     assert wrapper["size"] == 24
 
 
+@test()
+def test_type_query():
+    """type_query supports filtered type listing"""
+    result = type_query(
+        {
+            "filter": "*",
+            "kind": "any",
+            "offset": 0,
+            "count": 10,
+            "include_decl": False,
+        }
+    )
+    assert_is_list(result, min_length=1)
+    page = result[0]
+    assert "kind" in page
+    assert "data" in page
+    assert "next_offset" in page
+    assert "total" in page
+    assert "error" in page
+    if page["data"]:
+        assert "ordinal" in page["data"][0]
+        assert "name" in page["data"][0]
+        assert "size" in page["data"][0]
+        assert "kind" in page["data"][0]
+
+
+@test()
+def test_type_inspect():
+    """type_inspect returns metadata for declared struct"""
+    tname = "__TypeInspectTest__"
+    if not create_test_struct(tname):
+        skip_test("failed to declare type-inspect struct")
+
+    result = type_inspect({"name": tname, "include_members": True})
+    assert_is_list(result, min_length=1)
+    r = result[0]
+    assert r["name"] == tname
+    assert r["exists"] is True
+    assert r["error"] is None
+    assert r.get("member_count", 0) >= 0
+
+
+@test()
+def test_set_type():
+    """set_type applies type to address"""
+    result = set_type({"addr": _require_any_function(), "ty": TYPE_APPLY_SIGNATURE})
+    assert_is_list(result, min_length=1)
+
+
+@test()
+def test_enum_upsert_creates_and_replays_idempotently():
+    """enum_upsert creates a new enum and skips exact repeats."""
+    import idc
+
+    enum_name = "__TestEnumUpsert__"
+    enum_id = idc.get_enum(enum_name)
+    if enum_id != idc.BADADDR:
+        idc.del_enum(enum_id)
+
+    try:
+        first = enum_upsert(
+            {
+                "name": enum_name,
+                "members": [
+                    {"name": "__TEST_ENUM_ZERO__", "value": 0},
+                    {"name": "__TEST_ENUM_ONE__", "value": 1},
+                ],
+            }
+        )
+        second = enum_upsert(
+            {
+                "name": enum_name,
+                "members": [
+                    {"name": "__TEST_ENUM_ZERO__", "value": 0},
+                    {"name": "__TEST_ENUM_ONE__", "value": 1},
+                ],
+            }
+        )
+        assert_is_list(first, min_length=1)
+        assert first[0].get("ok") is True
+        assert first[0].get("created") is True
+        assert first[0]["summary"]["created"] == 2
+        assert_is_list(second, min_length=1)
+        assert second[0].get("ok") is True
+        assert second[0]["summary"]["skipped"] == 2
+    finally:
+        enum_id = idc.get_enum(enum_name)
+        if enum_id != idc.BADADDR:
+            idc.del_enum(enum_id)
+
+
+@test()
+def test_enum_upsert_reports_conflicting_member_value():
+    """enum_upsert reports conflicting member names cleanly."""
+    import idc
+
+    enum_name = "__TestEnumConflict__"
+    enum_id = idc.get_enum(enum_name)
+    if enum_id != idc.BADADDR:
+        idc.del_enum(enum_id)
+
+    try:
+        enum_upsert({"name": enum_name, "members": [{"name": "__TEST_ENUM_CONFLICT__", "value": 1}]})
+        result = enum_upsert({"name": enum_name, "members": [{"name": "__TEST_ENUM_CONFLICT__", "value": 2}]})
+        assert_is_list(result, min_length=1)
+        assert result[0].get("ok") is False
+        assert result[0]["summary"]["conflicts"] == 1
+        assert "conflict" in (result[0]["members"][0].get("error") or "").lower()
+    finally:
+        enum_id = idc.get_enum(enum_name)
+        if enum_id != idc.BADADDR:
+            idc.del_enum(enum_id)
+
+
 @test(binary="crackme03.elf")
 def test_set_type_applies_named_global_type():
     """set_type applies a concrete type to a known crackme global and reports success."""
@@ -222,9 +354,21 @@ def test_set_type_global_by_name_branch():
 @test(binary="typed_fixture.elf")
 def test_set_type_global_invalid_type_name():
     """set_type(kind=global) reports invalid type names cleanly."""
-    result = set_type({"addr": "0x1069f70", "ty": "NoSuchType", "kind": "global"})
+    result = set_type({"addr": TYPED_FIXTURE_G_POINT, "ty": "NoSuchType", "kind": "global"})
     assert_is_list(result, min_length=1)
     assert_error(result[0])
+
+
+@test()
+def test_type_apply_batch():
+    """type_apply_batch applies edits and returns summary counters"""
+    result = type_apply_batch({"edits": [{"addr": _require_any_function(), "ty": TYPE_APPLY_SIGNATURE}]})
+    assert "ok" in result
+    assert "applied" in result
+    assert "failed" in result
+    assert "stopped" in result
+    assert "results" in result
+    assert_is_list(result["results"], min_length=1)
 
 
 @test()
@@ -260,7 +404,7 @@ def test_set_type_stack_missing_member():
 def test_set_type_stack_missing_member_typed_fixture():
     """typed_fixture reports missing stack members against a stable non-main function."""
     result = set_type(
-        {"addr": "0x1013dc0", "kind": "stack", "name": "nope", "ty": "int"}
+        {"addr": TYPED_FIXTURE_USE_WRAPPER, "kind": "stack", "name": "nope", "ty": TYPE_APPLY_SIGNATURE}
     )
     assert_is_list(result, min_length=1)
     assert_error(result[0], contains="not found")
@@ -287,7 +431,7 @@ def test_set_type_function_branch():
     """set_type(kind=function) applies a function signature to a typed fixture function."""
     result = set_type(
         {
-            "addr": "0x1013c10",
+            "addr": TYPED_FIXTURE_SUM_POINT,
             "signature": "int __fastcall sum_point(struct Point *p)",
             "kind": "function",
         }
@@ -301,8 +445,8 @@ def test_set_type_function_invalid_signature():
     """set_type(kind=function) rejects non-function signatures."""
     result = set_type(
         {
-            "addr": "0x1013c10",
-            "signature": "int",
+            "addr": TYPED_FIXTURE_SUM_POINT,
+            "signature": TYPE_APPLY_SIGNATURE,
             "kind": "function",
         }
     )
@@ -315,15 +459,16 @@ def test_set_type_local_branch():
     """set_type(kind=local) reaches the local-variable type application path."""
     result = set_type(
         {
-            "addr": "0x1013dc0",
+            "addr": TYPED_FIXTURE_USE_WRAPPER,
             "kind": "local",
-            "variable": "rhs_handle",
-            "ty": "int",
+            "variable": TYPED_FIXTURE_LOCAL_NAME,
+            "ty": TYPE_APPLY_SIGNATURE,
         }
     )
     assert_is_list(result, min_length=1)
     assert (
-        result[0].get("ok") is True or result[0].get("error") == "Failed to apply type"
+        result[0].get("ok") is True
+        or result[0].get("error") == "Failed to apply local variable type"
     )
 
 
@@ -332,9 +477,9 @@ def test_set_type_local_invalid_type_name():
     """set_type(kind=local) reports invalid local type names cleanly."""
     result = set_type(
         {
-            "addr": "0x1013dc0",
+            "addr": TYPED_FIXTURE_USE_WRAPPER,
             "kind": "local",
-            "variable": "rhs_handle",
+            "variable": TYPED_FIXTURE_LOCAL_NAME,
             "ty": "NoSuchType",
         }
     )
@@ -347,10 +492,10 @@ def test_set_type_stack_branch():
     """set_type(kind=stack) applies a type to a real stack-frame member."""
     result = set_type(
         {
-            "addr": "0x1013dc0",
+            "addr": TYPED_FIXTURE_USE_WRAPPER,
             "kind": "stack",
-            "name": "rhs_handle",
-            "ty": "int",
+            "name": TYPED_FIXTURE_LOCAL_NAME,
+            "ty": TYPE_APPLY_SIGNATURE,
         }
     )
     assert_is_list(result, min_length=1)
@@ -360,7 +505,7 @@ def test_set_type_stack_branch():
 @test(binary="typed_fixture.elf")
 def test_infer_types_size_based_low_confidence():
     """infer_types falls back to size-based inference on a typed-fixture interior data address."""
-    result = infer_types("0x1069fa4")
+    result = infer_types(TYPED_FIXTURE_INFER_FALLBACK)
     assert_is_list(result, min_length=1)
     entry = result[0]
     assert entry["method"] == "size_based"
@@ -371,7 +516,7 @@ def test_infer_types_size_based_low_confidence():
 @test(binary="typed_fixture.elf")
 def test_infer_types_existing_or_hexrays_wrapper():
     """infer_types returns a strong typed result for the typed fixture wrapper object."""
-    result = infer_types("0x1069f80")
+    result = infer_types(TYPED_FIXTURE_G_WRAPPER)
     assert_is_list(result, min_length=1)
     entry = result[0]
     assert entry["method"] in {"hexrays", "existing"}

--- a/src/ida_pro_mcp/ida_mcp/tests/test_tool_metadata.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_tool_metadata.py
@@ -1,0 +1,92 @@
+"""Tests for concise, high-signal MCP tool metadata."""
+
+import ast
+import re
+from pathlib import Path
+
+from ..framework import test
+
+
+MAX_DOCSTRING_WORDS = 12
+PLACEHOLDER_PARAM_DESCRIPTIONS = {"address", "offset", "count"}
+
+
+def _is_tool_decorator(dec: ast.expr) -> bool:
+    if isinstance(dec, ast.Name):
+        return dec.id == "tool"
+    if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Name):
+        return dec.func.id == "tool"
+    return False
+
+
+def _iter_tool_functions():
+    root = Path(__file__).resolve().parents[1]
+    for path in sorted(root.glob("api_*.py")):
+        source = path.read_text(encoding="utf-8")
+        module = ast.parse(source)
+        for node in module.body:
+            if isinstance(node, ast.FunctionDef) and any(
+                _is_tool_decorator(d) for d in node.decorator_list
+            ):
+                yield path, node
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text))
+
+
+def _iter_annotated_descriptions(node: ast.FunctionDef):
+    for arg in [*node.args.args, *node.args.kwonlyargs]:
+        ann = arg.annotation
+        if not (
+            isinstance(ann, ast.Subscript)
+            and isinstance(ann.value, ast.Name)
+            and ann.value.id == "Annotated"
+        ):
+            continue
+        if isinstance(ann.slice, ast.Tuple) and len(ann.slice.elts) >= 2:
+            maybe_desc = ann.slice.elts[1]
+            if isinstance(maybe_desc, ast.Constant) and isinstance(maybe_desc.value, str):
+                yield arg.arg, maybe_desc.value
+
+
+@test()
+def test_tool_docstrings_concise():
+    """Tool docstrings are concise and avoid anti-py_eval nudging text."""
+    failures: list[str] = []
+    for path, node in _iter_tool_functions():
+        doc = ast.get_docstring(node) or ""
+        if not doc.strip():
+            failures.append(f"{path.name}:{node.lineno} {node.name} has empty docstring")
+            continue
+        words = _word_count(doc)
+        if words > MAX_DOCSTRING_WORDS:
+            failures.append(
+                f"{path.name}:{node.lineno} {node.name} has {words} words (> {MAX_DOCSTRING_WORDS})"
+            )
+        lower_doc = doc.lower()
+        if "py_eval" in lower_doc and (
+            "avoid " in lower_doc
+            or "instead of" in lower_doc
+            or "replace " in lower_doc
+        ):
+            failures.append(
+                f"{path.name}:{node.lineno} {node.name} includes anti-py_eval nudging"
+            )
+
+    assert not failures, "\n".join(failures)
+
+
+@test()
+def test_tool_param_descriptions_specific():
+    """Annotated parameter descriptions should not use generic placeholders."""
+    failures: list[str] = []
+    for path, node in _iter_tool_functions():
+        for arg_name, description in _iter_annotated_descriptions(node):
+            norm = description.strip().lower().rstrip(".")
+            if norm in PLACEHOLDER_PARAM_DESCRIPTIONS:
+                failures.append(
+                    f"{path.name}:{node.lineno} {node.name}({arg_name}) has generic description {description!r}"
+                )
+
+    assert not failures, "\n".join(failures)

--- a/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
@@ -39,6 +39,7 @@ G_NUMBERS = "0x1069fa0"
 G_MESSAGE = "0x1000c00"
 CALL_USE_WRAPPER = "0x1013f1b"
 IMMEDIATE_1234 = "0x1013e44"
+TYPED_FIXTURE_LOCAL_NAME = "rhs_handle"
 
 
 def _plain_hex_bytes(text: str) -> str:
@@ -166,12 +167,15 @@ def test_typed_fixture_struct_types_and_resources():
 def test_typed_fixture_set_type_local_and_stack_paths():
     """typed fixture hits set_type() local and stack branches on deterministic variables."""
     local = set_type(
-        {"addr": USE_WRAPPER, "kind": "local", "variable": "rhs_handle", "ty": "int"}
+        {"addr": USE_WRAPPER, "kind": "local", "variable": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
     )[0]
-    assert local.get("ok") is True or local.get("error") == "Failed to apply type"
+    assert (
+        local.get("ok") is True
+        or local.get("error") == "Failed to apply local variable type"
+    )
 
     stack = set_type(
-        {"addr": USE_WRAPPER, "kind": "stack", "name": "rhs_handle", "ty": "int"}
+        {"addr": USE_WRAPPER, "kind": "stack", "name": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
     )[0]
     assert stack.get("ok") is True
 
@@ -183,7 +187,7 @@ def test_typed_fixture_rename_local_and_stack_paths():
         local = rename(
             {
                 "local": [
-                    {"func_addr": USE_WRAPPER, "old": "rhs_handle", "new": "rhs_value"}
+                    {"func_addr": USE_WRAPPER, "old": TYPED_FIXTURE_LOCAL_NAME, "new": "rhs_value"}
                 ]
             }
         )
@@ -194,7 +198,7 @@ def test_typed_fixture_rename_local_and_stack_paths():
         stack = rename(
             {
                 "stack": [
-                    {"func_addr": USE_WRAPPER, "old": "rhs_handle", "new": "rhs_stack"}
+                    {"func_addr": USE_WRAPPER, "old": TYPED_FIXTURE_LOCAL_NAME, "new": "rhs_stack"}
                 ]
             }
         )
@@ -206,14 +210,14 @@ def test_typed_fixture_rename_local_and_stack_paths():
         rename(
             {
                 "local": [
-                    {"func_addr": USE_WRAPPER, "old": "rhs_value", "new": "rhs_handle"}
+                    {"func_addr": USE_WRAPPER, "old": "rhs_value", "new": TYPED_FIXTURE_LOCAL_NAME}
                 ]
             }
         )
         rename(
             {
                 "stack": [
-                    {"func_addr": USE_WRAPPER, "old": "rhs_stack", "new": "rhs_handle"}
+                    {"func_addr": USE_WRAPPER, "old": "rhs_stack", "new": TYPED_FIXTURE_LOCAL_NAME}
                 ]
             }
         )

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -85,6 +85,15 @@ class CommentOp(TypedDict):
     comment: Annotated[str, "Comment text"]
 
 
+class CommentAppendOp(TypedDict, total=False):
+    """Comment append operation"""
+
+    addr: Annotated[str, "Address (hex or decimal)"]
+    comment: Annotated[str, "Comment text to append"]
+    scope: Annotated[str, "auto|func|line (default: auto)"]
+    dedupe: Annotated[bool, "Skip if exact text already exists (default: true)"]
+
+
 class AsmPatchOp(TypedDict):
     """Assembly patch operation"""
 
@@ -138,6 +147,12 @@ class RenameBatch(TypedDict, total=False):
     stack: Annotated[
         list[StackRename] | StackRename | None, "Stack variable rename operations"
     ]
+    stop_on_error: Annotated[bool, "Stop processing remaining items on first failure"]
+    dry_run: Annotated[bool, "Validate only; report what would change"]
+    allow_overwrite: Annotated[
+        bool,
+        "Allow renaming even if target name already exists when backend supports force mode",
+    ]
 
 
 class StructFieldQuery(TypedDict):
@@ -147,12 +162,141 @@ class StructFieldQuery(TypedDict):
     field: Annotated[str, "Field name"]
 
 
+class XrefQuery(TypedDict, total=False):
+    """Generic cross-reference query"""
+
+    query: Annotated[str, "Address or name to resolve"]
+    direction: Annotated[str, "to|from|both (default: both)"]
+    xref_type: Annotated[str, "any|code|data (default: any)"]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum results (default: 200, max: 5000)"]
+    include_fn: Annotated[bool, "Include function metadata when available"]
+    dedup: Annotated[bool, "Deduplicate by address/type (default: true)"]
+    sort_by: Annotated[str, "Sort key: addr|type (default: addr)"]
+    descending: Annotated[bool, "Sort descending (default: false)"]
+
+
 class ListQuery(TypedDict, total=False):
     """Pagination query for listing operations"""
 
     filter: Annotated[str, "Optional glob pattern to filter results"]
     offset: Annotated[int, "Starting index (default: 0)"]
     count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
+
+
+class FunctionQuery(TypedDict, total=False):
+    """Function query with richer filtering"""
+
+    filter: Annotated[str, "Optional function name glob/regex filter"]
+    name_regex: Annotated[str, "Optional regex to apply to function names"]
+    min_size: Annotated[int, "Minimum function size in bytes (inclusive)"]
+    max_size: Annotated[int, "Maximum function size in bytes (inclusive)"]
+    has_type: Annotated[bool, "Require function type information to be present"]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
+    sort_by: Annotated[str, "Sort key: addr|name|size (default: addr)"]
+    descending: Annotated[bool, "Sort descending (default: false)"]
+
+
+class EntityQuery(TypedDict, total=False):
+    """Generic IDB entity query with filtering, projection, and pagination"""
+
+    kind: Annotated[str, "Entity kind: functions|globals|imports|strings|names"]
+    filter: Annotated[str, "Optional glob/regex filter (name/text depending on kind)"]
+    regex: Annotated[str, "Optional regex applied to the primary text field"]
+    min_addr: Annotated[str, "Optional minimum address bound (hex/decimal)"]
+    max_addr: Annotated[str, "Optional maximum address bound (hex/decimal)"]
+    segment: Annotated[str, "Optional segment filter for address-backed entities"]
+    module: Annotated[str, "Optional import module filter (imports only)"]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum number of results (default: 100, 0 for all)"]
+    sort_by: Annotated[str, "Sort key, e.g. addr|name|size|length"]
+    descending: Annotated[bool, "Sort descending (default: false)"]
+    fields: Annotated[
+        list[str] | str,
+        "Optional projection list; only selected fields are returned",
+    ]
+
+
+class FuncProfileQuery(TypedDict, total=False):
+    """Function profiling query with pagination and optional detail lists"""
+
+    query: Annotated[str, "Address/name or '*' for all functions"]
+    filter: Annotated[str, "Optional function-name glob/regex filter"]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
+    sort_by: Annotated[str, "Sort key: addr|name|size (default: addr)"]
+    descending: Annotated[bool, "Sort descending (default: false)"]
+    include_lists: Annotated[bool, "Include sampled callers/callees/strings/constants"]
+    max_items: Annotated[int, "Max sampled items per list when include_lists=true"]
+    include_prototype: Annotated[bool, "Include recovered function prototype text"]
+
+
+class AnalyzeBatchQuery(TypedDict, total=False):
+    """Comprehensive function analysis request"""
+
+    query: Annotated[str, "Function address or name"]
+    include_decompile: Annotated[bool, "Include decompiler output (default: true)"]
+    include_disasm: Annotated[
+        bool, "Include disassembly lines (default: false, use max_disasm_insns)"
+    ]
+    include_xrefs: Annotated[bool, "Include xrefs-to/from summary (default: true)"]
+    include_callers: Annotated[bool, "Include caller list (default: true)"]
+    include_callees: Annotated[bool, "Include callee list (default: true)"]
+    include_strings: Annotated[bool, "Include referenced strings (default: true)"]
+    include_constants: Annotated[
+        bool, "Include immediate constants referenced in function (default: true)"
+    ]
+    include_basic_blocks: Annotated[
+        bool, "Include CFG basic blocks (default: true, capped by max_blocks)"
+    ]
+    include_proto: Annotated[bool, "Include recovered prototype (default: true)"]
+    max_disasm_insns: Annotated[
+        int, "Maximum disassembly instructions when include_disasm=true (default: 300)"
+    ]
+    max_callers: Annotated[int, "Maximum callers returned (default: 100)"]
+    max_callees: Annotated[int, "Maximum callees returned (default: 100)"]
+    max_strings: Annotated[int, "Maximum string refs returned (default: 100)"]
+    max_constants: Annotated[int, "Maximum constants returned (default: 200)"]
+    max_blocks: Annotated[int, "Maximum basic blocks returned (default: 500)"]
+
+
+class ImportQuery(TypedDict, total=False):
+    """Import query with filtering and pagination"""
+
+    filter: Annotated[str, "Optional import name glob/regex filter"]
+    module: Annotated[str, "Optional module name glob/regex filter"]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum number of results (default: 100, 0 for all)"]
+
+
+class TypeInspectQuery(TypedDict, total=False):
+    """Type inspection request"""
+
+    name: Annotated[str, "Type name"]
+    include_members: Annotated[bool, "Include member details for UDT types"]
+    max_members: Annotated[int, "Maximum members to include (default: 128)"]
+
+
+class TypeQuery(TypedDict, total=False):
+    """Type catalog query with filtering, pagination, and optional relationships"""
+
+    filter: Annotated[str, "Optional type name glob/regex filter"]
+    kind: Annotated[
+        str,
+        "any|struct|union|enum|typedef|func|ptr|udt (default: any)",
+    ]
+    offset: Annotated[int, "Starting index (default: 0)"]
+    count: Annotated[int, "Maximum results (default: 100, 0 for all)"]
+    sort_by: Annotated[str, "Sort key: name|size|ordinal (default: name)"]
+    descending: Annotated[bool, "Sort descending (default: false)"]
+    include_decl: Annotated[bool, "Include declaration text (default: true)"]
+    include_members: Annotated[bool, "Include UDT member details (default: false)"]
+    max_members: Annotated[int, "Maximum members per UDT (default: 64)"]
+    include_relationships: Annotated[
+        bool,
+        "Include related/member type names to support type navigation (default: false)",
+    ]
 
 
 class BreakpointOp(TypedDict):
@@ -174,8 +318,16 @@ class InsnPattern(TypedDict, total=False):
     segment: Annotated[str, "Segment name to scope the scan"]
     start: Annotated[str, "Start address (hex/dec) to scope the scan"]
     end: Annotated[str, "End address (hex/dec, exclusive) to scope the scan"]
+    offset: Annotated[int, "Starting match index (default: 0)"]
+    count: Annotated[int, "Maximum matches to return (default: 100, max: 5000)"]
     max_scan_insns: Annotated[
         int, "Max instructions to scan (default: 200000, max: 2000000)"
+    ]
+    include_fn: Annotated[
+        bool, "Include containing function metadata for each match (default: false)"
+    ]
+    include_disasm: Annotated[
+        bool, "Include disassembly text for each match (default: false)"
     ]
     allow_broad: Annotated[
         bool,
@@ -212,6 +364,28 @@ class TypeEdit(TypedDict, total=False):
     kind: Annotated[str, "Type of entity (auto-detected if omitted)"]
     signature: Annotated[str, "Function signature (for kind=function)"]
     variable: Annotated[str, "Local variable name (for kind=local)"]
+
+
+class EnumMemberUpsert(TypedDict, total=False):
+    """Enum member upsert operation"""
+
+    name: Annotated[str, "Enum member name"]
+    value: Annotated[int | str, "Enum member value"]
+
+
+class EnumUpsert(TypedDict, total=False):
+    """Enum create/update operation"""
+
+    name: Annotated[str, "Enum type name"]
+    members: Annotated[list[EnumMemberUpsert] | EnumMemberUpsert, "Members to upsert"]
+    bitfield: Annotated[bool, "Whether the enum is a bitfield (default: false)"]
+
+
+class TypeApplyBatch(TypedDict, total=False):
+    """Batch type application configuration"""
+
+    edits: Annotated[list[TypeEdit] | TypeEdit, "Type edits to apply"]
+    stop_on_error: Annotated[bool, "Stop processing remaining edits on first failure"]
 
 
 class StackVarDecl(TypedDict):

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -8,8 +8,10 @@ from typing import Annotated, Optional
 
 # idapro must go first to initialize idalib
 import idapro
+import ida_loader
 
 from ida_pro_mcp.ida_mcp import MCP_SERVER
+from ida_pro_mcp.ida_mcp.api_core import server_health, server_warmup
 from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, tool
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 
@@ -24,6 +26,9 @@ IDALIB_MANAGEMENT_TOOLS = {
     "idalib_unbind",
     "idalib_list",
     "idalib_current",
+    "idalib_save",
+    "idalib_health",
+    "idalib_warmup",
 }
 
 _ISOLATED_CONTEXTS_ENABLED = False
@@ -241,6 +246,134 @@ def idalib_current() -> dict:
         return {**session.to_dict(), **_context_response_fields(context_id)}
     except Exception as e:
         return {"error": f"Failed to get current session: {e}"}
+
+
+@tool
+def idalib_save(
+    path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
+    session_id: Annotated[
+        Optional[str], "Optional session to activate before saving"
+    ] = None,
+) -> dict:
+    """Save the active (or requested) IDA session database to disk."""
+
+    try:
+        manager = get_session_manager()
+        context_id = _resolve_effective_context_id()
+
+        if session_id:
+            manager.bind_context(context_id, session_id, activate=True)
+        else:
+            manager.activate_context(context_id)
+
+        save_path = path.strip() if path else ""
+        if not save_path:
+            save_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        if not save_path:
+            return {
+                "ok": False,
+                **_context_response_fields(context_id),
+                "error": "Could not resolve IDB path",
+            }
+
+        ok = bool(ida_loader.save_database(save_path, 0))
+        return {
+            "ok": ok,
+            "path": save_path,
+            **_context_response_fields(context_id),
+            "error": None if ok else "save_database returned false",
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@tool
+def idalib_health(
+    session_id: Annotated[
+        Optional[str], "Optional session to bind/activate before probing health"
+    ] = None,
+) -> dict:
+    """Health/ready probe for idalib context + core server status."""
+    try:
+        manager = get_session_manager()
+        context_id = _resolve_effective_context_id()
+
+        if session_id:
+            session = manager.bind_context(context_id, session_id, activate=True)
+        else:
+            session = manager.get_context_session(context_id)
+            if session is None:
+                return {
+                    "ready": False,
+                    **_context_response_fields(context_id),
+                    "session": None,
+                    "health": None,
+                    "error": (
+                        "No session bound for this context. "
+                        "Use idalib_open(...) or idalib_switch(session_id) first."
+                    ),
+                }
+            manager.activate_context(context_id)
+            session = manager.get_context_session(context_id)
+
+        health = server_health()
+        return {
+            "ready": bool(health.get("status") == "ok"),
+            **_context_response_fields(context_id),
+            "session": session.to_dict() if session is not None else None,
+            "health": health,
+            "error": None,
+        }
+    except Exception as e:
+        return {"ready": False, "error": str(e)}
+
+
+@tool
+def idalib_warmup(
+    session_id: Annotated[
+        Optional[str], "Optional session to bind/activate before warmup"
+    ] = None,
+    wait_auto_analysis: Annotated[bool, "Wait for auto analysis queue"] = True,
+    build_caches: Annotated[bool, "Build core caches"] = True,
+    init_hexrays: Annotated[bool, "Initialize Hex-Rays plugin"] = True,
+) -> dict:
+    """Warm up idalib context and core subsystems."""
+    try:
+        manager = get_session_manager()
+        context_id = _resolve_effective_context_id()
+
+        if session_id:
+            session = manager.bind_context(context_id, session_id, activate=True)
+        else:
+            session = manager.get_context_session(context_id)
+            if session is None:
+                return {
+                    "ready": False,
+                    **_context_response_fields(context_id),
+                    "session": None,
+                    "warmup": None,
+                    "error": (
+                        "No session bound for this context. "
+                        "Use idalib_open(...) or idalib_switch(session_id) first."
+                    ),
+                }
+            manager.activate_context(context_id)
+            session = manager.get_context_session(context_id)
+
+        warmup = server_warmup(
+            wait_auto_analysis=wait_auto_analysis,
+            build_caches=build_caches,
+            init_hexrays=init_hexrays,
+        )
+        return {
+            "ready": bool(warmup.get("ok")),
+            **_context_response_fields(context_id),
+            "session": session.to_dict() if session is not None else None,
+            "warmup": warmup,
+            "error": None,
+        }
+    except Exception as e:
+        return {"ready": False, "error": str(e)}
 
 
 def main():

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -41,16 +41,30 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
     elif request_obj["method"].startswith("notifications/"):
         return dispatch_original(request)
 
-    conn = http.client.HTTPConnection(IDA_HOST, IDA_PORT, timeout=30)
+    payload: bytes | str | dict = request
+    if isinstance(payload, dict):
+        payload = json.dumps(payload)
+    elif isinstance(payload, str):
+        payload = payload.encode("utf-8")
+
     try:
-        if isinstance(request, dict):
-            request = json.dumps(request)
-        elif isinstance(request, str):
-            request = request.encode("utf-8")
-        conn.request("POST", "/mcp", request, {"Content-Type": "application/json"})
-        response = conn.getresponse()
-        data = response.read().decode()
-        return json.loads(data)
+        conn = http.client.HTTPConnection(IDA_HOST, IDA_PORT, timeout=30)
+        try:
+            conn.request(
+                "POST",
+                "/mcp",
+                payload,
+                {"Content-Type": "application/json"},
+            )
+            response = conn.getresponse()
+            raw_data = response.read().decode()
+            if response.status >= 400:
+                raise RuntimeError(
+                    f"HTTP {response.status} {response.reason}: {raw_data}"
+                )
+            return json.loads(raw_data)
+        finally:
+            conn.close()
     except Exception as e:
         full_info = traceback.format_exc()
         id = request_obj.get("id")
@@ -66,14 +80,18 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
                 "jsonrpc": "2.0",
                 "error": {
                     "code": -32000,
-                    "message": f"Failed to connect to IDA Pro! Did you run Edit -> Plugins -> MCP ({shortcut}) to start the server?\n{full_info}",
+                    "message": (
+                        "Failed to complete request to IDA Pro. "
+                        f"Did you run Edit -> Plugins -> MCP ({shortcut}) to start the server?\n"
+                        "The request was not retried automatically. "
+                        "If this was a mutating operation, verify IDA state before retrying.\n"
+                        f"{full_info}"
+                    ),
                     "data": str(e),
                 },
                 "id": id,
             }
         )
-    finally:
-        conn.close()
 
 
 mcp.registry.dispatch = dispatch_proxy

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import patch
+
+from ida_pro_mcp import server
+
+
+class _FakeResponse:
+    def __init__(self, status=200, reason="OK", body=b'{"jsonrpc":"2.0","result":{"ok":true},"id":1}'):
+        self.status = status
+        self.reason = reason
+        self._body = body
+
+    def read(self):
+        return self._body
+
+
+class _BaseFakeConnection:
+    instances = []
+
+    def __init__(self, host, port, timeout=30):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.request_calls = 0
+        self.closed = False
+        type(self).instances.append(self)
+
+    @classmethod
+    def reset(cls):
+        cls.instances = []
+
+    def request(self, method, path, body, headers):
+        self.request_calls += 1
+
+    def close(self):
+        self.closed = True
+
+
+class _ResponseFailureConnection(_BaseFakeConnection):
+    def getresponse(self):
+        raise TimeoutError("read timeout")
+
+
+class _Http503Connection(_BaseFakeConnection):
+    def getresponse(self):
+        return _FakeResponse(status=503, reason="Service Unavailable", body=b"busy")
+
+
+class _ConnectFailureConnection(_BaseFakeConnection):
+    def request(self, method, path, body, headers):
+        super().request(method, path, body, headers)
+        raise ConnectionRefusedError("refused")
+
+
+class DispatchProxyTransportTests(unittest.TestCase):
+    def setUp(self):
+        _ResponseFailureConnection.reset()
+        _Http503Connection.reset()
+        _ConnectFailureConnection.reset()
+
+    def test_dispatch_proxy_does_not_retry_post_send_failures(self):
+        request = {"jsonrpc": "2.0", "method": "tools/call", "params": {}, "id": 1}
+        with patch("ida_pro_mcp.server.http.client.HTTPConnection", _ResponseFailureConnection):
+            response = server.dispatch_proxy(request)
+
+        self.assertIsNotNone(response)
+        self.assertIn("error", response)
+        self.assertIn("not retried automatically", response["error"]["message"])
+        self.assertIn("read timeout", response["error"]["data"])
+        self.assertEqual(len(_ResponseFailureConnection.instances), 1)
+        self.assertEqual(_ResponseFailureConnection.instances[0].request_calls, 1)
+        self.assertTrue(_ResponseFailureConnection.instances[0].closed)
+
+    def test_dispatch_proxy_does_not_retry_http_503(self):
+        request = {"jsonrpc": "2.0", "method": "tools/call", "params": {}, "id": 1}
+        with patch("ida_pro_mcp.server.http.client.HTTPConnection", _Http503Connection):
+            response = server.dispatch_proxy(request)
+
+        self.assertIsNotNone(response)
+        self.assertIn("error", response)
+        self.assertIn("HTTP 503 Service Unavailable", response["error"]["data"])
+        self.assertEqual(len(_Http503Connection.instances), 1)
+        self.assertEqual(_Http503Connection.instances[0].request_calls, 1)
+        self.assertTrue(_Http503Connection.instances[0].closed)
+
+    def test_dispatch_proxy_does_not_retry_connection_failures(self):
+        request = {"jsonrpc": "2.0", "method": "tools/call", "params": {}, "id": 1}
+        with patch("ida_pro_mcp.server.http.client.HTTPConnection", _ConnectFailureConnection):
+            response = server.dispatch_proxy(request)
+
+        self.assertIsNotNone(response)
+        self.assertIn("error", response)
+        self.assertIn("refused", response["error"]["data"])
+        self.assertEqual(len(_ConnectFailureConnection.instances), 1)
+        self.assertEqual(_ConnectFailureConnection.instances[0].request_calls, 1)
+        self.assertTrue(_ConnectFailureConnection.instances[0].closed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I've been using ida-pro-mcp in anger a lot lately and I had noticed it was relying on py_eval a lot, jitting scripts to /tmp and running those to do what I asked it to do.

After some conversations at unprompted, it was suggested that I use codex to analyze the execution traces to improve the tool and/or prompting. This PR is exactly that, I pointed codex at my execution traces and told it to find mistakes and anytime it used py_eval due to missing functionality, and to help me add or improve that functionality.

Created as a draft so we can discuss it (it's a lot of changes).

The remainder of this message is the AI created PR message which summarizes the changes. [/human]

## Summary

This branch makes the MCP surface more usable for iterative reverse-engineering conversations with Codex.

The main goal was not just to add more raw capability, but to make the server easier for an agent to use correctly over long analysis sessions:
  - richer structured queries instead of forcing ad hoc `py_eval`
  - better pagination / truncation / filtering so responses stay model-friendly
  - stronger type and rename workflows for applying results back into the IDB
  - better runtime health, warmup, and save behavior for more reliable automation

  ## Approach

A lot of the changes here came from using Codex against real analysis traces and looking for failure patterns rather than designing the API in the abstract.

The rough loop was:
  1. run Codex on real reverse-engineering tasks
  2. inspect the traces for places where it got stuck, made avoidable mistakes, or fell back to `py_eval`
  3. identify what structured operation was missing or too awkward
  4. add or expand a first-class tool so the agent could do that work directly
  5. tighten metadata and tests so the tool descriptions stay concise and don’t push the model back toward `py_eval`

That trace-driven workflow pushed this branch in a few consistent directions:
  - when Codex needed “list then filter then page”, add a structured query API
  - when it needed to inspect a function holistically, add batch/profile-style analysis tools
  - when it needed to mutate names/types, provide explicit batch mutation APIs with dry-run / stop-on-error support
  - when startup or transient state caused flaky behavior, add health/warmup/save support

`py_eval` still exists and is useful as an escape hatch, but the intent of this branch is to reduce how often the model needs it for routine work.

## Added / Expanded Functions

### Core / runtime
  - `server_health()`
    Returns a health/readiness snapshot for the current IDB and MCP server state.
  - `server_warmup(wait_auto_analysis, build_caches, init_hexrays)`
    Prepares IDA subsystems up front to reduce first-call latency and transient failures.
  - `func_query(...)`
    Richer function querying with filtering, sorting, and pagination.
  - `list_globals(...)`
    Structured global listing with filtering and pagination.
  - `entity_query(...)`
    Generic query interface over functions, globals, imports, strings, and names.
  - `imports_query(...)`
    Import querying with module/name filters and pagination.
  - `idb_save(path="")`
    Saves the active IDB, optionally to a caller-provided destination.

### Analysis
  - `func_profile(...)`
    Produces compact per-function summaries including size and optional sampled details.
  - `analyze_batch(...)`
    Runs broader per-function analysis in one call, with selectable sections like decompilation, disassembly, xrefs, callers/callees, strings, constants, and basic blocks.
  - `xref_query(...)`
    Structured xref querying with direction/type filters, deduping, sorting, and pagination.
  - `callees(...)`
    Returns unique callees for target functions with truncation support.
  - `insn_query(...)`
    Searches instructions by mnemonic and operand constraints within explicit scopes.
  - `xrefs_to(...)`
    Improved bounded xref lookup with truncation signaling.
  - `find_bytes(...)`
    Byte-pattern search with pagination and wildcard support.
  - `basic_blocks(...)`
    CFG/basic-block listing with pagination.
  - `find(...)`
    Expanded structured search for strings, immediates, data refs, and code refs.

### Types
  - `type_query(...)`
    Structured local type catalog query with filtering, paging, optional members, and relationships.
  - `type_inspect(...)`
    Inspect a named type including declaration, size, and optionally member layout.
  - `set_type(...)`
    Applies type edits to functions, globals, locals, and stack variables.
  - `type_apply_batch(...)`
    Batch type application with aggregate status and optional stop-on-error behavior.
  - `infer_types(...)`
    Infers likely types at target addresses using available IDA/Hex-Rays information.

### Modification workflows
  - `rename(...)`
    Expanded into a structured batch rename API for functions, globals, locals, and stack vars, with support for `dry_run`, overwrite control, and stop-on-error behavior.

## Other Improvements

  - Added RPC retry/backoff and runtime stability improvements around IDA/idalib workflows.
  - Added metadata quality tests to keep tool descriptions concise and avoid nudging the model toward `py_eval`.
  - Added coverage for the new query/type/rename behavior in analysis/core/type/modify tests.

## Why This Matters

  The branch is aimed at making Codex more reliable as an analysis partner:
  - less custom Python for routine tasks
  - more predictable, typed responses
  - fewer oversized tool outputs
  - better support for iterative “inspect -> decide -> apply -> verify” workflows inside a single session