### PR TITLE
Fix IDA 9.0 early build API compatibility

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -9,6 +9,7 @@ import ida_dirtree
 import ida_funcs
 import ida_ua
 
+from .compat import tinfo_get_udm
 from .rpc import tool
 from .sync import idasync, IDAError
 from .utils import (
@@ -567,7 +568,7 @@ def rename(batch: RenameBatch | dict) -> dict:
                         break
                     continue
 
-                idx, udm = frame_tif.get_udm(old_name)
+                idx, udm = tinfo_get_udm(frame_tif, old_name)
                 if not udm:
                     result = {
                         "func_addr": func_addr,

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -9,6 +9,7 @@ import ida_typeinf
 import ida_frame
 import idaapi
 
+from .compat import tinfo_get_udm
 from .rpc import tool
 from .sync import idasync
 from .utils import (
@@ -118,7 +119,7 @@ def delete_stack(
                 )
                 continue
 
-            idx, udm = frame_tif.get_udm(var_name)
+            idx, udm = tinfo_get_udm(frame_tif, var_name)
             if not udm:
                 results.append(
                     {

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -27,6 +27,7 @@ from .utils import (
     EnumUpsert,
 )
 from . import compat
+from .compat import tinfo_get_udm
 
 
 # ============================================================================
@@ -739,7 +740,8 @@ def _parse_type_tinfo(type_text: str) -> ida_typeinf.tinfo_t:
         for candidate in candidates:
             tif = ida_typeinf.tinfo_t()
             try:
-                if parse_decl(tif, None, candidate, flags):
+                # parse_decl returns '' on success in IDA 9.0, check is not None
+                if parse_decl(tif, None, candidate, flags) is not None and not tif.empty():
                     return tif
             except Exception:
                 continue
@@ -773,7 +775,8 @@ def _parse_function_tinfo(signature_text: str) -> ida_typeinf.tinfo_t:
         for candidate in candidates:
             tif = ida_typeinf.tinfo_t()
             try:
-                if parse_decl(tif, None, candidate, flags) and tif.is_func():
+                # parse_decl returns '' on success in IDA 9.0, check is not None
+                if parse_decl(tif, None, candidate, flags) is not None and tif.is_func():
                     return tif
             except Exception:
                 continue
@@ -804,7 +807,7 @@ def _infer_type_edit_kind(edit: dict) -> str:
             if fn:
                 frame_tif = ida_typeinf.tinfo_t()
                 if ida_frame.get_func_frame(frame_tif, fn):
-                    _, udm = frame_tif.get_udm(str(edit["name"]))
+                    _, udm = tinfo_get_udm(frame_tif, str(edit["name"]))
                     if udm:
                         return "stack"
         except Exception:
@@ -898,7 +901,7 @@ def _apply_type_edit(edit: dict) -> dict:
             if not ida_frame.get_func_frame(frame_tif, func):
                 return {"edit": edit, "kind": kind, "error": "No frame available"}
 
-            idx, udm = frame_tif.get_udm(stack_name)
+            idx, udm = tinfo_get_udm(frame_tif, stack_name)
             if not udm:
                 return {
                     "edit": edit,

--- a/src/ida_pro_mcp/ida_mcp/compat.py
+++ b/src/ida_pro_mcp/ida_mcp/compat.py
@@ -151,15 +151,17 @@ def inf_is_64bit() -> bool:
 
 
 def get_func_name(func: ida_funcs.func_t) -> str | None:
-    # func_t.get_name() introduced in 8.5
-    if IDA_GE_85:
+    # func_t.get_name() introduced in 8.5, but missing in early 9.0 builds (build 240925)
+    # Use hasattr() to handle early IDA 9.0 builds that lack the method
+    if IDA_GE_85 and hasattr(func, "get_name"):
         return func.get_name()
     return ida_funcs.get_func_name(func.start_ea)
 
 
 def get_func_prototype(func: ida_funcs.func_t) -> ida_typeinf.tinfo_t | None:
-    # func_t.get_prototype() introduced in 8.5
-    if IDA_GE_85:
+    # func_t.get_prototype() introduced in 8.5, but missing in early 9.0 builds (build 240925)
+    # Use hasattr() to handle early IDA 9.0 builds that lack the method
+    if IDA_GE_85 and hasattr(func, "get_prototype"):
         return func.get_prototype()
 
     tif = ida_typeinf.tinfo_t()
@@ -249,3 +251,39 @@ def guess_tinfo(tif: ida_typeinf.tinfo_t, ea: int) -> bool:
             pass
 
     return False
+
+
+# ============================================================================
+# UDM (struct/union member) compatibility
+# ============================================================================
+
+
+def tinfo_get_udm(
+    tif: ida_typeinf.tinfo_t, name: str
+) -> tuple[int, ida_typeinf.udm_t | None]:
+    """
+    Get a UDM (user-defined member) from a tinfo_t by name.
+
+    tinfo_t.get_udm() was introduced in IDA 8.5 but is missing in early
+    IDA 9.0 builds (build 240925). This wrapper provides a fallback using
+    the older find_udm() + get_udm_by_tid() APIs.
+
+    Returns:
+        tuple of (index, udm) where udm is None if not found
+    """
+    # Try modern API first (available in 8.5+ but not early 9.0 builds)
+    if hasattr(tif, "get_udm"):
+        return tif.get_udm(name)
+
+    # Fallback for early 9.0 builds using find_udm + get_udm_by_tid
+    idx = tif.find_udm(name)
+    if idx == -1:
+        return -1, None
+
+    udm = ida_typeinf.udm_t()
+    tid = tif.get_udm_tid(idx)
+    # get_udm_by_tid returns 0 on success (C convention), check if udm.name is populated
+    tif.get_udm_by_tid(udm, tid)
+    if udm.name:
+        return idx, udm
+    return -1, None

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
@@ -126,7 +126,8 @@ def test_declare_stack_invalid_type_error():
         {"addr": "0x1013dc0", "name": "x", "offset": -0x18, "ty": "NoSuchType"}
     )
     assert_is_list(result, min_length=1)
-    assert_error(result[0], contains="Invalid input data")
+    # Error message may vary: "Unable to retrieve ... type info object" or similar
+    assert_error(result[0], contains="NoSuchType")
 
 
 @test(binary="typed_fixture.elf")

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -799,6 +799,7 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         "int64",
         "__int64",
         "int64_t",
+        "signed __int64",
         "long long",
         "long long int",
         "signed long long",
@@ -810,6 +811,7 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         "__uint64",
         "uint64_t",
         "unsigned int64",
+        "unsigned __int64",
         "unsigned long long",
         "unsigned long long int",
         "qword",
@@ -850,7 +852,12 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         return tif
     if tif.get_named_type(None, type_name, ida_typeinf.BTF_UNION):
         return tif
-    if tif := ida_typeinf.tinfo_t(type_name):
+
+    # Try parse_decl for arbitrary type expressions (works in IDA 9.0+)
+    tif = ida_typeinf.tinfo_t()
+    flags = ida_typeinf.PT_SIL | ida_typeinf.PT_TYP
+    candidate = type_name if type_name.endswith(";") else type_name + ";"
+    if ida_typeinf.parse_decl(tif, None, candidate, flags) is not None and not tif.empty():
         return tif
 
     raise IDAError(f"Unable to retrieve {type_name} type info object")


### PR DESCRIPTION
IDA 9.0 build 240925 removed several methods that were added in IDA 8.5 but were later reinstated in IDA 9.1+. This commit adds runtime detection using hasattr() to handle these missing methods gracefully.

API Compatibility Fixes:
- func_t.get_name() missing in early 9.0 builds
- func_t.get_prototype() missing in early 9.0 builds
- tinfo_t.get_udm() missing in early 9.0 builds

parse_decl Return Value Fixes:
- In IDA 9.0, parse_decl() returns '' (empty string) on success
- Changed checks from 'if parse_decl(...)' to 'if parse_decl(...) is not None'
- Applied to _parse_type_tinfo(), _parse_function_tinfo(), and get_type_by_name()

tinfo_get_udm Fixes:
- get_udm_by_tid() returns 0 on success (C convention)
- Changed to check if udm.name is populated instead of return value

Type Lookup Fixes:
- Added 'signed __int64' and 'unsigned __int64' to type lookup table
- These are valid type names in IDA 9.0+ that were missing

Test Updates:
- Updated test_declare_stack_invalid_type_error to check for 'NoSuchType' in error message (more robust across IDA versions)

Tested: IDA 9.0.240925 and IDA 9.3.260213 - all tests pass

Related issues: #104, #121, #125, #214