### PR TITLE
feat: add Opencode project-level config and fix transport structure

### DIFF
--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -148,6 +148,7 @@ PROJECT_LEVEL_CONFIGS: dict[str, tuple[str, str]] = {
     "VS Code": (".vscode", "mcp.json"),
     "VS Code Insiders": (".vscode", "mcp.json"),
     "Windsurf": (".windsurf", "mcp.json"),
+    "Opencode": (".config/opencode", "opencode.json"),
     "Zed": (".zed", "settings.json"),
 }
 
@@ -272,7 +273,7 @@ def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
         return {"url": force_mcp_path(transport_url)}
 
     # Claude/Claude Code support explicit transport type in JSON config.
-    if client_name in ("Claude", "Claude Code"):
+    if client_name in ("Claude", "Claude Code", "Opencode"):
         return {"type": infer_http_transport_type(transport_url), "url": transport_url}
 
     # Keep all other clients on streamable HTTP /mcp for compatibility.


### PR DESCRIPTION
## Summary
This PR addresses additional incompatibilities for the Opencode client found after #282.
### Fixes
- Added `Opencode` to `PROJECT_LEVEL_CONFIGS`, allowing users to install the MCP server config locally within their project at `.config/opencode/opencode.json`.
- Opencode requires an explicit `{ "type": "...", "url": "..." }` structure for HTTP/SSE transports (identical to Claude/Claude Code). This PR adds Opencode to the list of clients using this format, resolving "Invalid input" errors when using HTTP/SSE transports.

Before this there were issues installing Opencode MCP with the HTTP option which I tried on a clean install and got JSON config issues. This should hopefully fix them