### PR TITLE
Add stdio transport for Opencode

### DIFF
--- a/src/ida_pro_mcp/installer.py
+++ b/src/ida_pro_mcp/installer.py
@@ -156,8 +156,7 @@ def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
 
     transport_url = normalize_transport_url(transport)
     if client_name == "Opencode":
-        # Opencode requires local (stdio) transport
-        return generate_mcp_config(client_name=client_name, transport="stdio")
+        return {"type": "remote", "url": transport_url}
     if client_name == "Codex":
         return {"url": force_mcp_path(transport_url)}
     if client_name in ("Claude", "Claude Code"):


### PR DESCRIPTION
## Summary
This PR addresses additional incompatibilities for the Opencode client found after #282.
### Fixes
Opencode requires an explicit `{ "type": "...", "url": "..." }` structure for HTTP/SSE transports (identical to Claude/Claude Code). This PR adds Opencode to the list of clients using this format, resolving "Invalid input" errors when using HTTP/SSE transports.

Before this there were issues installing Opencode MCP with the HTTP option which I tried on a clean install and got JSON config issues. This should hopefully fix them.