### PR TITLE
fix opencode MCP server config

### DIFF
--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -217,14 +217,25 @@ def infer_http_transport_type(transport_url: str) -> str:
 
 def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
     if transport == "stdio":
-        mcp_config = {
-            "command": get_python_executable(),
-            "args": [
-                __file__,
-                "--ida-rpc",
-                f"http://{IDA_HOST}:{IDA_PORT}",
-            ],
-        }
+        if client_name == "Opencode":
+            mcp_config = {
+                "type": "local",
+                "command": [
+                    get_python_executable(),
+                    __file__,
+                    "--ida-rpc",
+                    f"http://{IDA_HOST}:{IDA_PORT}",
+                ],
+            }
+        else:
+            mcp_config = {
+                "command": get_python_executable(),
+                "args": [
+                    __file__,
+                    "--ida-rpc",
+                    f"http://{IDA_HOST}:{IDA_PORT}",
+                ],
+            }
         env = {}
         if copy_python_env(env):
             print("[WARNING] Custom Python environment variables detected")
@@ -326,6 +337,7 @@ GLOBAL_SPECIAL_JSON_STRUCTURES: dict[str, tuple[str | None, str]] = {
     "VS Code": ("mcp", "servers"),
     "VS Code Insiders": ("mcp", "servers"),
     "Visual Studio 2022": (None, "servers"),  # servers at top level
+    "Opencode": (None, "mcp"),  # mcp at top level
 }
 
 
@@ -430,8 +442,8 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp_config.json",
             ),
             "Opencode": (
-                os.path.join(os.path.expanduser("~"), ".opencode"),
-                "mcp_config.json",
+                os.path.join(os.path.expanduser("~"), ".config", "opencode"),
+                "opencode.json",
             ),
             "Kiro": (
                 os.path.join(os.path.expanduser("~"), ".kiro"),
@@ -589,8 +601,8 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp_config.json",
             ),
             "Opencode": (
-                os.path.join(os.path.expanduser("~"), ".opencode"),
-                "mcp_config.json",
+                os.path.join(os.path.expanduser("~"), ".config", "opencode"),
+                "opencode.json",
             ),
             "Kiro": (
                 os.path.join(os.path.expanduser("~"), ".kiro"),
@@ -722,8 +734,8 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp_config.json",
             ),
             "Opencode": (
-                os.path.join(os.path.expanduser("~"), ".opencode"),
-                "mcp_config.json",
+                os.path.join(os.path.expanduser("~"), ".config", "opencode"),
+                "opencode.json",
             ),
             "Kiro": (
                 os.path.join(os.path.expanduser("~"), ".kiro"),


### PR DESCRIPTION
Fixes #247 

### Summary
This PR corrects the `ida-pro-mcp --install` command to support Opencode by aligning with its expected configuration path and JSON format.
### Changes
- Updated the global config path for Opencode from `~/.opencode/mcp_config.json` to the correct `~/.config/opencode/opencode.json` (consistent with Opencode's precedence order).
- Modified `generate_mcp_config` for Opencode to use the required `type: "local"` and a single `command` array instead of the `command`/`args` split.

Tested this on my local system and it worked w/ no issues.