### PR TITLE
Add --targets CLI arg and fix Kilo Code install paths

### DIFF
--- a/src/ida_pro_mcp/installer.py
+++ b/src/ida_pro_mcp/installer.py
@@ -124,7 +124,7 @@ def infer_http_transport_type(transport_url: str) -> str:
 
 def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
     if transport == "stdio":
-        if client_name == "Opencode":
+        if client_name in ("Opencode", "Kilo Code"):
             mcp_config = {
                 "type": "local",
                 "command": [
@@ -133,6 +133,7 @@ def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
                     "--ida-rpc",
                     f"http://{IDA_HOST}:{IDA_PORT}",
                 ],
+                **({"enabled": True} if client_name == "Kilo Code" else {}),
             }
         else:
             mcp_config = {
@@ -155,8 +156,12 @@ def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
         transport = f"http://{IDA_HOST}:{IDA_PORT}/sse"
 
     transport_url = normalize_transport_url(transport)
-    if client_name == "Opencode":
-        return {"type": "remote", "url": transport_url}
+    if client_name in ("Opencode", "Kilo Code"):
+        return {
+            "type": "remote",
+            "url": transport_url,
+            **({"enabled": True} if client_name == "Kilo Code" else {}),
+        }
     if client_name == "Codex":
         return {"url": force_mcp_path(transport_url)}
     if client_name in ("Claude", "Claude Code"):
@@ -328,9 +333,10 @@ def list_available_clients():
     print("Usage examples:")
     print("  ida-pro-mcp --install                                    # Interactive selector")
     print("  ida-pro-mcp --install claude,cursor                       # Specific client targets")
-    print("  ida-pro-mcp --install vscode --scope project              # Project-level config")
-    print("  ida-pro-mcp --install cursor --transport streamable-http  # Streamable HTTP config")
-    print("  ida-pro-mcp --uninstall cursor                            # Uninstall specific target")
+    print("  ida-pro-mcp --install --targets=kilo,opencode,zed         # Targets via --targets")
+    print("  ida-pro-mcp --install --targets=cursor --scope=global     # Global scope")
+    print("  ida-pro-mcp --install --targets=cursor --transport=sse    # SSE transport")
+    print("  ida-pro-mcp --uninstall --targets=cursor                  # Uninstall specific target")
 
 
 def install_mcp_servers(
@@ -403,6 +409,9 @@ def install_mcp_servers(
                 client_name=name,
                 transport=transport,
             )
+
+        if not uninstall and name == "Kilo Code":
+            config["$schema"] = "https://app.kilo.ai/config.json"
 
         _write_config_file(config_path, config, is_toml=is_toml)
         if not quiet:

--- a/src/ida_pro_mcp/installer_data.py
+++ b/src/ida_pro_mcp/installer_data.py
@@ -54,6 +54,7 @@ GLOBAL_SPECIAL_JSON_STRUCTURES: dict[str, tuple[str | None, str]] = {
     "VS Code Insiders": ("mcp", "servers"),
     "Visual Studio 2022": (None, "servers"),
     "Opencode": (None, "mcp"),
+    "Kilo Code": (None, "mcp"),
 }
 
 
@@ -83,15 +84,8 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp_settings.json",
             ),
             "Kilo Code": (
-                os.path.join(
-                    os.getenv("APPDATA", ""),
-                    "Code",
-                    "User",
-                    "globalStorage",
-                    "kilocode.kilo-code",
-                    "settings",
-                ),
-                "mcp_settings.json",
+                os.path.join(os.getenv("APPDATA", ""), "kilo"),
+                "kilo.json",
             ),
             "Claude": (
                 os.path.join(os.getenv("APPDATA", ""), "Claude"),
@@ -218,13 +212,9 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                     os.path.expanduser("~"),
                     "Library",
                     "Application Support",
-                    "Code",
-                    "User",
-                    "globalStorage",
-                    "kilocode.kilo-code",
-                    "settings",
+                    "kilo",
                 ),
-                "mcp_settings.json",
+                "kilo.json",
             ),
             "Claude": (
                 os.path.join(
@@ -375,16 +365,8 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp_settings.json",
             ),
             "Kilo Code": (
-                os.path.join(
-                    os.path.expanduser("~"),
-                    ".config",
-                    "Code",
-                    "User",
-                    "globalStorage",
-                    "kilocode.kilo-code",
-                    "settings",
-                ),
-                "mcp_settings.json",
+                os.path.join(os.path.expanduser("~"), ".config", "kilo"),
+                "kilo.json",
             ),
             "Cursor": (os.path.join(os.path.expanduser("~"), ".cursor"), "mcp.json"),
             "Windsurf": (

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -133,6 +133,14 @@ def main():
         "For running: use stdio (default) or pass a URL (e.g., http://127.0.0.1:8744[/mcp|/sse])",
     )
     parser.add_argument(
+        "--targets",
+        type=str,
+        default=None,
+        metavar="TARGETS",
+        help="Comma-separated MCP client targets for install/uninstall (e.g., 'kilo,opencode,zed'). "
+        "Use with --install or --uninstall to skip the interactive selector.",
+    )
+    parser.add_argument(
         "--scope",
         type=str,
         choices=["global", "project"],
@@ -176,14 +184,25 @@ def main():
         print("--scope requires --install or --uninstall")
         return
 
+    if args.targets and not (is_install or is_uninstall):
+        print("--targets requires --install or --uninstall")
+        return
+
     if is_install and is_uninstall:
         print("Cannot install and uninstall at the same time")
         return
 
     if is_install or is_uninstall:
+        # Merge --targets with --install/--uninstall positional targets
+        positional = args.install if is_install else args.uninstall
+        targets = positional or ""
+        if args.targets:
+            # Combine: positional targets (if any) + --targets
+            parts = [t.strip() for t in (targets, args.targets) if t.strip()]
+            targets = ",".join(parts)
         run_install_command(
             uninstall=is_uninstall,
-            targets_str=args.install if is_install else args.uninstall,
+            targets_str=targets,
             args=args,
         )
         return


### PR DESCRIPTION
## Summary
- Add `--targets` argument to skip interactive TUI during install/uninstall
- Fix Kilo Code config paths from VS Code extension storage to standalone `~/.config/kilo/kilo.json`
- Add `"enabled": true` and `"$schema"` field for Kilo Code config format
- Kilo Code now uses same JSON structure as Opencode (`"mcp": {...}`)
