### PR TITLE
Add multi-instance discovery, autostart, and instance routing

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -174,17 +174,31 @@ class MCP(idaapi.plugin_t):
 
         return idaapi.PLUGIN_KEEP
 
+    def _unregister_instance(self):
+        port = getattr(self, "_registered_port", None)
+        if port is not None:
+            try:
+                if TYPE_CHECKING:
+                    from .ida_mcp.discovery import unregister_instance
+                else:
+                    from ida_mcp.discovery import unregister_instance
+                unregister_instance(port)
+            except Exception as e:
+                print(f"[MCP] Instance unregistration failed: {e}")
+            self._registered_port = None
+
     def run(self, arg):
         if self.mcp:
+            self._unregister_instance()
             self.mcp.stop()
             self.mcp = None
 
         # HACK: ensure fresh load of ida_mcp package
         unload_package("ida_mcp")
         if TYPE_CHECKING:
-            from .ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, init_caches
+            from .ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, init_caches, set_local_instance
         else:
-            from ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, init_caches
+            from ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, init_caches, set_local_instance
 
         try:
             init_caches()
@@ -200,6 +214,8 @@ class MCP(idaapi.plugin_t):
                 )
                 print(f"  Config: http://{self.host}:{port}/config.html")
                 self.mcp = MCP_SERVER
+                set_local_instance(self.host, port)
+                self._register_instance(port)
                 return
             except OSError as e:
                 if e.errno in (48, 98, 10048):  # Address already in use
@@ -208,10 +224,37 @@ class MCP(idaapi.plugin_t):
                     raise
         print(f"[MCP] Error: No available port in range {self.port}-{max_port - 1}")
 
+    def _register_instance(self, port: int):
+        try:
+            if TYPE_CHECKING:
+                from .ida_mcp.discovery import register_instance
+            else:
+                from ida_mcp.discovery import register_instance
+            import os
+            import idc
+            import ida_nalt
+            binary = ida_nalt.get_root_filename() or ""
+            idb_path = idc.get_idb_path() or ""
+            file_path = register_instance(
+                host=self.host,
+                port=port,
+                pid=os.getpid(),
+                binary=binary,
+                idb_path=idb_path,
+            )
+            self._registered_port = port
+            print(f"[MCP] Registered instance: {binary} (pid={os.getpid()}, port={port})")
+            print(f"  Discovery file: {file_path}")
+        except Exception as e:
+            import traceback
+            print(f"[MCP] Instance registration failed: {e}")
+            traceback.print_exc()
+
     def term(self):
         if hasattr(self, "_ui_hooks"):
             self._ui_hooks.unhook()
         ida_kernwin.unregister_action(CONFIG_ACTION_ID)
+        self._unregister_instance()
         if self.mcp:
             self.mcp.stop()
 

--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -7,10 +7,27 @@ It loads the actual implementation from the ida_mcp package.
 import sys
 import idaapi
 import ida_kernwin
+import ida_netnode
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import ida_mcp
+
+
+NETNODE_AUTOSTART = "$ ida_mcp.autostart"
+
+
+def _get_autostart() -> bool:
+    """Read the autostart preference from the IDB. Defaults to True."""
+    node = ida_netnode.netnode(NETNODE_AUTOSTART)
+    val = node.altval(0)  # 0 = not set, 1 = off, 2 = on
+    return val != 1
+
+
+def _set_autostart(enabled: bool):
+    """Persist the autostart preference into the IDB."""
+    node = ida_netnode.netnode(NETNODE_AUTOSTART, 0, True)
+    node.altset(0, 1 if not enabled else 2)
 
 
 def unload_package(package_name: str):
@@ -31,18 +48,20 @@ CONFIG_ACTION_LABEL = "MCP Configuration"
 class MCPConfigForm(idaapi.Form):
     """Form to configure MCP server host and port."""
 
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int, autostart: bool):
         form_str = r"""STARTITEM 0
 MCP Server Configuration
 
 <Host:{host}>
 <Port:{port}>
+<Autostart server when IDA opens:{autostart}>{checks}>
 """
         super().__init__(
             form_str,
             {
                 "host": idaapi.Form.StringInput(value=host),
                 "port": idaapi.Form.NumericInput(value=port, tp=idaapi.Form.FT_DEC),
+                "checks": idaapi.Form.ChkGroupControl(("autostart",), value=1 if autostart else 0),
             },
         )
 
@@ -55,8 +74,9 @@ class MCPConfigHandler(idaapi.action_handler_t):
     def activate(self, ctx):
         old_host = self.plugin.host
         old_port = self.plugin.port
+        old_autostart = self.plugin.autostart
 
-        form = MCPConfigForm(self.plugin.host, self.plugin.port)
+        form = MCPConfigForm(self.plugin.host, self.plugin.port, self.plugin.autostart)
         form.Compile()
         ok = form.Execute()
         if ok != 1:
@@ -65,14 +85,21 @@ class MCPConfigHandler(idaapi.action_handler_t):
 
         host = form.host.value
         port = form.port.value
+        autostart = bool(form.checks.value & 1)
         form.Free()
 
         if port < 1 or port > 65535:
             print(f"[MCP] Invalid port: {port}")
             return 0
 
+        if autostart != old_autostart:
+            self.plugin.autostart = autostart
+            _set_autostart(autostart)
+            print(f"[MCP] Autostart {'enabled' if autostart else 'disabled'}")
+
         if host == old_host and port == old_port:
-            print(f"[MCP] Configuration unchanged: {host}:{port}")
+            if autostart == old_autostart:
+                print(f"[MCP] Configuration unchanged: {host}:{port}")
             return 1
 
         self.plugin.host = host
@@ -90,12 +117,19 @@ class MCPConfigHandler(idaapi.action_handler_t):
 
 
 class MCPUIHooks(ida_kernwin.UI_Hooks):
-    """Defers menu attachment until the UI is fully ready."""
+    """Defers menu attachment and autostart until the UI is fully ready."""
+
+    def __init__(self, plugin: "MCP"):
+        super().__init__()
+        self.plugin = plugin
 
     def ready_to_run(self):
         ida_kernwin.attach_action_to_menu(
             "Edit/Plugins/", CONFIG_ACTION_ID, idaapi.SETMENU_APP
         )
+        if self.plugin.autostart:
+            print("[MCP] Autostarting server...")
+            self.plugin.run(0)
         self.unhook()
 
 
@@ -114,12 +148,17 @@ class MCP(idaapi.plugin_t):
         if __import__("sys").platform == "darwin":
             hotkey = hotkey.replace("Alt", "Option")
 
-        print(
-            f"[MCP] Plugin loaded, use Edit -> Plugins -> MCP ({hotkey}) to start the server"
-        )
         self.mcp: "ida_mcp.rpc.McpServer | None" = None
         self.host = self.DEFAULT_HOST
         self.port = self.DEFAULT_PORT
+        self.autostart = _get_autostart()
+
+        if self.autostart:
+            print("[MCP] Plugin loaded, server will start automatically")
+        else:
+            print(
+                f"[MCP] Plugin loaded, use Edit -> Plugins -> MCP ({hotkey}) to start the server"
+            )
 
         # Register a separate menu item for host/port configuration
         ida_kernwin.register_action(
@@ -129,8 +168,8 @@ class MCP(idaapi.plugin_t):
                 MCPConfigHandler(self),
             )
         )
-        # Defer menu attachment until the UI is fully initialized
-        self._ui_hooks = MCPUIHooks()
+        # Defer menu attachment and autostart until the UI is fully initialized
+        self._ui_hooks = MCPUIHooks(self)
         self._ui_hooks.hook()
 
         return idaapi.PLUGIN_KEEP

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -36,12 +36,14 @@ from . import api_python
 from . import api_resources
 from . import api_survey
 from . import api_composite
+from . import api_discovery
 
 # Re-export key components for external use
 from .sync import idasync, IDAError, IDASyncError, CancelledError
 from .rpc import MCP_SERVER, MCP_UNSAFE, tool, unsafe, resource
 from .http import IdaMcpHttpRequestHandler
 from .api_core import init_caches
+from .api_discovery import set_local_instance
 
 __all__ = [
     # Infrastructure modules
@@ -60,6 +62,7 @@ __all__ = [
     "api_resources",
     "api_survey",
     "api_composite",
+    "api_discovery",
     # Re-exported components
     "idasync",
     "IDAError",
@@ -72,4 +75,5 @@ __all__ = [
     "resource",
     "IdaMcpHttpRequestHandler",
     "init_caches",
+    "set_local_instance",
 ]

--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -333,7 +333,6 @@ def _profile_function(
         "constant_count": len(constants),
         "has_type": has_type,
         "prototype": None,
-        "error": None,
     }
 
     if include_prototype:
@@ -651,7 +650,6 @@ def func_profile(
                 "query": q,
                 "data": profiled,
                 "next_offset": page["next_offset"],
-                "error": None,
             }
         )
 
@@ -846,7 +844,6 @@ def analyze_batch(
                     "addr": hex(fn.start_ea),
                     "name": fn_name,
                     "analysis": analysis,
-                    "error": None,
                 }
             )
         except Exception as e:
@@ -1017,7 +1014,6 @@ def xref_query(
                     "data": page["data"],
                     "next_offset": page["next_offset"],
                     "total": len(rows),
-                    "error": None,
                 }
             )
         except Exception as e:
@@ -1360,7 +1356,6 @@ def basic_blocks(
                     "cursor": (
                         {"next": offset + max_blocks} if more else {"done": True}
                     ),
-                    "error": None,
                 }
             )
         except Exception as e:
@@ -1449,7 +1444,6 @@ def find(
                     "matches": matches,
                     "count": len(matches),
                     "cursor": {"next": offset + limit} if more else {"done": True},
-                    "error": None,
                 }
             )
 
@@ -1521,7 +1515,6 @@ def find(
                     "matches": matches,
                     "count": len(matches),
                     "cursor": {"next": offset + limit} if more else {"done": True},
-                    "error": None,
                 }
             )
 
@@ -1545,7 +1538,6 @@ def find(
                         "cursor": (
                             {"next": offset + limit} if more else {"done": True}
                         ),
-                        "error": None,
                     }
                 )
             except Exception as e:
@@ -1579,7 +1571,6 @@ def find(
                         "cursor": (
                             {"next": offset + limit} if more else {"done": True}
                         ),
-                        "error": None,
                     }
                 )
             except Exception as e:
@@ -1863,7 +1854,6 @@ def insn_query(
                     "scanned": scanned,
                     "truncated": truncated,
                     "next_start": hex(next_start) if next_start is not None else None,
-                    "error": None,
                 }
             )
         except Exception as e:
@@ -2073,7 +2063,6 @@ def callgraph(
                     "max_edges": max_edges,
                     "max_edges_per_func": max_edges_per_func,
                     "per_func_capped": per_func_capped,
-                    "error": None,
                 }
             )
 

--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -1,6 +1,6 @@
 from itertools import islice
 import struct
-from typing import Annotated, Optional
+from typing import Annotated, Any, NotRequired, Optional, TypedDict
 import ida_lines
 import ida_funcs
 import idaapi
@@ -44,6 +44,282 @@ from .utils import (
     AnalyzeBatchQuery,
 )
 from . import compat
+
+
+class DecompileResult(TypedDict):
+    addr: str
+    code: str | None
+    error: NotRequired[str]
+
+
+class ResultCursor(TypedDict, total=False):
+    next: int
+    done: bool
+
+
+class DisasmResult(TypedDict, total=False):
+    addr: str
+    asm: DisassemblyFunction | None
+    instruction_count: int
+    total_instructions: int | None
+    cursor: ResultCursor
+    error: str
+
+
+class FuncProfileItem(TypedDict, total=False):
+    addr: str
+    name: str
+    size: str
+    instruction_count: int
+    basic_block_count: int
+    caller_count: int
+    callee_count: int
+    string_ref_count: int
+    constant_count: int
+    has_type: bool
+    prototype: str | None
+    callers: list[dict[str, Any]]
+    callers_truncated: bool
+    callees: list[dict[str, Any]]
+    callees_truncated: bool
+    strings: list[dict[str, Any]]
+    strings_truncated: bool
+    constants: list[dict[str, Any]]
+    constants_truncated: bool
+    error: str | None
+
+
+class FuncProfileResult(TypedDict, total=False):
+    query: str
+    data: list[FuncProfileItem]
+    next_offset: int | None
+    error: str | None
+
+
+class AnalyzeBatchDisasm(TypedDict):
+    lines: list[str]
+    instruction_count: int
+    truncated: bool
+
+
+AnalyzeBatchXrefs = TypedDict(
+    "AnalyzeBatchXrefs",
+    {
+        "to": list[dict[str, str]],
+        "from": list[dict[str, str]],
+        "to_truncated": bool,
+        "from_truncated": bool,
+        "to_count": int,
+        "from_count": int,
+    },
+)
+
+
+class AnalyzeBatchDetails(TypedDict, total=False):
+    size: str
+    prototype: str | None
+    decompile: str | None
+    decompile_error: str | None
+    disasm: AnalyzeBatchDisasm | None
+    xrefs: AnalyzeBatchXrefs | None
+    callers: list[dict[str, Any]] | None
+    caller_count: int
+    callers_truncated: bool
+    callees: list[dict[str, Any]] | None
+    callee_count: int
+    callees_truncated: bool
+    strings: list[dict[str, Any]] | None
+    string_ref_count: int
+    strings_truncated: bool
+    constants: list[dict[str, Any]] | None
+    constant_count: int
+    constants_truncated: bool
+    basic_blocks: list[BasicBlock] | None
+    basic_block_count: int
+    basic_blocks_truncated: bool
+
+
+class AnalyzeBatchResult(TypedDict, total=False):
+    query: str
+    addr: str | None
+    name: str | None
+    analysis: AnalyzeBatchDetails | None
+    error: str | None
+
+
+class XrefsToResult(TypedDict, total=False):
+    addr: str
+    xrefs: list[Xref] | None
+    more: bool
+    error: str
+
+
+XrefQueryRow = TypedDict(
+    "XrefQueryRow",
+    {
+        "direction": str,
+        "addr": str,
+        "from": str,
+        "to": str,
+        "type": str,
+        "fn": Function | None,
+    },
+    total=False,
+)
+
+
+class XrefQueryResult(TypedDict, total=False):
+    query: str
+    resolved_addr: str | None
+    direction: str
+    xref_type: str
+    data: list[XrefQueryRow]
+    next_offset: int | None
+    total: int
+    error: str | None
+
+
+class StructFieldXrefsResult(TypedDict, total=False):
+    struct: str
+    field: str
+    xrefs: list[Xref]
+    error: str
+
+
+class CalleeResultItem(TypedDict):
+    addr: str
+    name: str
+    type: str
+
+
+class CalleesResult(TypedDict, total=False):
+    addr: str
+    callees: list[CalleeResultItem] | None
+    more: bool
+    error: str
+
+
+class FindBytesResult(TypedDict, total=False):
+    pattern: str
+    matches: list[str]
+    n: int
+    cursor: ResultCursor
+    error: str
+
+
+class BasicBlocksResult(TypedDict, total=False):
+    addr: str
+    error: str
+    blocks: list[BasicBlock]
+    count: int
+    total_blocks: int
+    cursor: ResultCursor
+
+
+class FindResult(TypedDict, total=False):
+    query: str | int | None
+    matches: list[str]
+    count: int
+    cursor: ResultCursor
+    error: str | None
+
+
+class InsnScanRange(TypedDict):
+    start: str
+    end: str
+
+
+class InsnQuerySummary(TypedDict, total=False):
+    mnem: str | None
+    op0: int | str | None
+    op1: int | str | None
+    op2: int | str | None
+    op_any: int | str | None
+    func: str | None
+    segment: str | None
+    start: str | None
+    end: str | None
+    offset: int
+    count: int
+    max_scan_insns: int
+    allow_broad: bool
+
+
+class InsnQueryMatch(TypedDict, total=False):
+    addr: str
+    disasm: str
+    fn: Function | None
+
+
+class InsnQueryResult(TypedDict, total=False):
+    query: InsnQuerySummary
+    ranges: list[InsnScanRange]
+    matches: list[InsnQueryMatch]
+    count: int
+    cursor: ResultCursor
+    scanned: int
+    truncated: bool
+    next_start: str | None
+    error: str | None
+
+
+class ExportedFunctionJson(TypedDict, total=False):
+    addr: str
+    name: str | None
+    prototype: str | None
+    size: str
+    comments: dict[str, dict[str, str]]
+    asm: str
+    code: str | None
+    xrefs: dict[str, list[dict[str, str]]]
+    error: str
+
+
+class ExportedPrototype(TypedDict, total=False):
+    name: str | None
+    prototype: str
+
+
+class ExportFuncsJsonResult(TypedDict):
+    format: str
+    functions: list[ExportedFunctionJson]
+
+
+class ExportFuncsHeaderResult(TypedDict):
+    format: str
+    content: str
+
+
+class ExportFuncsPrototypesResult(TypedDict):
+    format: str
+    functions: list[ExportedPrototype]
+
+
+class CallGraphNode(TypedDict):
+    addr: str
+    name: str | None
+    depth: int
+
+
+CallGraphEdge = TypedDict(
+    "CallGraphEdge",
+    {"from": str, "to": str, "type": str},
+)
+
+
+class CallGraphResult(TypedDict, total=False):
+    root: str
+    nodes: list[CallGraphNode]
+    edges: list[CallGraphEdge]
+    max_depth: int
+    truncated: bool
+    limit_reason: str | None
+    max_nodes: int
+    max_edges: int
+    max_edges_per_func: int
+    per_func_capped: bool
+    error: str
+
 
 # ============================================================================
 # Instruction Helpers
@@ -304,7 +580,7 @@ def _profile_function(
     include_lists: bool,
     max_items: int,
     include_prototype: bool,
-) -> dict:
+) -> FuncProfileItem:
     func = idaapi.get_func(start_ea)
     if not func:
         return {"addr": hex(start_ea), "error": "Function not found"}
@@ -333,6 +609,7 @@ def _profile_function(
         "constant_count": len(constants),
         "has_type": has_type,
         "prototype": None,
+        "error": None,
     }
 
     if include_prototype:
@@ -366,7 +643,7 @@ def _profile_function(
 @tool_timeout(90.0)
 def decompile(
     addr: Annotated[str, "Function address or name to decompile"],
-) -> dict:
+) -> DecompileResult:
     """Decompile function(s) at address(es); returns pseudocode and per-item errors."""
     try:
         try:
@@ -400,7 +677,7 @@ def disasm(
     include_total: Annotated[
         bool, "Compute total instruction count (default: false)"
     ] = False,
-) -> dict:
+) -> DisasmResult:
     """Disassemble function with offset/max_instructions pagination and optional total count."""
 
     # Enforce max limit
@@ -552,7 +829,7 @@ def func_profile(
         list[FuncProfileQuery] | FuncProfileQuery | str,
         "Function profiling query (supports name/address filters + pagination)",
     ],
-) -> list[dict]:
+) -> list[FuncProfileResult]:
     """Profile functions with summary metrics and optional sampled details."""
     queries = normalize_dict_list(
         queries,
@@ -650,6 +927,7 @@ def func_profile(
                 "query": q,
                 "data": profiled,
                 "next_offset": page["next_offset"],
+                "error": None,
             }
         )
 
@@ -664,7 +942,7 @@ def analyze_batch(
         list[AnalyzeBatchQuery] | AnalyzeBatchQuery | str,
         "Comprehensive per-function analysis with selectable sections",
     ],
-) -> list[dict]:
+) -> list[AnalyzeBatchResult]:
     """Run comprehensive analysis over one or more target functions."""
     queries = normalize_dict_list(
         queries,
@@ -844,6 +1122,7 @@ def analyze_batch(
                     "addr": hex(fn.start_ea),
                     "name": fn_name,
                     "analysis": analysis,
+                    "error": None,
                 }
             )
         except Exception as e:
@@ -870,7 +1149,7 @@ def analyze_batch(
 def xrefs_to(
     addrs: Annotated[list[str] | str, "Addresses to find cross-references to"],
     limit: Annotated[int, "Max xrefs per address (default: 100, max: 1000)"] = 100,
-) -> list[dict]:
+) -> list[XrefsToResult]:
     """Return xrefs to address(es), capped per target with truncation flag."""
     addrs = normalize_list_input(addrs)
 
@@ -908,7 +1187,7 @@ def xref_query(
         list[XrefQuery] | XrefQuery | str,
         "Generic xref query with direction/type filters and pagination",
     ],
-) -> list[dict]:
+) -> list[XrefQueryResult]:
     """Query xrefs with direction/type filters and pagination."""
     queries = normalize_dict_list(
         queries,
@@ -1014,6 +1293,7 @@ def xref_query(
                     "data": page["data"],
                     "next_offset": page["next_offset"],
                     "total": len(rows),
+                    "error": None,
                 }
             )
         except Exception as e:
@@ -1035,7 +1315,9 @@ def xref_query(
 
 @tool
 @idasync
-def xrefs_to_field(queries: list[StructFieldQuery] | StructFieldQuery) -> list[dict]:
+def xrefs_to_field(
+    queries: list[StructFieldQuery] | StructFieldQuery,
+) -> list[StructFieldXrefsResult]:
     """Get cross-references to structure fields"""
     if isinstance(queries, dict):
         queries = [queries]
@@ -1130,7 +1412,7 @@ def xrefs_to_field(queries: list[StructFieldQuery] | StructFieldQuery) -> list[d
 def callees(
     addrs: Annotated[list[str] | str, "Function addresses to get callees for"],
     limit: Annotated[int, "Max callees per function (default: 200, max: 500)"] = 200,
-) -> list[dict]:
+) -> list[CalleesResult]:
     """Return unique callees per function, capped by limit."""
     addrs = normalize_list_input(addrs)
 
@@ -1215,7 +1497,7 @@ def find_bytes(
     ],
     limit: Annotated[int, "Max matches per pattern (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
-) -> list[dict]:
+) -> list[FindBytesResult]:
     """Search byte patterns (supports ??) with offset/limit pagination."""
     patterns = normalize_list_input(patterns)
 
@@ -1303,7 +1585,7 @@ def basic_blocks(
         int, "Max basic blocks per function (default: 1000, max: 10000)"
     ] = 1000,
     offset: Annotated[int, "Skip first N blocks (default: 0)"] = 0,
-) -> list[dict]:
+) -> list[BasicBlocksResult]:
     """Return function CFG blocks with offset/max_blocks pagination."""
     addrs = normalize_list_input(addrs)
 
@@ -1386,7 +1668,7 @@ def find(
     ],
     limit: Annotated[int, "Max matches per target (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
-) -> list[dict]:
+) -> list[FindResult]:
     """Search strings/immediates/refs for targets with offset/limit pagination."""
     if not isinstance(targets, list):
         targets = [targets]
@@ -1444,6 +1726,7 @@ def find(
                     "matches": matches,
                     "count": len(matches),
                     "cursor": {"next": offset + limit} if more else {"done": True},
+                    "error": None,
                 }
             )
 
@@ -1515,6 +1798,7 @@ def find(
                     "matches": matches,
                     "count": len(matches),
                     "cursor": {"next": offset + limit} if more else {"done": True},
+                    "error": None,
                 }
             )
 
@@ -1538,6 +1822,7 @@ def find(
                         "cursor": (
                             {"next": offset + limit} if more else {"done": True}
                         ),
+                        "error": None,
                     }
                 )
             except Exception as e:
@@ -1571,6 +1856,7 @@ def find(
                         "cursor": (
                             {"next": offset + limit} if more else {"done": True}
                         ),
+                        "error": None,
                     }
                 )
             except Exception as e:
@@ -1757,7 +2043,7 @@ def insn_query(
         list[InsnPattern] | InsnPattern | str,
         "Instruction query with mnemonic/operand filters and scoped scan",
     ],
-) -> list[dict]:
+) -> list[InsnQueryResult]:
     """Query instructions with mnemonic/operand filters and scoped scans."""
     queries = normalize_dict_list(
         queries,
@@ -1854,6 +2140,7 @@ def insn_query(
                     "scanned": scanned,
                     "truncated": truncated,
                     "next_start": hex(next_start) if next_start is not None else None,
+                    "error": None,
                 }
             )
         except Exception as e:
@@ -1886,7 +2173,7 @@ def export_funcs(
     format: Annotated[
         str, "Export format: json (default), c_header, or prototypes"
     ] = "json",
-) -> dict:
+) -> ExportFuncsJsonResult | ExportFuncsHeaderResult | ExportFuncsPrototypesResult:
     """Export function data for addresses in json/c_header/prototypes formats."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -1959,7 +2246,7 @@ def callgraph(
     max_edges_per_func: Annotated[
         int, "Max edges per function (default: 200, max: 5000)"
     ] = 200,
-) -> list[dict]:
+) -> list[CallGraphResult]:
     """Build bounded callgraph from roots with depth/node/edge limits."""
     roots = normalize_list_input(roots)
     if max_depth < 0:

--- a/src/ida_pro_mcp/ida_mcp/api_composite.py
+++ b/src/ida_pro_mcp/ida_mcp/api_composite.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Annotated
+from typing import Annotated, Any, TypedDict
 
 from .rpc import tool, unsafe
 from .sync import idasync, tool_timeout, IDAError
@@ -32,6 +32,100 @@ _TOP_CONSTANTS = 10
 _BORING_CONSTANTS = frozenset({0, 1, -1, 0xFF, 0xFFFF, 0xFFFFFFFF, 0xFFFFFFFFFFFFFFFF})
 
 
+class BasicBlockSummary(TypedDict):
+    count: int
+    cyclomatic_complexity: int
+
+
+class AnalyzeFunctionResult(TypedDict, total=False):
+    addr: str
+    name: str
+    prototype: str
+    size: int
+    decompiled: str | None
+    decompile_truncated: int
+    assembly: str | None
+    strings: list[str]
+    constants: list[dict[str, Any]]
+    callees: list[str]
+    callers: list[str]
+    xrefs: dict[str, Any]
+    comments: dict[str, Any]
+    basic_blocks: BasicBlockSummary
+    error: str
+
+
+class ComponentFunctionSummary(TypedDict, total=False):
+    addr: str
+    name: str
+    prototype: str
+    size: int
+    callees: list[str]
+    strings: list[str]
+    basic_blocks: int
+    complexity: int
+    error: str
+
+
+ComponentGraphEdge = TypedDict(
+    "ComponentGraphEdge",
+    {"from": str, "to": str, "name": str},
+)
+
+
+class InternalCallGraph(TypedDict):
+    nodes: list[str]
+    edges: list[ComponentGraphEdge]
+
+
+class SharedGlobalInfo(TypedDict):
+    addr: str
+    name: str
+    accessed_by: list[str]
+
+
+class AnalyzeComponentResult(TypedDict, total=False):
+    functions: list[ComponentFunctionSummary]
+    internal_call_graph: InternalCallGraph
+    shared_globals: list[SharedGlobalInfo]
+    interface_functions: list[str]
+    internal_only: list[str]
+    string_usage: dict[str, list[str]]
+    error: str
+
+
+class DiffBeforeAfterResult(TypedDict, total=False):
+    before: str | None
+    after: str | None
+    action_applied: str
+    changes_detected: bool
+    error: str
+
+
+class TraceDataFlowNode(TypedDict):
+    addr: str
+    func: str | None
+    instruction: str | None
+    type: str
+    name: str | None
+    depth: int
+
+
+TraceDataFlowEdge = TypedDict(
+    "TraceDataFlowEdge",
+    {"from": str, "to": str, "type": str},
+)
+
+
+class TraceDataFlowResult(TypedDict, total=False):
+    start: str
+    direction: str
+    depth_reached: int
+    nodes: list[TraceDataFlowNode]
+    edges: list[TraceDataFlowEdge]
+    error: str
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers (no @tool — called from within @idasync context)
 # ---------------------------------------------------------------------------
@@ -49,7 +143,7 @@ def _resolve_addr(addr: str) -> int:
         return ea
 
 
-def _basic_block_info(ea: int) -> dict:
+def _basic_block_info(ea: int) -> BasicBlockSummary:
     """Return block count and cyclomatic complexity for the function at *ea*."""
     import idaapi
 
@@ -114,7 +208,9 @@ def _compact_callees(raw: list[dict]) -> list[str]:
     return [c.get("name") or c.get("addr", "?") for c in raw]
 
 
-def _analyze_function_internal(ea: int, *, include_asm: bool = False) -> dict:
+def _analyze_function_internal(
+    ea: int, *, include_asm: bool = False
+) -> AnalyzeFunctionResult:
     """Core analysis logic — must be called from an @idasync context.
 
     Returns a compact response by default: decompilation capped at 100 lines,
@@ -179,7 +275,7 @@ def _analyze_function_internal(ea: int, *, include_asm: bool = False) -> dict:
 def analyze_function(
     addr: Annotated[str, "Function address or name"],
     include_asm: Annotated[bool, "Include full disassembly (default: false, saves tokens)"] = False,
-) -> dict:
+) -> AnalyzeFunctionResult:
     """Compact single-function analysis: pseudocode, strings, constants, callers, callees, xrefs, blocks."""
 
     try:
@@ -200,7 +296,7 @@ def analyze_function(
 @tool_timeout(180.0)
 def analyze_component(
     addrs: Annotated[list[str] | str, "Function addresses (comma-separated or list)"],
-) -> dict:
+) -> AnalyzeComponentResult:
     """Analyze related functions as a group: per-function summaries, internal call graph, shared data."""
 
     import idaapi
@@ -355,7 +451,7 @@ def diff_before_after(
     addr: Annotated[str, "Function address"],
     action: Annotated[str, "Action: 'rename_func', 'set_type', 'set_comment'"],
     action_args: Annotated[dict, "Arguments for the action"],
-) -> dict:
+) -> DiffBeforeAfterResult:
     """Rename a function, set its type, or add a comment, and immediately see the
     before/after decompilation side by side. Use this instead of calling rename
     then decompile separately when you want to verify that a rename or type change
@@ -447,7 +543,7 @@ def trace_data_flow(
     addr: Annotated[str, "Starting address"],
     direction: Annotated[str, "'forward' (xrefs from) or 'backward' (xrefs to)"] = "forward",
     max_depth: Annotated[int, "Maximum traversal depth"] = 5,
-) -> dict:
+) -> TraceDataFlowResult:
     """Follow cross-references from or to an address, automatically traversing
     multiple hops. Use 'forward' to see where data flows TO (xrefs-from), or
     'backward' to see where data flows FROM (xrefs-to). At each node in the

--- a/src/ida_pro_mcp/ida_mcp/api_composite.py
+++ b/src/ida_pro_mcp/ida_mcp/api_composite.py
@@ -122,7 +122,7 @@ def _analyze_function_internal(ea: int, *, include_asm: bool = False) -> dict:
     Pass include_asm=True to include full disassembly."""
     import idaapi
 
-    result: dict = {"addr": hex(ea), "error": None}
+    result: dict = {"addr": hex(ea)}
 
     try:
         func = idaapi.get_func(ea)
@@ -180,13 +180,7 @@ def analyze_function(
     addr: Annotated[str, "Function address or name"],
     include_asm: Annotated[bool, "Include full disassembly (default: false, saves tokens)"] = False,
 ) -> dict:
-    """Get a compact analysis of a single function: decompiled pseudocode (capped
-    at 100 lines), top 10 strings as values, top 10 non-trivial constants, caller
-    and callee names, cross-references, and basic block metrics. Disassembly is
-    excluded by default to save context tokens — set include_asm=true only when
-    you need raw instructions (crypto analysis, shellcode, decompiler failure).
-    Use this instead of calling decompile, disasm, callees, xrefs_to, stack_frame,
-    and basic_blocks separately."""
+    """Compact single-function analysis: pseudocode, strings, constants, callers, callees, xrefs, blocks."""
 
     try:
         ea = _resolve_addr(addr)
@@ -207,13 +201,7 @@ def analyze_function(
 def analyze_component(
     addrs: Annotated[list[str] | str, "Function addresses (comma-separated or list)"],
 ) -> dict:
-    """Analyze a group of related functions as one logical unit. Returns a COMPACT
-    summary of each function (name, prototype, size, callee names, top 5 strings,
-    block count) plus relationship data: internal call graph, shared globals,
-    interface vs internal classification, and strings used by multiple functions.
-    Use analyze_function on individual addresses if you need full decompilation.
-    Use this when you see a cluster of sub_* functions called from the same parent
-    or when callees/callers overlap suggests a module."""
+    """Analyze related functions as a group: per-function summaries, internal call graph, shared data."""
 
     import idaapi
     import idautils

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -2,7 +2,7 @@
 
 import re
 import time
-from typing import Annotated
+from typing import Annotated, Any, NotRequired, TypedDict
 
 import ida_auto
 import idaapi
@@ -34,6 +34,81 @@ from .utils import (
     paginate,
     pattern_filter,
 )
+
+
+class ServerHealthResult(TypedDict):
+    status: str
+    uptime_sec: float
+    idb_path: str | None
+    module: str
+    input_path: str
+    imagebase: str
+    auto_analysis_ready: bool | None
+    hexrays_ready: bool
+    strings_cache_ready: bool
+    strings_cache_size: int
+
+
+class ServerWarmupStep(TypedDict, total=False):
+    step: str
+    ok: bool
+    ms: float
+    error: str
+
+
+class ServerWarmupResult(TypedDict):
+    ok: bool
+    steps: list[ServerWarmupStep]
+    health: ServerHealthResult
+
+
+class LookupFuncResult(TypedDict):
+    query: str
+    fn: Function | None
+    error: str | None
+
+
+class IntConvertResult(TypedDict):
+    input: str
+    result: ConvertedNumber | None
+    error: str | None
+
+
+class FunctionQueryRow(Function, total=False):
+    has_type: bool
+    size_int: int
+
+
+class FunctionQueryPage(TypedDict, total=False):
+    data: list[FunctionQueryRow]
+    next_offset: int | None
+    error: str | None
+
+
+class EntityQueryPage(TypedDict, total=False):
+    kind: str
+    data: list[dict[str, Any]]
+    next_offset: int | None
+    total: int
+    error: str | None
+
+
+class ImportsQueryPage(TypedDict):
+    data: list[Import]
+    next_offset: int | None
+
+
+class IdbSaveResult(TypedDict):
+    ok: bool
+    path: str | None
+    error: NotRequired[str]
+
+
+class FindRegexResult(TypedDict, total=False):
+    matches: list[dict[str, Any]]
+    cursor: dict[str, Any]
+    error: str | None
+
 
 # Cached strings list: [(ea, text), ...]
 _strings_cache: list[tuple[int, str]] | None = None
@@ -256,6 +331,7 @@ def _build_health_payload() -> dict:
         idb_path = None
 
     return {
+        "status": "ok",
         "uptime_sec": round(time.time() - _server_started_at, 3),
         "idb_path": idb_path,
         "module": ida_nalt.get_root_filename(),
@@ -270,7 +346,7 @@ def _build_health_payload() -> dict:
 
 @tool
 @idasync
-def server_health() -> dict:
+def server_health() -> ServerHealthResult:
     """Health/ready probe for MCP server and current IDB state."""
     return _build_health_payload()
 
@@ -281,19 +357,31 @@ def server_warmup(
     wait_auto_analysis: Annotated[bool, "Wait for auto analysis queue"] = True,
     build_caches: Annotated[bool, "Build core caches (currently strings)"] = True,
     init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler plugin"] = True,
-) -> dict:
+) -> ServerWarmupResult:
     """Warm up IDA subsystems to reduce first-call latency and transient failures."""
     steps = []
 
     if wait_auto_analysis:
         t0 = time.perf_counter()
         ida_auto.auto_wait()
-        steps.append({"step": "auto_wait", "ok": True, "ms": round((time.perf_counter() - t0) * 1000, 2)})
+        steps.append(
+            {
+                "step": "auto_wait",
+                "ok": True,
+                "ms": round((time.perf_counter() - t0) * 1000, 2),
+            }
+        )
 
     if build_caches:
         t0 = time.perf_counter()
         init_caches()
-        steps.append({"step": "init_caches", "ok": True, "ms": round((time.perf_counter() - t0) * 1000, 2)})
+        steps.append(
+            {
+                "step": "init_caches",
+                "ok": True,
+                "ms": round((time.perf_counter() - t0) * 1000, 2),
+            }
+        )
 
     if init_hexrays:
         t0 = time.perf_counter()
@@ -318,7 +406,7 @@ def server_warmup(
 @idasync
 def lookup_funcs(
     queries: Annotated[list[str] | str, "Address(es) or name(s)"],
-) -> list[dict]:
+) -> list[LookupFuncResult]:
     """Get functions by address or name (auto-detects)"""
     queries = normalize_list_input(queries)
 
@@ -329,7 +417,7 @@ def lookup_funcs(
             all_funcs.append(get_function(addr))
             if len(all_funcs) >= 1000:
                 break
-        return [{"query": "*", "fn": fn} for fn in all_funcs]
+        return [{"query": "*", "fn": fn, "error": None} for fn in all_funcs]
 
     results = []
     for query in queries:
@@ -344,15 +432,15 @@ def lookup_funcs(
             if ea != idaapi.BADADDR:
                 func = get_function(ea, raise_error=False)
                 if func:
-                    results.append({"query": query, "fn": func})
+                    results.append({"query": query, "fn": func, "error": None})
                 else:
                     results.append(
-                        {"query": query, "error": "Not a function"}
+                        {"query": query, "fn": None, "error": "Not a function"}
                     )
             else:
-                results.append({"query": query, "error": "Not found"})
+                results.append({"query": query, "fn": None, "error": "Not found"})
         except Exception as e:
-            results.append({"query": query, "error": str(e)})
+            results.append({"query": query, "fn": None, "error": str(e)})
 
     return results
 
@@ -363,7 +451,7 @@ def int_convert(
         list[NumberConversion] | NumberConversion,
         "Convert numbers to various formats (hex, decimal, binary, ascii)",
     ],
-) -> list[dict]:
+) -> list[IntConvertResult]:
     """Convert numbers to different formats"""
     inputs = normalize_dict_list(inputs, lambda s: {"text": s, "size": 64})
 
@@ -462,7 +550,7 @@ def func_query(
         list[FunctionQuery] | FunctionQuery | str,
         "Richer function query (size/type/name filters + pagination)",
     ],
-) -> list[dict]:
+) -> list[FunctionQueryPage]:
     """Query functions with richer filtering than list_funcs."""
     queries = normalize_dict_list(
         queries,
@@ -586,7 +674,7 @@ def entity_query(
         list[EntityQuery] | EntityQuery | str,
         "Generic entity query with filtering, projection, and pagination",
     ],
-) -> list[dict]:
+) -> list[EntityQueryPage]:
     """Query IDB entities with typed filters, projection, and pagination."""
     queries = normalize_dict_list(
         queries,
@@ -680,6 +768,7 @@ def entity_query(
                 "data": data,
                 "next_offset": page["next_offset"],
                 "total": len(rows),
+                "error": None,
             }
         )
 
@@ -703,7 +792,7 @@ def imports_query(
         list[ImportQuery] | ImportQuery | str,
         "Import query with import/module filters and pagination",
     ],
-) -> list[dict]:
+) -> list[ImportsQueryPage]:
     """Query imports with richer filtering than imports(offset,count)."""
     queries = normalize_dict_list(
         queries, lambda s: {"filter": s, "offset": 0, "count": 100}
@@ -732,7 +821,7 @@ def imports_query(
 @idasync
 def idb_save(
     path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
-) -> dict:
+) -> IdbSaveResult:
     """Save active IDB to disk, optionally to a provided path."""
     try:
         save_path = path.strip() if path else ""
@@ -756,7 +845,7 @@ def find_regex(
     pattern: Annotated[str, "Regex pattern to search for in strings"],
     limit: Annotated[int, "Max matches (default: 30, max: 500)"] = 30,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
-) -> dict:
+) -> FindRegexResult:
     """Search strings by case-insensitive regex with offset/limit pagination."""
     if limit <= 0:
         limit = 30

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -256,7 +256,6 @@ def _build_health_payload() -> dict:
         idb_path = None
 
     return {
-        "status": "ok",
         "uptime_sec": round(time.time() - _server_started_at, 3),
         "idb_path": idb_path,
         "module": ida_nalt.get_root_filename(),
@@ -299,14 +298,14 @@ def server_warmup(
     if init_hexrays:
         t0 = time.perf_counter()
         ok = bool(ida_hexrays.init_hexrays_plugin())
-        steps.append(
-            {
-                "step": "init_hexrays",
-                "ok": ok,
-                "ms": round((time.perf_counter() - t0) * 1000, 2),
-                "error": None if ok else "Hex-Rays unavailable",
-            }
-        )
+        step = {
+            "step": "init_hexrays",
+            "ok": ok,
+            "ms": round((time.perf_counter() - t0) * 1000, 2),
+        }
+        if not ok:
+            step["error"] = "Hex-Rays unavailable"
+        steps.append(step)
 
     return {
         "ok": all(bool(step.get("ok")) for step in steps),
@@ -330,7 +329,7 @@ def lookup_funcs(
             all_funcs.append(get_function(addr))
             if len(all_funcs) >= 1000:
                 break
-        return [{"query": "*", "fn": fn, "error": None} for fn in all_funcs]
+        return [{"query": "*", "fn": fn} for fn in all_funcs]
 
     results = []
     for query in queries:
@@ -345,15 +344,15 @@ def lookup_funcs(
             if ea != idaapi.BADADDR:
                 func = get_function(ea, raise_error=False)
                 if func:
-                    results.append({"query": query, "fn": func, "error": None})
+                    results.append({"query": query, "fn": func})
                 else:
                     results.append(
-                        {"query": query, "fn": None, "error": "Not a function"}
+                        {"query": query, "error": "Not a function"}
                     )
             else:
-                results.append({"query": query, "fn": None, "error": "Not found"})
+                results.append({"query": query, "error": "Not found"})
         except Exception as e:
-            results.append({"query": query, "fn": None, "error": str(e)})
+            results.append({"query": query, "error": str(e)})
 
     return results
 
@@ -420,7 +419,6 @@ def int_convert(
                     ascii=ascii_str,
                     binary=bin(value),
                 ),
-                "error": None,
             }
         )
 
@@ -682,7 +680,6 @@ def entity_query(
                 "data": data,
                 "next_offset": page["next_offset"],
                 "total": len(rows),
-                "error": None,
             }
         )
 
@@ -745,11 +742,10 @@ def idb_save(
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
         ok = bool(ida_loader.save_database(save_path, 0))
-        return {
-            "ok": ok,
-            "path": save_path,
-            "error": None if ok else "save_database returned false",
-        }
+        result: dict = {"ok": ok, "path": save_path}
+        if not ok:
+            result["error"] = "save_database returned false"
+        return result
     except Exception as e:
         return {"ok": False, "path": path or None, "error": str(e)}
 

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -9,7 +9,7 @@ This module provides comprehensive debugging functionality including:
 """
 
 import os
-from typing import Annotated
+from typing import Annotated, NotRequired, TypedDict
 
 import ida_dbg
 import ida_entry
@@ -31,6 +31,44 @@ from .utils import (
     normalize_dict_list,
     parse_address,
 )
+
+
+class DebugControlResult(TypedDict, total=False):
+    ip: str
+    exited: bool
+    error: str
+
+
+class BreakpointResult(TypedDict, total=False):
+    addr: str
+    ok: bool
+    error: str
+
+
+class ThreadRegistersResult(TypedDict, total=False):
+    tid: int
+    regs: ThreadRegisters | None
+    error: str
+
+
+class StackFrameInfo(TypedDict):
+    addr: str
+    module: str
+    symbol: str
+
+
+class DebugMemoryReadResult(TypedDict):
+    addr: str | None
+    size: int
+    data: str | None
+    error: NotRequired[str | None]
+
+
+class DebugMemoryWriteResult(TypedDict, total=False):
+    addr: str | None
+    size: int
+    ok: bool
+    error: str | None
 
 
 # ============================================================================
@@ -137,7 +175,7 @@ def _get_registers_specific_for_thread(
     )
 
 
-def list_breakpoints():
+def list_breakpoints() -> list[Breakpoint]:
     breakpoints: list[Breakpoint] = []
     for i in range(ida_dbg.get_bpt_qty()):
         bpt = ida_dbg.bpt_t()
@@ -161,7 +199,7 @@ def list_breakpoints():
 @unsafe
 @tool
 @idasync
-def dbg_start():
+def dbg_start() -> DebugControlResult:
     """Start debugger session for current target."""
     if len(list_breakpoints()) == 0:
         for i in range(ida_entry.get_entry_qty()):
@@ -173,7 +211,7 @@ def dbg_start():
     if idaapi.start_process("", "", "") == 1:
         ip = ida_dbg.get_ip_val()
         if ip is not None:
-            return hex(ip)
+            return {"ip": hex(ip)}
     raise IDAError("Failed to start debugger")
 
 
@@ -181,11 +219,11 @@ def dbg_start():
 @unsafe
 @tool
 @idasync
-def dbg_exit():
+def dbg_exit() -> DebugControlResult:
     """Terminate active debugger session."""
     dbg_ensure_running()
     if idaapi.exit_process():
-        return
+        return {"exited": True}
     raise IDAError("Failed to exit debugger")
 
 
@@ -193,13 +231,13 @@ def dbg_exit():
 @unsafe
 @tool
 @idasync
-def dbg_continue() -> str:
+def dbg_continue() -> DebugControlResult:
     """Resume execution in active debugger session."""
     dbg_ensure_running()
     if idaapi.continue_process():
         ip = ida_dbg.get_ip_val()
         if ip is not None:
-            return hex(ip)
+            return {"ip": hex(ip)}
     raise IDAError("Failed to continue debugger")
 
 
@@ -209,14 +247,14 @@ def dbg_continue() -> str:
 @idasync
 def dbg_run_to(
     addr: Annotated[str, "Target execution address (hex or decimal)"],
-):
+) -> DebugControlResult:
     """Run debuggee until target address is reached."""
     dbg_ensure_running()
     ea = parse_address(addr)
     if idaapi.run_to(ea):
         ip = ida_dbg.get_ip_val()
         if ip is not None:
-            return hex(ip)
+            return {"ip": hex(ip)}
     raise IDAError(f"Failed to run to address {hex(ea)}")
 
 
@@ -224,13 +262,13 @@ def dbg_run_to(
 @unsafe
 @tool
 @idasync
-def dbg_step_into():
+def dbg_step_into() -> DebugControlResult:
     """Execute one instruction, stepping into calls."""
     dbg_ensure_running()
     if idaapi.step_into():
         ip = ida_dbg.get_ip_val()
         if ip is not None:
-            return hex(ip)
+            return {"ip": hex(ip)}
     raise IDAError("Failed to step into")
 
 
@@ -238,13 +276,13 @@ def dbg_step_into():
 @unsafe
 @tool
 @idasync
-def dbg_step_over():
+def dbg_step_over() -> DebugControlResult:
     """Execute one instruction, stepping over calls."""
     dbg_ensure_running()
     if idaapi.step_over():
         ip = ida_dbg.get_ip_val()
         if ip is not None:
-            return hex(ip)
+            return {"ip": hex(ip)}
     raise IDAError("Failed to step over")
 
 
@@ -257,7 +295,7 @@ def dbg_step_over():
 @unsafe
 @tool
 @idasync
-def dbg_bps():
+def dbg_bps() -> list[Breakpoint]:
     """List breakpoints with address and enabled status."""
     return list_breakpoints()
 
@@ -268,7 +306,7 @@ def dbg_bps():
 @idasync
 def dbg_add_bp(
     addrs: Annotated[list[str] | str, "Address(es) to add breakpoints at"],
-) -> list[dict]:
+) -> list[BreakpointResult]:
     """Add breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -298,7 +336,7 @@ def dbg_add_bp(
 @idasync
 def dbg_delete_bp(
     addrs: Annotated[list[str] | str, "Address(es) to delete breakpoints from"],
-) -> list[dict]:
+) -> list[BreakpointResult]:
     """Delete breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -320,7 +358,9 @@ def dbg_delete_bp(
 @unsafe
 @tool
 @idasync
-def dbg_toggle_bp(items: list[BreakpointOp] | BreakpointOp) -> list[dict]:
+def dbg_toggle_bp(
+    items: list[BreakpointOp] | BreakpointOp,
+) -> list[BreakpointResult]:
     """Enable or disable existing breakpoints in batch."""
 
     items = normalize_dict_list(items)
@@ -372,7 +412,7 @@ def dbg_regs_all() -> list[ThreadRegisters]:
 @idasync
 def dbg_regs_remote(
     tids: Annotated[list[int] | int, "Thread ID(s) to get registers for"],
-) -> list[dict]:
+) -> list[ThreadRegistersResult]:
     """Return full register sets for specified thread IDs."""
     if isinstance(tids, int):
         tids = [tids]
@@ -413,7 +453,7 @@ def dbg_regs() -> ThreadRegisters:
 @idasync
 def dbg_gpregs_remote(
     tids: Annotated[list[int] | int, "Thread ID(s) to get GP registers for"],
-) -> list[dict]:
+) -> list[ThreadRegistersResult]:
     """Get GP registers for threads"""
     if isinstance(tids, int):
         tids = [tids]
@@ -493,7 +533,7 @@ def dbg_regs_named(
 @unsafe
 @tool
 @idasync
-def dbg_stacktrace() -> list[dict[str, str]]:
+def dbg_stacktrace() -> list[StackFrameInfo]:
     """Return current call stack with module and symbol context."""
     callstack = []
     try:
@@ -545,7 +585,9 @@ def dbg_stacktrace() -> list[dict[str, str]]:
 @unsafe
 @tool
 @idasync
-def dbg_read(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
+def dbg_read(
+    regions: list[MemoryRead] | MemoryRead,
+) -> list[DebugMemoryReadResult]:
     """Read debuggee memory from one or more regions."""
 
     regions = normalize_dict_list(regions)
@@ -589,7 +631,9 @@ def dbg_read(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
 @unsafe
 @tool
 @idasync
-def dbg_write(regions: list[MemoryPatch] | MemoryPatch) -> list[dict]:
+def dbg_write(
+    regions: list[MemoryPatch] | MemoryPatch,
+) -> list[DebugMemoryWriteResult]:
     """Write bytes to debuggee memory regions."""
 
     regions = normalize_dict_list(regions)

--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -1,0 +1,212 @@
+"""Discovery API - list and switch between IDA instances.
+
+When running in streamable-http mode (client connects directly to IDA),
+select_instance makes this IDA instance proxy tool calls to the target.
+This lets a single MCP endpoint reach any running IDA instance.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from typing import Annotated
+
+from .rpc import tool
+from .discovery import discover_instances, probe_instance
+
+
+# Track which instance this server is (filled in by the plugin loader)
+_LOCAL_PORT: int | None = None
+_LOCAL_HOST: str = "127.0.0.1"
+
+# Redirect target: when set, tool calls are proxied to this instance
+_redirect_host: str | None = None
+_redirect_port: int | None = None
+
+# Tools that are always handled locally, never proxied
+_LOCAL_TOOL_NAMES = {"list_instances", "select_instance", "open_file"}
+
+
+def set_local_instance(host: str, port: int):
+    """Called by the plugin loader after server starts."""
+    global _LOCAL_HOST, _LOCAL_PORT
+    _LOCAL_HOST = host
+    _LOCAL_PORT = port
+
+
+def get_redirect_target() -> tuple[str, int] | None:
+    """Returns (host, port) if requests should be proxied, else None."""
+    if _redirect_host is not None and _redirect_port is not None:
+        return (_redirect_host, _redirect_port)
+    return None
+
+
+# ============================================================================
+# Tools
+# ============================================================================
+
+
+@tool
+def list_instances() -> list[dict]:
+    """List all discovered IDA Pro instances with their binary name, port, and reachability status.
+
+    Use this to see which IDA databases are currently open and available for analysis.
+    The 'active' field indicates which instance is currently handling your tool calls.
+    """
+    instances = discover_instances()
+    result = []
+    redirect = get_redirect_target()
+    for inst in instances:
+        reachable = probe_instance(inst["host"], inst["port"])
+        if redirect:
+            active = inst["host"] == redirect[0] and inst["port"] == redirect[1]
+        else:
+            active = inst["host"] == _LOCAL_HOST and inst["port"] == _LOCAL_PORT
+        result.append({
+            **inst,
+            "reachable": reachable,
+            "active": active,
+        })
+    return result
+
+
+@tool
+def select_instance(
+    port: Annotated[int, "Port number of the IDA instance to connect to"],
+    host: Annotated[str, "Host address of the IDA instance"] = "127.0.0.1",
+) -> dict:
+    """Switch to a different IDA Pro instance. All subsequent tool calls will be
+    routed to the selected instance. Use list_instances to see available instances.
+
+    To switch back to this instance, call select_instance with this instance's port,
+    or call select_instance with port=0 to reset.
+    """
+    global _redirect_host, _redirect_port
+
+    # Reset redirect
+    if port == 0:
+        _redirect_host = None
+        _redirect_port = None
+        return {
+            "success": True,
+            "message": f"Reset to local instance at {_LOCAL_HOST}:{_LOCAL_PORT}",
+        }
+
+    # Selecting the local instance clears redirect
+    if host == _LOCAL_HOST and port == _LOCAL_PORT:
+        _redirect_host = None
+        _redirect_port = None
+        return {"success": True, "host": host, "port": port, "message": "Selected local instance"}
+
+    if not probe_instance(host, port):
+        return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
+
+    _redirect_host = host
+    _redirect_port = port
+    return {"success": True, "host": host, "port": port}
+
+
+def _find_existing_idb(file_path: str) -> str | None:
+    """Check if an IDB already exists for the given binary.
+
+    IDA creates .idb (32-bit) or .i64 (64-bit) files next to the binary.
+    Opening the IDB directly skips the packed/unpacked dialog.
+    """
+    base = os.path.splitext(file_path)[0]
+    # Prefer .i64 (64-bit) over .idb (32-bit)
+    for ext in (".i64", ".idb"):
+        idb_path = base + ext
+        if os.path.isfile(idb_path):
+            return idb_path
+    return None
+
+
+@tool
+def open_file(
+    file_path: Annotated[str, "Absolute path to the binary file to open in a new IDA instance"],
+    switch: Annotated[bool, "Automatically switch to the new instance once it starts"] = True,
+    autonomous: Annotated[bool, "Run in autonomous mode (-A flag), suppressing all dialogs"] = False,
+    new_database: Annotated[bool, "Force creating a new database even if one exists"] = False,
+    timeout: Annotated[int, "Seconds to wait for the new instance to register (0 = don't wait)"] = 30,
+) -> dict:
+    """Open a file in a new IDA Pro instance.
+
+    Launches a new IDA process for the given binary. If an existing IDB/i64 database
+    is found, opens that directly (skips the packed/unpacked dialog). Use new_database=True
+    to force a fresh analysis. Use autonomous=True to suppress all IDA dialogs.
+
+    If switch=True (default), automatically routes subsequent tool calls to the new instance.
+    """
+    global _redirect_host, _redirect_port
+
+    if not os.path.isfile(file_path):
+        return {"success": False, "error": f"File not found: {file_path}"}
+
+    # Get the IDA executable from the currently running instance
+    ida_exe = sys.executable
+    if not os.path.isfile(ida_exe):
+        return {"success": False, "error": f"Cannot find IDA executable: {ida_exe}"}
+
+    # Determine what to open: existing IDB or raw binary
+    target = file_path
+    if not new_database:
+        existing_idb = _find_existing_idb(file_path)
+        if existing_idb:
+            target = existing_idb
+
+    args = [ida_exe]
+    if autonomous:
+        args.append("-A")
+    if new_database:
+        args.append("-c")  # Force new database
+    args.append(target)
+
+    # Snapshot current instances before launch
+    before = {(i["host"], i["port"]) for i in discover_instances()}
+
+    try:
+        subprocess.Popen(
+            args,
+            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+            if sys.platform == "win32" else 0,
+        )
+    except Exception as e:
+        return {"success": False, "error": f"Failed to launch IDA: {e}"}
+
+    if timeout == 0:
+        return {"success": True, "message": "IDA launched, not waiting for registration"}
+
+    # Poll for the new instance to register
+    deadline = time.monotonic() + timeout
+    new_instance = None
+    while time.monotonic() < deadline:
+        time.sleep(1)
+        current = discover_instances()
+        for inst in current:
+            key = (inst["host"], inst["port"])
+            if key not in before:
+                new_instance = inst
+                break
+        if new_instance:
+            break
+
+    if not new_instance:
+        return {
+            "success": True,
+            "message": f"IDA launched but did not register within {timeout}s. Use list_instances to check later.",
+        }
+
+    result = {
+        "success": True,
+        "host": new_instance["host"],
+        "port": new_instance["port"],
+        "binary": new_instance["binary"],
+        "pid": new_instance["pid"],
+    }
+
+    if switch:
+        _redirect_host = new_instance["host"]
+        _redirect_port = new_instance["port"]
+        result["switched"] = True
+
+    return result

--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -22,6 +22,9 @@ from .discovery import discover_instances, probe_instance
 _LOCAL_PORT: int | None = None
 _LOCAL_HOST: str = "127.0.0.1"
 
+# Thread-local: set by HTTP handler when request is a proxied forward
+_request_context = threading.local()
+
 # Redirect target: when set, tool calls are proxied to this instance
 _redirect_host: str | None = None
 _redirect_port: int | None = None
@@ -42,10 +45,6 @@ def get_redirect_target() -> tuple[str, int] | None:
     if _redirect_host is not None and _redirect_port is not None:
         return (_redirect_host, _redirect_port)
     return None
-
-
-# Thread-local: set by HTTP handler when request is a proxied forward
-_request_context = threading.local()
 
 
 def set_request_proxied(proxied: bool):

--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -5,13 +5,16 @@ select_instance makes this IDA instance proxy tool calls to the target.
 This lets a single MCP endpoint reach any running IDA instance.
 """
 
+import http.client
+import json
 import os
 import subprocess
 import sys
+import threading
 import time
 from typing import Annotated
 
-from .rpc import tool
+from .rpc import tool, MCP_SERVER
 from .discovery import discover_instances, probe_instance
 
 
@@ -39,6 +42,133 @@ def get_redirect_target() -> tuple[str, int] | None:
     if _redirect_host is not None and _redirect_port is not None:
         return (_redirect_host, _redirect_port)
     return None
+
+
+# Thread-local: set by HTTP handler when request is a proxied forward
+_request_context = threading.local()
+
+
+def set_request_proxied(proxied: bool):
+    """Called by HTTP handler to mark the current request as proxied."""
+    _request_context.proxied = proxied
+
+
+def is_request_proxied() -> bool:
+    """Check if the current request was forwarded from another instance."""
+    return getattr(_request_context, "proxied", False)
+
+
+def is_local_tool(name: str) -> bool:
+    """Check if a tool should be handled locally even when redirecting."""
+    return name in _LOCAL_TOOL_NAMES
+
+
+PROXY_HEADER = "X-MCP-Proxied"
+
+
+def proxy_to_instance(host: str, port: int, payload: bytes) -> dict:
+    """Forward a JSON-RPC request to another IDA instance.
+
+    Sets X-MCP-Proxied header so the target knows this is a forwarded request
+    and won't follow its own redirect (preventing A→B→A loops).
+    """
+    headers = {
+        "Content-Type": "application/json",
+        PROXY_HEADER: "1",
+    }
+    conn = http.client.HTTPConnection(host, port, timeout=30)
+    try:
+        conn.request("POST", "/mcp", payload, headers)
+        response = conn.getresponse()
+        raw_data = response.read().decode()
+        if response.status >= 400:
+            raise RuntimeError(f"HTTP {response.status} {response.reason}: {raw_data}")
+        return json.loads(raw_data)
+    finally:
+        conn.close()
+
+
+# ============================================================================
+# Dispatch interception: proxy tools/call and tools/list when redirecting
+# ============================================================================
+
+_original_dispatch = MCP_SERVER.registry.dispatch
+
+
+def _redirecting_dispatch(request):
+    """Intercept dispatch to proxy tool calls when redirect is active."""
+    redirect = get_redirect_target()
+    if redirect is None or is_request_proxied():
+        # No redirect, or this request was already proxied here — handle locally
+        return _original_dispatch(request)
+
+    # Parse the request
+    if not isinstance(request, dict):
+        request_obj = json.loads(request)
+    else:
+        request_obj = request
+
+    method = request_obj.get("method", "")
+
+    # Always handle locally: initialize, notifications, non-tool methods
+    if method == "initialize" or method.startswith("notifications/"):
+        return _original_dispatch(request)
+
+    # tools/call: proxy unless it's a local tool
+    if method == "tools/call":
+        params = request_obj.get("params", {})
+        tool_name = params.get("name", "")
+        if is_local_tool(tool_name):
+            return _original_dispatch(request)
+        # Proxy to redirect target (with loop detection)
+        try:
+            payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+            if isinstance(payload, str):
+                payload = payload.encode("utf-8")
+            return proxy_to_instance(redirect[0], redirect[1], payload)
+        except Exception as e:
+            request_id = request_obj.get("id")
+            if request_id is None:
+                return None
+            return {
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32000,
+                    "message": f"Failed to proxy to {redirect[0]}:{redirect[1]}: {e}",
+                },
+                "id": request_id,
+            }
+
+    # tools/list: merge local discovery tools with redirect target's tools
+    if method == "tools/list":
+        local_result = _original_dispatch(request)
+        try:
+            payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+            if isinstance(payload, str):
+                payload = payload.encode("utf-8")
+            remote_result = proxy_to_instance(redirect[0], redirect[1], payload)
+            if remote_result and "result" in remote_result:
+                remote_tools = remote_result["result"].get("tools", [])
+                # Filter out remote list_instances/select_instance to avoid duplicates
+                remote_tools = [t for t in remote_tools if t.get("name") not in _LOCAL_TOOL_NAMES]
+                if local_result and "result" in local_result:
+                    local_tools = local_result["result"].get("tools", [])
+                    local_result["result"]["tools"] = remote_tools + local_tools
+        except Exception:
+            pass  # Remote unreachable, show local tools only
+        return local_result
+
+    # Everything else (resources/list, etc.): proxy
+    try:
+        payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+        if isinstance(payload, str):
+            payload = payload.encode("utf-8")
+        return proxy_to_instance(redirect[0], redirect[1], payload)
+    except Exception:
+        return _original_dispatch(request)
+
+
+MCP_SERVER.registry.dispatch = _redirecting_dispatch
 
 
 # ============================================================================

--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -12,10 +12,40 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Annotated
+from typing import Annotated, NotRequired, TypedDict
 
 from .rpc import tool, MCP_SERVER
 from .discovery import discover_instances, probe_instance
+
+
+class InstanceSelectionResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    message: str
+    error: str
+
+
+class InstanceListItem(TypedDict, total=False):
+    host: str
+    port: int
+    pid: int
+    binary: str
+    idb_path: str
+    started_at: str
+    reachable: bool
+    active: bool
+
+
+class OpenFileResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    binary: str
+    pid: int
+    switched: bool
+    message: str
+    error: str
 
 
 # Track which instance this server is (filled in by the plugin loader)
@@ -28,6 +58,8 @@ _request_context = threading.local()
 # Redirect target: when set, tool calls are proxied to this instance
 _redirect_host: str | None = None
 _redirect_port: int | None = None
+_redirect_targets: dict[str, tuple[str, int]] = {}
+_redirect_lock = threading.Lock()
 
 # Tools that are always handled locally, never proxied
 _LOCAL_TOOL_NAMES = {"list_instances", "select_instance", "open_file"}
@@ -40,11 +72,44 @@ def set_local_instance(host: str, port: int):
     _LOCAL_PORT = port
 
 
+def _get_redirect_session_key() -> str | None:
+    """Return the current MCP transport session id, if any."""
+    return MCP_SERVER.get_current_transport_session_id()
+
+
 def get_redirect_target() -> tuple[str, int] | None:
     """Returns (host, port) if requests should be proxied, else None."""
+    session_key = _get_redirect_session_key()
+    if session_key is not None:
+        with _redirect_lock:
+            return _redirect_targets.get(session_key)
     if _redirect_host is not None and _redirect_port is not None:
         return (_redirect_host, _redirect_port)
     return None
+
+
+def _set_redirect_target(host: str, port: int):
+    """Set the redirect target for the current MCP transport session."""
+    global _redirect_host, _redirect_port
+    session_key = _get_redirect_session_key()
+    if session_key is not None:
+        with _redirect_lock:
+            _redirect_targets[session_key] = (host, port)
+        return
+    _redirect_host = host
+    _redirect_port = port
+
+
+def _clear_redirect_target():
+    """Clear the redirect target for the current MCP transport session."""
+    global _redirect_host, _redirect_port
+    session_key = _get_redirect_session_key()
+    if session_key is not None:
+        with _redirect_lock:
+            _redirect_targets.pop(session_key, None)
+        return
+    _redirect_host = None
+    _redirect_port = None
 
 
 def set_request_proxied(proxied: bool):
@@ -65,19 +130,42 @@ def is_local_tool(name: str) -> bool:
 PROXY_HEADER = "X-MCP-Proxied"
 
 
+def _get_proxy_request_path() -> str:
+    """Build the proxied MCP path, preserving enabled extensions."""
+    enabled = sorted(getattr(MCP_SERVER._enabled_extensions, "data", set()))
+    if enabled:
+        return f"/mcp?ext={','.join(enabled)}"
+    return "/mcp"
+
+
+def _get_proxy_request_headers() -> dict[str, str]:
+    """Build proxy request headers, preserving MCP session identity."""
+    headers = {
+        "Content-Type": "application/json",
+        PROXY_HEADER: "1",
+    }
+    transport_session_id = MCP_SERVER.get_current_transport_session_id()
+    if transport_session_id and transport_session_id.startswith("http:"):
+        session_id = transport_session_id.split(":", 1)[1]
+        if session_id and session_id != "anonymous":
+            headers["Mcp-Session-Id"] = session_id
+    return headers
+
+
 def proxy_to_instance(host: str, port: int, payload: bytes) -> dict:
     """Forward a JSON-RPC request to another IDA instance.
 
     Sets X-MCP-Proxied header so the target knows this is a forwarded request
     and won't follow its own redirect (preventing A→B→A loops).
     """
-    headers = {
-        "Content-Type": "application/json",
-        PROXY_HEADER: "1",
-    }
     conn = http.client.HTTPConnection(host, port, timeout=30)
     try:
-        conn.request("POST", "/mcp", payload, headers)
+        conn.request(
+            "POST",
+            _get_proxy_request_path(),
+            payload,
+            _get_proxy_request_headers(),
+        )
         response = conn.getresponse()
         raw_data = response.read().decode()
         if response.status >= 400:
@@ -121,7 +209,11 @@ def _redirecting_dispatch(request):
             return _original_dispatch(request)
         # Proxy to redirect target (with loop detection)
         try:
-            payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+            payload = (
+                json.dumps(request_obj).encode("utf-8")
+                if isinstance(request, dict)
+                else request
+            )
             if isinstance(payload, str):
                 payload = payload.encode("utf-8")
             return proxy_to_instance(redirect[0], redirect[1], payload)
@@ -142,14 +234,20 @@ def _redirecting_dispatch(request):
     if method == "tools/list":
         local_result = _original_dispatch(request)
         try:
-            payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+            payload = (
+                json.dumps(request_obj).encode("utf-8")
+                if isinstance(request, dict)
+                else request
+            )
             if isinstance(payload, str):
                 payload = payload.encode("utf-8")
             remote_result = proxy_to_instance(redirect[0], redirect[1], payload)
             if remote_result and "result" in remote_result:
                 remote_tools = remote_result["result"].get("tools", [])
                 # Filter out remote list_instances/select_instance to avoid duplicates
-                remote_tools = [t for t in remote_tools if t.get("name") not in _LOCAL_TOOL_NAMES]
+                remote_tools = [
+                    t for t in remote_tools if t.get("name") not in _LOCAL_TOOL_NAMES
+                ]
                 if local_result and "result" in local_result:
                     local_tools = local_result["result"].get("tools", [])
                     local_result["result"]["tools"] = remote_tools + local_tools
@@ -159,7 +257,11 @@ def _redirecting_dispatch(request):
 
     # Everything else (resources/list, etc.): proxy
     try:
-        payload = json.dumps(request_obj).encode("utf-8") if isinstance(request, dict) else request
+        payload = (
+            json.dumps(request_obj).encode("utf-8")
+            if isinstance(request, dict)
+            else request
+        )
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
         return proxy_to_instance(redirect[0], redirect[1], payload)
@@ -176,7 +278,7 @@ MCP_SERVER.registry.dispatch = _redirecting_dispatch
 
 
 @tool
-def list_instances() -> list[dict]:
+def list_instances() -> list[InstanceListItem]:
     """List all discovered IDA Pro instances with their binary name, port, and reachability status.
 
     Use this to see which IDA databases are currently open and available for analysis.
@@ -203,19 +305,16 @@ def list_instances() -> list[dict]:
 def select_instance(
     port: Annotated[int, "Port number of the IDA instance to connect to"],
     host: Annotated[str, "Host address of the IDA instance"] = "127.0.0.1",
-) -> dict:
+) -> InstanceSelectionResult:
     """Switch to a different IDA Pro instance. All subsequent tool calls will be
     routed to the selected instance. Use list_instances to see available instances.
 
     To switch back to this instance, call select_instance with this instance's port,
     or call select_instance with port=0 to reset.
     """
-    global _redirect_host, _redirect_port
-
     # Reset redirect
     if port == 0:
-        _redirect_host = None
-        _redirect_port = None
+        _clear_redirect_target()
         return {
             "success": True,
             "message": f"Reset to local instance at {_LOCAL_HOST}:{_LOCAL_PORT}",
@@ -223,15 +322,13 @@ def select_instance(
 
     # Selecting the local instance clears redirect
     if host == _LOCAL_HOST and port == _LOCAL_PORT:
-        _redirect_host = None
-        _redirect_port = None
+        _clear_redirect_target()
         return {"success": True, "host": host, "port": port, "message": "Selected local instance"}
 
     if not probe_instance(host, port):
         return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
 
-    _redirect_host = host
-    _redirect_port = port
+    _set_redirect_target(host, port)
     return {"success": True, "host": host, "port": port}
 
 
@@ -252,12 +349,22 @@ def _find_existing_idb(file_path: str) -> str | None:
 
 @tool
 def open_file(
-    file_path: Annotated[str, "Absolute path to the binary file to open in a new IDA instance"],
-    switch: Annotated[bool, "Automatically switch to the new instance once it starts"] = True,
-    autonomous: Annotated[bool, "Run in autonomous mode (-A flag), suppressing all dialogs"] = False,
-    new_database: Annotated[bool, "Force creating a new database even if one exists"] = False,
-    timeout: Annotated[int, "Seconds to wait for the new instance to register (0 = don't wait)"] = 30,
-) -> dict:
+    file_path: Annotated[
+        str, "Absolute path to the binary file to open in a new IDA instance"
+    ],
+    switch: Annotated[
+        bool, "Automatically switch to the new instance once it starts"
+    ] = True,
+    autonomous: Annotated[
+        bool, "Run in autonomous mode (-A flag), suppressing all dialogs"
+    ] = False,
+    new_database: Annotated[
+        bool, "Force creating a new database even if one exists"
+    ] = False,
+    timeout: Annotated[
+        int, "Seconds to wait for the new instance to register (0 = don't wait)"
+    ] = 30,
+) -> OpenFileResult:
     """Open a file in a new IDA Pro instance.
 
     Launches a new IDA process for the given binary. If an existing IDB/i64 database
@@ -266,8 +373,6 @@ def open_file(
 
     If switch=True (default), automatically routes subsequent tool calls to the new instance.
     """
-    global _redirect_host, _redirect_port
-
     if not os.path.isfile(file_path):
         return {"success": False, "error": f"File not found: {file_path}"}
 
@@ -322,7 +427,10 @@ def open_file(
     if not new_instance:
         return {
             "success": True,
-            "message": f"IDA launched but did not register within {timeout}s. Use list_instances to check later.",
+            "message": (
+                f"IDA launched but did not register within {timeout}s. "
+                "Use list_instances to check later."
+            ),
         }
 
     result = {
@@ -334,8 +442,7 @@ def open_file(
     }
 
     if switch:
-        _redirect_host = new_instance["host"]
-        _redirect_port = new_instance["port"]
+        _set_redirect_target(new_instance["host"], new_instance["port"])
         result["switched"] = True
 
     return result

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -112,7 +112,7 @@ def get_int(
 
             value = int.from_bytes(data, byte_order, signed=signed)
             results.append(
-                {"addr": addr, "ty": normalized, "value": value, "error": None}
+                {"addr": addr, "ty": normalized, "value": value}
             )
         except Exception as e:
             results.append({"addr": addr, "ty": ty, "value": None, "error": str(e)})
@@ -214,7 +214,7 @@ def get_global_value(
                 continue
 
             value = get_global_variable_value_internal(ea)
-            results.append({"query": query, "value": value, "error": None})
+            results.append({"query": query, "value": value})
         except Exception as e:
             results.append({"query": query, "value": None, "error": str(e)})
 
@@ -245,7 +245,7 @@ def patch(patches: list[MemoryPatch] | MemoryPatch) -> list[dict]:
 
             ida_bytes.patch_bytes(ea, data)
             results.append(
-                {"addr": patch["addr"], "size": len(data), "ok": True, "error": None}
+                {"addr": patch["addr"], "size": len(data)}
             )
 
         except Exception as e:
@@ -290,8 +290,6 @@ def put_int(
                     "addr": addr,
                     "ty": normalized,
                     "value": str(value_text),
-                    "ok": True,
-                    "error": None,
                 }
             )
         except Exception as e:
@@ -300,7 +298,6 @@ def put_int(
                     "addr": addr,
                     "ty": ty,
                     "value": str(value_text) if value_text is not None else None,
-                    "ok": False,
                     "error": str(e),
                 }
             )

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -6,7 +6,7 @@ granularities (bytes, integers, strings) and patching binary data.
 
 import re
 
-from typing import Annotated
+from typing import Annotated, NotRequired, TypedDict
 import ida_bytes
 import idaapi
 
@@ -22,6 +22,44 @@ from .utils import (
 )
 
 
+class BytesReadResult(TypedDict):
+    addr: str | None
+    data: str | None
+    error: NotRequired[str]
+
+
+class IntReadResult(TypedDict):
+    addr: str
+    ty: str
+    value: int | None
+    error: NotRequired[str]
+
+
+class StringReadResult(TypedDict):
+    addr: str
+    value: str | None
+    error: NotRequired[str]
+
+
+class GlobalValueResult(TypedDict):
+    query: str
+    value: str | None
+    error: NotRequired[str]
+
+
+class PatchResult(TypedDict):
+    addr: str | None
+    size: int
+    error: NotRequired[str]
+
+
+class IntWriteResult(TypedDict):
+    addr: str
+    ty: str
+    value: str | None
+    error: NotRequired[str]
+
+
 # ============================================================================
 # Memory Reading Operations
 # ============================================================================
@@ -29,7 +67,7 @@ from .utils import (
 
 @tool
 @idasync
-def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[dict]:
+def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[BytesReadResult]:
     """Read bytes from memory addresses"""
     if isinstance(regions, dict):
         regions = [regions]
@@ -92,7 +130,7 @@ def get_int(
         list[IntRead] | IntRead,
         "Integer read requests (ty, addr). ty: i8/u64/i16le/i16be/etc",
     ],
-) -> list[dict]:
+) -> list[IntReadResult]:
     """Read integer values from memory addresses"""
     if isinstance(queries, dict):
         queries = [queries]
@@ -124,7 +162,7 @@ def get_int(
 @idasync
 def get_string(
     addrs: Annotated[list[str] | str, "Addresses to read strings from"],
-) -> list[dict]:
+) -> list[StringReadResult]:
     """Read strings from memory addresses"""
     addrs = normalize_list_input(addrs)
     results = []
@@ -187,7 +225,7 @@ def get_global_value(
     queries: Annotated[
         list[str] | str, "Global variable addresses or names to read values from"
     ],
-) -> list[dict]:
+) -> list[GlobalValueResult]:
     """Read global variable values by address or symbol name."""
     from .utils import looks_like_address
 
@@ -228,7 +266,7 @@ def get_global_value(
 
 @tool
 @idasync
-def patch(patches: list[MemoryPatch] | MemoryPatch) -> list[dict]:
+def patch(patches: list[MemoryPatch] | MemoryPatch) -> list[PatchResult]:
     """Patch bytes at memory addresses with hex data"""
     if isinstance(patches, dict):
         patches = [patches]
@@ -261,7 +299,7 @@ def put_int(
         list[IntWrite] | IntWrite,
         "Integer write requests (ty, addr, value). value is a string; supports 0x.. and negatives",
     ],
-) -> list[dict]:
+) -> list[IntWriteResult]:
     """Write integer values to memory addresses"""
     if isinstance(items, dict):
         items = [items]

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -1,3 +1,5 @@
+from typing import Any, NotRequired, TypedDict
+
 import idaapi
 import idautils
 import idc
@@ -28,6 +30,66 @@ from .utils import (
 )
 
 
+class CommentResult(TypedDict):
+    addr: str
+    error: NotRequired[str]
+
+
+class AppendCommentResult(TypedDict):
+    addr: str
+    scope: NotRequired[str]
+    appended: NotRequired[bool]
+    skipped: NotRequired[bool]
+    error: NotRequired[str]
+
+
+class PatchAsmResult(TypedDict):
+    addr: str
+    error: NotRequired[str]
+
+
+class RenameItemResult(TypedDict, total=False):
+    addr: str
+    func_addr: str
+    old: str
+    new: str | None
+    name: str
+    dir: str
+    dir_error: str
+    dry_run: bool
+    error: str
+
+
+class RenameSummaryResult(TypedDict, total=False):
+    total: int
+    ok: int
+    failed: int
+    stopped: bool
+    dry_run: bool
+    allow_overwrite: bool
+    stop_on_error: bool
+    stopped_at: str
+
+
+class RenameResult(TypedDict, total=False):
+    func: list[RenameItemResult]
+    data: list[RenameItemResult]
+    global_alias: list[RenameItemResult]
+    local: list[RenameItemResult]
+    stack: list[RenameItemResult]
+    summary: RenameSummaryResult
+
+
+class DefineResult(TypedDict, total=False):
+    addr: str
+    ea: str
+    start: str
+    end: str
+    size: int
+    length: int
+    error: str
+
+
 # ============================================================================
 # Modification Operations
 # ============================================================================
@@ -35,7 +97,7 @@ from .utils import (
 
 @tool
 @idasync
-def set_comments(items: list[CommentOp] | CommentOp):
+def set_comments(items: list[CommentOp] | CommentOp) -> list[CommentResult]:
     """Set comments at addresses (both disassembly and decompiler views)"""
     if isinstance(items, dict):
         items = [items]
@@ -115,7 +177,9 @@ def set_comments(items: list[CommentOp] | CommentOp):
 
 @tool
 @idasync
-def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
+def append_comments(
+    items: list[CommentAppendOp] | CommentAppendOp,
+) -> list[AppendCommentResult]:
     """Append comments at addresses, deduping exact text by default."""
     if isinstance(items, dict):
         items = [items]
@@ -134,7 +198,9 @@ def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
                 continue
 
             fn = idaapi.get_func(ea)
-            use_func_comment = scope == "func" or (scope == "auto" and fn is not None and fn.start_ea == ea)
+            use_func_comment = scope == "func" or (
+                scope == "auto" and fn is not None and fn.start_ea == ea
+            )
 
             if use_func_comment:
                 if fn is None:
@@ -148,7 +214,10 @@ def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
                     continue
                 if not idc.set_func_cmt(target_ea, new_comment, False):
                     results.append(
-                        {"addr": addr_str, "error": f"Failed to set function comment at {hex(target_ea)}"}
+                        {
+                            "addr": addr_str,
+                            "error": f"Failed to set function comment at {hex(target_ea)}",
+                        }
                     )
                     continue
                 results.append({"addr": addr_str, "scope": "func", "appended": True})
@@ -160,7 +229,12 @@ def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
                 results.append({"addr": addr_str, "scope": "line", "skipped": True})
                 continue
             if not idaapi.set_cmt(ea, new_comment, False):
-                results.append({"addr": addr_str, "error": f"Failed to set disassembly comment at {hex(ea)}"})
+                results.append(
+                    {
+                        "addr": addr_str,
+                        "error": f"Failed to set disassembly comment at {hex(ea)}",
+                    }
+                )
                 continue
             results.append({"addr": addr_str, "scope": "line", "appended": True})
         except Exception as e:
@@ -185,7 +259,7 @@ def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> tuple[
 
 @tool
 @idasync
-def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[dict]:
+def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[PatchAsmResult]:
     """Patch assembly instructions at addresses"""
     if isinstance(items, dict):
         items = [items]
@@ -227,7 +301,7 @@ def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[dict]:
 
 @tool
 @idasync
-def rename(batch: RenameBatch | dict) -> dict:
+def rename(batch: RenameBatch | dict) -> RenameResult:
     """Batch-rename funcs/globals/locals/stack vars with dry-run options."""
 
     if not isinstance(batch, dict):
@@ -686,7 +760,12 @@ def rename(batch: RenameBatch | dict) -> dict:
             else:
                 failed += 1
 
-    summary: dict = {"total": total, "ok": ok, "failed": failed}
+    summary: dict = {
+        "total": total,
+        "ok": ok,
+        "failed": failed,
+        "stopped": stopped,
+    }
     if dry_run:
         summary["dry_run"] = True
     if allow_overwrite:
@@ -701,7 +780,7 @@ def rename(batch: RenameBatch | dict) -> dict:
 
 @tool
 @idasync
-def define_func(items: list[DefineOp] | DefineOp) -> list[dict]:
+def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
     """Define functions; IDA infers bounds unless end is provided."""
     if isinstance(items, dict):
         items = [items]
@@ -753,7 +832,7 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[dict]:
 
 @tool
 @idasync
-def define_code(items: list[DefineOp] | DefineOp) -> list[dict]:
+def define_code(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
     """Convert bytes to code instruction(s) at address(es)."""
     if isinstance(items, dict):
         items = [items]
@@ -785,7 +864,7 @@ def define_code(items: list[DefineOp] | DefineOp) -> list[dict]:
 
 @tool
 @idasync
-def undefine(items: list[UndefineOp] | UndefineOp) -> list[dict]:
+def undefine(items: list[UndefineOp] | UndefineOp) -> list[DefineResult]:
     """Undefine item(s) at address(es), converting back to raw bytes."""
     if isinstance(items, dict):
         items = [items]

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -58,19 +58,19 @@ def set_comments(items: list[CommentOp] | CommentOp):
                 continue
 
             if not ida_hexrays.init_hexrays_plugin():
-                results.append({"addr": addr_str, "ok": True})
+                results.append({"addr": addr_str})
                 continue
 
             try:
                 cfunc = decompile_checked(ea)
             except IDAError:
-                results.append({"addr": addr_str, "ok": True})
+                results.append({"addr": addr_str})
                 continue
 
             if ea == cfunc.entry_ea:
                 idc.set_func_cmt(ea, comment, True)
                 cfunc.refresh_func_ctext()
-                results.append({"addr": addr_str, "ok": True})
+                results.append({"addr": addr_str})
                 continue
 
             eamap = cfunc.get_eamap()
@@ -78,7 +78,6 @@ def set_comments(items: list[CommentOp] | CommentOp):
                 results.append(
                     {
                         "addr": addr_str,
-                        "ok": True,
                         "error": f"Failed to set decompiler comment at {hex(ea)}",
                     }
                 )
@@ -97,7 +96,7 @@ def set_comments(items: list[CommentOp] | CommentOp):
                 cfunc.save_user_cmts()
                 cfunc.refresh_func_ctext()
                 if not cfunc.has_orphan_cmts():
-                    results.append({"addr": addr_str, "ok": True})
+                    results.append({"addr": addr_str})
                     break
                 cfunc.del_orphan_cmts()
                 cfunc.save_user_cmts()
@@ -105,7 +104,6 @@ def set_comments(items: list[CommentOp] | CommentOp):
                 results.append(
                     {
                         "addr": addr_str,
-                        "ok": True,
                         "error": f"Failed to set decompiler comment at {hex(ea)}",
                     }
                 )
@@ -146,25 +144,25 @@ def append_comments(items: list[CommentAppendOp] | CommentAppendOp):
                 current = idc.get_func_cmt(target_ea, False) or ""
                 new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
                 if skipped:
-                    results.append({"addr": addr_str, "ok": True, "scope": "func", "skipped": True})
+                    results.append({"addr": addr_str, "scope": "func", "skipped": True})
                     continue
                 if not idc.set_func_cmt(target_ea, new_comment, False):
                     results.append(
                         {"addr": addr_str, "error": f"Failed to set function comment at {hex(target_ea)}"}
                     )
                     continue
-                results.append({"addr": addr_str, "ok": True, "scope": "func", "appended": True})
+                results.append({"addr": addr_str, "scope": "func", "appended": True})
                 continue
 
             current = idaapi.get_cmt(ea, False) or ""
             new_comment, skipped = _append_comment_text(current, comment, dedupe=dedupe)
             if skipped:
-                results.append({"addr": addr_str, "ok": True, "scope": "line", "skipped": True})
+                results.append({"addr": addr_str, "scope": "line", "skipped": True})
                 continue
             if not idaapi.set_cmt(ea, new_comment, False):
                 results.append({"addr": addr_str, "error": f"Failed to set disassembly comment at {hex(ea)}"})
                 continue
-            results.append({"addr": addr_str, "ok": True, "scope": "line", "appended": True})
+            results.append({"addr": addr_str, "scope": "line", "appended": True})
         except Exception as e:
             results.append({"addr": addr_str, "error": str(e)})
 
@@ -220,7 +218,7 @@ def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[dict]:
                     )
                     break
             else:
-                results.append({"addr": addr_str, "ok": True})
+                results.append({"addr": addr_str})
         except Exception as e:
             results.append({"addr": addr_str, "error": str(e)})
 
@@ -325,7 +323,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                     result = {
                         "addr": addr_text,
                         "name": new_name,
-                        "ok": False,
                         "error": "Function rename requires addr + name",
                     }
                     results.append(result)
@@ -340,7 +337,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                     result = {
                         "addr": addr_text,
                         "name": new_name,
-                        "ok": False,
                         "error": "Function not found",
                     }
                     results.append(result)
@@ -363,18 +359,21 @@ def rename(batch: RenameBatch | dict) -> dict:
                     "addr": addr_text,
                     "old": old_name,
                     "name": str(new_name),
-                    "ok": success,
-                    "error": error,
-                    "dir": "vibe" if success and placed else None,
-                    "dir_error": place_error if success else None,
-                    "dry_run": dry_run,
                 }
+                if error:
+                    result["error"] = error
+                if success and placed:
+                    result["dir"] = "vibe"
+                if place_error and success:
+                    result["dir_error"] = place_error
+                if dry_run:
+                    result["dry_run"] = True
                 results.append(result)
                 if not success and stop_on_error:
                     halted = True
                     break
             except Exception as e:
-                results.append({"addr": item.get("addr"), "ok": False, "error": str(e)})
+                results.append({"addr": item.get("addr"), "error": str(e)})
                 if stop_on_error:
                     halted = True
                     break
@@ -401,7 +400,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                     result = {
                         "old": old_name,
                         "new": None,
-                        "ok": False,
                         "error": "Global rename requires target and new name",
                     }
                     results.append(result)
@@ -421,7 +419,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                     result = {
                         "old": old_name,
                         "new": str(new_name),
-                        "ok": False,
                         "error": f"Global '{old_name}' not found",
                     }
                     results.append(result)
@@ -435,16 +432,17 @@ def rename(batch: RenameBatch | dict) -> dict:
                     "addr": hex(ea),
                     "old": old_name,
                     "new": str(new_name),
-                    "ok": success,
-                    "error": error,
-                    "dry_run": dry_run,
                 }
+                if error:
+                    result["error"] = error
+                if dry_run:
+                    result["dry_run"] = True
                 results.append(result)
                 if not success and stop_on_error:
                     halted = True
                     break
             except Exception as e:
-                results.append({"old": item.get("old"), "ok": False, "error": str(e)})
+                results.append({"old": item.get("old"), "error": str(e)})
                 if stop_on_error:
                     halted = True
                     break
@@ -463,7 +461,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "Local rename requires func_addr + old + new",
                     }
                     results.append(result)
@@ -478,7 +475,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "No function found",
                     }
                     results.append(result)
@@ -500,16 +496,17 @@ def rename(batch: RenameBatch | dict) -> dict:
                     "func_addr": func_addr,
                     "old": old_name,
                     "new": new_name,
-                    "ok": success,
-                    "error": error,
-                    "dry_run": dry_run,
                 }
+                if error:
+                    result["error"] = error
+                if dry_run:
+                    result["dry_run"] = True
                 results.append(result)
                 if not success and stop_on_error:
                     halted = True
                     break
             except Exception as e:
-                results.append({"func_addr": item.get("func_addr"), "ok": False, "error": str(e)})
+                results.append({"func_addr": item.get("func_addr"), "error": str(e)})
                 if stop_on_error:
                     halted = True
                     break
@@ -528,7 +525,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "Stack rename requires func_addr + old + new",
                     }
                     results.append(result)
@@ -543,7 +539,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "No function found",
                     }
                     results.append(result)
@@ -558,7 +553,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "No frame",
                     }
                     results.append(result)
@@ -573,7 +567,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": f"'{old_name}' not found",
                     }
                     results.append(result)
@@ -588,7 +581,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "Special frame member",
                     }
                     results.append(result)
@@ -605,7 +597,6 @@ def rename(batch: RenameBatch | dict) -> dict:
                         "func_addr": func_addr,
                         "old": old_name,
                         "new": new_name,
-                        "ok": False,
                         "error": "Argument member",
                     }
                     results.append(result)
@@ -626,16 +617,17 @@ def rename(batch: RenameBatch | dict) -> dict:
                     "func_addr": func_addr,
                     "old": old_name,
                     "new": new_name,
-                    "ok": success,
-                    "error": error,
-                    "dry_run": dry_run,
                 }
+                if error:
+                    result["error"] = error
+                if dry_run:
+                    result["dry_run"] = True
                 results.append(result)
                 if not success and stop_on_error:
                     halted = True
                     break
             except Exception as e:
-                results.append({"func_addr": item.get("func_addr"), "ok": False, "error": str(e)})
+                results.append({"func_addr": item.get("func_addr"), "error": str(e)})
                 if stop_on_error:
                     halted = True
                     break
@@ -689,21 +681,21 @@ def rename(batch: RenameBatch | dict) -> dict:
     for key in ("func", "data", "local", "stack"):
         for item in result.get(key, []):
             total += 1
-            if item.get("ok"):
+            if "error" not in item:
                 ok += 1
             else:
                 failed += 1
 
-    result["summary"] = {
-        "total": total,
-        "ok": ok,
-        "failed": failed,
-        "dry_run": dry_run,
-        "allow_overwrite": allow_overwrite,
-        "stop_on_error": stop_on_error,
-        "stopped": stopped,
-        "stopped_at": stopped_at,
-    }
+    summary: dict = {"total": total, "ok": ok, "failed": failed}
+    if dry_run:
+        summary["dry_run"] = True
+    if allow_overwrite:
+        summary["allow_overwrite"] = True
+    if stop_on_error:
+        summary["stop_on_error"] = True
+    if stopped:
+        summary["stopped_at"] = stopped_at
+    result["summary"] = summary
     return result
 
 
@@ -743,7 +735,6 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[dict]:
                         "addr": addr_str,
                         "start": hex(func.start_ea),
                         "end": hex(func.end_ea),
-                        "ok": True,
                     }
                 )
             else:
@@ -776,7 +767,7 @@ def define_code(items: list[DefineOp] | DefineOp) -> list[dict]:
             length = ida_ua.create_insn(ea)
             if length > 0:
                 results.append(
-                    {"addr": addr_str, "ea": hex(ea), "length": length, "ok": True}
+                    {"addr": addr_str, "ea": hex(ea), "length": length}
                 )
             else:
                 results.append(
@@ -825,7 +816,6 @@ def undefine(items: list[UndefineOp] | UndefineOp) -> list[dict]:
                         "addr": addr_str,
                         "start": hex(start_ea),
                         "size": nbytes,
-                        "ok": True,
                     }
                 )
             else:

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, TypedDict
 import ast
 import io
 import sys
@@ -96,6 +96,12 @@ def _make_exec_globals() -> dict:
     }
 
 
+class PythonExecResult(TypedDict):
+    result: str
+    stdout: str
+    stderr: str
+
+
 # ============================================================================
 # Python Evaluation
 # ============================================================================
@@ -106,7 +112,7 @@ def _make_exec_globals() -> dict:
 @unsafe
 def py_eval(
     code: Annotated[str, "Python code"],
-) -> dict:
+) -> PythonExecResult:
     """Execute Python in IDA context and return result/stdout/stderr."""
     # Capture stdout/stderr
     stdout_capture = io.StringIO()
@@ -198,7 +204,7 @@ def py_eval(
 @unsafe
 def py_exec_file(
     file_path: Annotated[str, "Absolute path to a Python script to execute"],
-) -> dict:
+) -> PythonExecResult:
     """Execute a Python script file in IDA context and return stdout/stderr.
 
     Unlike py_eval, this runs the entire file with exec() using a single shared
@@ -219,6 +225,8 @@ def py_exec_file(
 
         exec_globals = _make_exec_globals()
         exec_globals["__file__"] = file_path
+        exec_globals["__name__"] = "__main__"
+        exec_globals["__package__"] = None
 
         with open(file_path, "r", encoding="utf-8") as f:
             code = f.read()

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 import ast
 import io
+import os
 import sys
 import idaapi
 import idc
@@ -184,6 +185,64 @@ def py_eval(
         return {
             "result": "",
             "stdout": "",
+            "stderr": traceback.format_exc(),
+        }
+    finally:
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+
+
+@tool
+@idasync
+@unsafe
+def py_exec_file(
+    file_path: Annotated[str, "Absolute path to a Python script to execute"],
+) -> dict:
+    """Execute a Python script file in IDA context and return stdout/stderr.
+
+    Unlike py_eval, this runs the entire file with exec() using a single shared
+    globals dict (no locals split), so top-level definitions are visible to all
+    code in the script. Handles large scripts that would be unwieldy as inline code.
+    """
+    if not os.path.isfile(file_path):
+        return {"result": "", "stdout": "", "stderr": f"File not found: {file_path}"}
+
+    stdout_capture = io.StringIO()
+    stderr_capture = io.StringIO()
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+
+    try:
+        sys.stdout = stdout_capture
+        sys.stderr = stderr_capture
+
+        exec_globals = _make_exec_globals()
+        exec_globals["__file__"] = file_path
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            code = f.read()
+
+        exec(compile(code, file_path, "exec"), exec_globals)
+
+        stdout_text = stdout_capture.getvalue()
+        stderr_text = stderr_capture.getvalue()
+
+        result_value = ""
+        if "result" in exec_globals and exec_globals["result"] is not None:
+            result_value = str(exec_globals["result"])
+
+        return {
+            "result": result_value,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
+        }
+
+    except Exception:
+        import traceback
+
+        return {
+            "result": "",
+            "stdout": stdout_capture.getvalue(),
             "stderr": traceback.format_exc(),
         }
     finally:

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -24,6 +24,77 @@ from .sync import idasync
 from .utils import parse_address, get_function
 
 # ============================================================================
+# Shared execution context
+# ============================================================================
+
+
+def _make_exec_globals() -> dict:
+    """Build an execution context with all IDA modules available."""
+    def lazy_import(module_name):
+        try:
+            return __import__(module_name)
+        except Exception:
+            return None
+
+    return {
+        "__builtins__": __builtins__,
+        "idaapi": idaapi,
+        "idc": idc,
+        "idautils": lazy_import("idautils"),
+        "ida_allins": lazy_import("ida_allins"),
+        "ida_auto": lazy_import("ida_auto"),
+        "ida_bitrange": lazy_import("ida_bitrange"),
+        "ida_bytes": ida_bytes,
+        "ida_dbg": ida_dbg,
+        "ida_dirtree": lazy_import("ida_dirtree"),
+        "ida_diskio": lazy_import("ida_diskio"),
+        "ida_entry": ida_entry,
+        "ida_expr": lazy_import("ida_expr"),
+        "ida_fixup": lazy_import("ida_fixup"),
+        "ida_fpro": lazy_import("ida_fpro"),
+        "ida_frame": ida_frame,
+        "ida_funcs": ida_funcs,
+        "ida_gdl": lazy_import("ida_gdl"),
+        "ida_graph": lazy_import("ida_graph"),
+        "ida_hexrays": ida_hexrays,
+        "ida_ida": ida_ida,
+        "ida_idd": lazy_import("ida_idd"),
+        "ida_idp": lazy_import("ida_idp"),
+        "ida_ieee": lazy_import("ida_ieee"),
+        "ida_kernwin": ida_kernwin,
+        "ida_libfuncs": lazy_import("ida_libfuncs"),
+        "ida_lines": ida_lines,
+        "ida_loader": lazy_import("ida_loader"),
+        "ida_merge": lazy_import("ida_merge"),
+        "ida_mergemod": lazy_import("ida_mergemod"),
+        "ida_moves": lazy_import("ida_moves"),
+        "ida_nalt": ida_nalt,
+        "ida_name": ida_name,
+        "ida_netnode": lazy_import("ida_netnode"),
+        "ida_offset": lazy_import("ida_offset"),
+        "ida_pro": lazy_import("ida_pro"),
+        "ida_problems": lazy_import("ida_problems"),
+        "ida_range": lazy_import("ida_range"),
+        "ida_regfinder": lazy_import("ida_regfinder"),
+        "ida_registry": lazy_import("ida_registry"),
+        "ida_search": lazy_import("ida_search"),
+        "ida_segment": ida_segment,
+        "ida_segregs": lazy_import("ida_segregs"),
+        "ida_srclang": lazy_import("ida_srclang"),
+        "ida_strlist": lazy_import("ida_strlist"),
+        "ida_struct": lazy_import("ida_struct"),
+        "ida_tryblks": lazy_import("ida_tryblks"),
+        "ida_typeinf": ida_typeinf,
+        "ida_ua": lazy_import("ida_ua"),
+        "ida_undo": lazy_import("ida_undo"),
+        "ida_xref": ida_xref,
+        "ida_enum": lazy_import("ida_enum"),
+        "parse_address": parse_address,
+        "get_function": get_function,
+    }
+
+
+# ============================================================================
 # Python Evaluation
 # ============================================================================
 
@@ -45,69 +116,7 @@ def py_eval(
         sys.stdout = stdout_capture
         sys.stderr = stderr_capture
 
-        # Create execution context with IDA modules (lazy import to avoid errors)
-        def lazy_import(module_name):
-            try:
-                return __import__(module_name)
-            except Exception:
-                return None
-
-        exec_globals = {
-            "__builtins__": __builtins__,
-            "idaapi": idaapi,
-            "idc": idc,
-            "idautils": lazy_import("idautils"),
-            "ida_allins": lazy_import("ida_allins"),
-            "ida_auto": lazy_import("ida_auto"),
-            "ida_bitrange": lazy_import("ida_bitrange"),
-            "ida_bytes": ida_bytes,
-            "ida_dbg": ida_dbg,
-            "ida_dirtree": lazy_import("ida_dirtree"),
-            "ida_diskio": lazy_import("ida_diskio"),
-            "ida_entry": ida_entry,
-            "ida_expr": lazy_import("ida_expr"),
-            "ida_fixup": lazy_import("ida_fixup"),
-            "ida_fpro": lazy_import("ida_fpro"),
-            "ida_frame": ida_frame,
-            "ida_funcs": ida_funcs,
-            "ida_gdl": lazy_import("ida_gdl"),
-            "ida_graph": lazy_import("ida_graph"),
-            "ida_hexrays": ida_hexrays,
-            "ida_ida": ida_ida,
-            "ida_idd": lazy_import("ida_idd"),
-            "ida_idp": lazy_import("ida_idp"),
-            "ida_ieee": lazy_import("ida_ieee"),
-            "ida_kernwin": ida_kernwin,
-            "ida_libfuncs": lazy_import("ida_libfuncs"),
-            "ida_lines": ida_lines,
-            "ida_loader": lazy_import("ida_loader"),
-            "ida_merge": lazy_import("ida_merge"),
-            "ida_mergemod": lazy_import("ida_mergemod"),
-            "ida_moves": lazy_import("ida_moves"),
-            "ida_nalt": ida_nalt,
-            "ida_name": ida_name,
-            "ida_netnode": lazy_import("ida_netnode"),
-            "ida_offset": lazy_import("ida_offset"),
-            "ida_pro": lazy_import("ida_pro"),
-            "ida_problems": lazy_import("ida_problems"),
-            "ida_range": lazy_import("ida_range"),
-            "ida_regfinder": lazy_import("ida_regfinder"),
-            "ida_registry": lazy_import("ida_registry"),
-            "ida_search": lazy_import("ida_search"),
-            "ida_segment": ida_segment,
-            "ida_segregs": lazy_import("ida_segregs"),
-            "ida_srclang": lazy_import("ida_srclang"),
-            "ida_strlist": lazy_import("ida_strlist"),
-            "ida_struct": lazy_import("ida_struct"),
-            "ida_tryblks": lazy_import("ida_tryblks"),
-            "ida_typeinf": ida_typeinf,
-            "ida_ua": lazy_import("ida_ua"),
-            "ida_undo": lazy_import("ida_undo"),
-            "ida_xref": ida_xref,
-            "ida_enum": lazy_import("ida_enum"),
-            "parse_address": parse_address,
-            "get_function": get_function,
-        }
+        exec_globals = _make_exec_globals()
 
         result_value = None
         exec_locals = {}

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -1,7 +1,6 @@
 from typing import Annotated
 import ast
 import io
-import os
 import sys
 import idaapi
 import idc
@@ -19,6 +18,8 @@ import ida_name
 import ida_segment
 import ida_typeinf
 import ida_xref
+
+import os
 
 from .rpc import tool, unsafe
 from .sync import idasync

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -4,7 +4,7 @@ This module provides batch operations for managing stack frame variables,
 including reading, creating, and deleting stack variables in functions.
 """
 
-from typing import Annotated
+from typing import Annotated, NotRequired, TypedDict
 import ida_typeinf
 import ida_frame
 import idaapi
@@ -18,8 +18,21 @@ from .utils import (
     get_type_by_name,
     StackVarDecl,
     StackVarDelete,
+    StackFrameVariable,
     get_stack_frame_variables_internal,
 )
+
+
+class StackFrameResult(TypedDict):
+    addr: str
+    vars: list[StackFrameVariable] | None
+    error: NotRequired[str]
+
+
+class StackMutationResult(TypedDict):
+    addr: str
+    name: str
+    error: NotRequired[str]
 
 
 # ============================================================================
@@ -29,7 +42,9 @@ from .utils import (
 
 @tool
 @idasync
-def stack_frame(addrs: Annotated[list[str] | str, "Address(es)"]) -> list[dict]:
+def stack_frame(
+    addrs: Annotated[list[str] | str, "Address(es)"]
+) -> list[StackFrameResult]:
     """Return stack variables for function address(es)."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -49,7 +64,7 @@ def stack_frame(addrs: Annotated[list[str] | str, "Address(es)"]) -> list[dict]:
 @idasync
 def declare_stack(
     items: list[StackVarDecl] | StackVarDecl,
-):
+) -> list[StackMutationResult]:
     """Create stack variables from typed stack declarations."""
     items = normalize_dict_list(items)
     results = []
@@ -94,7 +109,7 @@ def declare_stack(
 @idasync
 def delete_stack(
     items: list[StackVarDelete] | StackVarDelete,
-):
+) -> list[StackMutationResult]:
     """Delete stack variables by name or offset."""
 
     items = normalize_dict_list(items)

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -83,7 +83,7 @@ def declare_stack(
                 )
                 continue
 
-            results.append({"addr": fn_addr, "name": var_name, "ok": True})
+            results.append({"addr": fn_addr, "name": var_name})
         except Exception as e:
             results.append({"addr": fn_addr, "name": var_name, "error": str(e)})
 
@@ -160,7 +160,7 @@ def delete_stack(
                 )
                 continue
 
-            results.append({"addr": fn_addr, "name": var_name, "ok": True})
+            results.append({"addr": fn_addr, "name": var_name})
         except Exception as e:
             results.append({"addr": fn_addr, "name": var_name, "error": str(e)})
 

--- a/src/ida_pro_mcp/ida_mcp/api_survey.py
+++ b/src/ida_pro_mcp/ida_mcp/api_survey.py
@@ -5,13 +5,95 @@ from __future__ import annotations
 import hashlib
 import re
 from itertools import islice
-from typing import Annotated
+from typing import Annotated, TypedDict
 
 from .rpc import tool
 from .sync import idasync, tool_timeout
 from . import compat
 from .api_core import _get_strings_cache
 from .utils import get_image_size
+
+
+class SurveyMetadata(TypedDict):
+    path: str
+    module: str
+    arch: str
+    base_address: str
+    image_size: str
+    md5: str
+    sha256: str
+
+
+class SurveySegmentInfo(TypedDict):
+    name: str
+    start: str
+    end: str
+    size: str
+    permissions: str
+
+
+class SurveyEntrypoint(TypedDict):
+    addr: str
+    name: str
+    ordinal: int
+
+
+class SurveyStatistics(TypedDict):
+    total_functions: int
+    named_functions: int
+    library_functions: int
+    unnamed_functions: int
+    total_strings: int
+    total_segments: int
+
+
+class SurveyInterestingString(TypedDict):
+    addr: str
+    string: str
+    xref_count: int
+
+
+class SurveyInterestingFunction(TypedDict):
+    addr: str
+    name: str
+    size: int
+    xref_count: int
+    callee_count: int
+    type: str
+
+
+class SurveyImportEntry(TypedDict):
+    addr: str
+    name: str
+    module: str
+
+
+class SurveyImportsByCategory(TypedDict):
+    crypto: list[SurveyImportEntry]
+    network: list[SurveyImportEntry]
+    file_io: list[SurveyImportEntry]
+    process: list[SurveyImportEntry]
+    registry: list[SurveyImportEntry]
+    other: list[SurveyImportEntry]
+
+
+class SurveyCallGraphSummary(TypedDict):
+    total_edges: int
+    max_depth_estimate: None
+    root_functions: list[str]
+    leaf_functions_count: int
+
+
+class SurveyBinaryResult(TypedDict, total=False):
+    metadata: SurveyMetadata
+    statistics: SurveyStatistics
+    segments: list[SurveySegmentInfo]
+    entrypoints: list[SurveyEntrypoint]
+    interesting_strings: list[SurveyInterestingString]
+    interesting_functions: list[SurveyInterestingFunction]
+    imports_by_category: SurveyImportsByCategory
+    call_graph_summary: SurveyCallGraphSummary
+    _note: str
 
 # Max functions to iterate for xref counting on large binaries.
 _MAX_FUNC_ITER = 10_000
@@ -315,7 +397,7 @@ def _build_call_graph_summary(func_eas: list[int]) -> dict:
 @tool_timeout(120.0)
 def survey_binary(
     detail_level: Annotated[str, "Detail level: 'standard' or 'minimal'"] = "standard",
-) -> dict:
+) -> SurveyBinaryResult:
     """Compact binary overview: metadata, segments, entries, stats, top strings/functions, imports by category, call graph."""
     import idautils
 

--- a/src/ida_pro_mcp/ida_mcp/api_survey.py
+++ b/src/ida_pro_mcp/ida_mcp/api_survey.py
@@ -316,13 +316,7 @@ def _build_call_graph_summary(func_eas: list[int]) -> dict:
 def survey_binary(
     detail_level: Annotated[str, "Detail level: 'standard' or 'minimal'"] = "standard",
 ) -> dict:
-    """Get a compact overview of the binary in one call. Returns file metadata,
-    segment layout, entry points, statistics, top 15 strings and functions ranked
-    by xref count (functions include classification: thunk/wrapper/leaf/dispatcher/
-    complex), imports by category, and call graph summary. Use this as your FIRST
-    tool call when starting analysis. Do not call list_funcs, imports, or find_regex
-    separately for triage — this returns all of that. Use detail_level='minimal'
-    for binaries with >10k functions."""
+    """Compact binary overview: metadata, segments, entries, stats, top strings/functions, imports by category, call graph."""
     import idautils
 
     minimal = detail_level == "minimal"

--- a/src/ida_pro_mcp/ida_mcp/api_survey.py
+++ b/src/ida_pro_mcp/ida_mcp/api_survey.py
@@ -398,7 +398,13 @@ def _build_call_graph_summary(func_eas: list[int]) -> dict:
 def survey_binary(
     detail_level: Annotated[str, "Detail level: 'standard' or 'minimal'"] = "standard",
 ) -> SurveyBinaryResult:
-    """Compact binary overview: metadata, segments, entries, stats, top strings/functions, imports by category, call graph."""
+    """Get a compact overview of the binary in one call. Returns file metadata,
+    segment layout, entry points, statistics, top 15 strings and functions ranked
+    by xref count (functions include classification: thunk/wrapper/leaf/dispatcher/
+    complex), imports by category, and call graph summary. Use this as your FIRST
+    tool call when starting analysis. Do not call list_funcs, imports, or find_regex
+    separately for triage — this returns all of that. Use detail_level='minimal'
+    for binaries with >10k functions."""
     import idautils
 
     minimal = detail_level == "minimal"

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -54,7 +54,7 @@ def declare_type(
                     {"decl": decl, "error": f"Failed to parse:\n{pretty_messages}"}
                 )
             else:
-                results.append({"decl": decl, "ok": True})
+                results.append({"decl": decl})
         except Exception as e:
             results.append({"decl": decl, "error": str(e)})
 
@@ -129,7 +129,7 @@ def enum_upsert(
                     existing_value = idc.get_enum_member_value(existing_member_id)
                     if existing_enum == enum_id and existing_value == value:
                         member_results.append(
-                            {"name": member_name, "value": value, "ok": True, "skipped": True}
+                            {"name": member_name, "value": value, "skipped": True}
                         )
                         skipped_count += 1
                         continue
@@ -151,7 +151,7 @@ def enum_upsert(
                     existing_name = idc.get_enum_member_name(existing_const) or ""
                     if existing_name == member_name:
                         member_results.append(
-                            {"name": member_name, "value": value, "ok": True, "skipped": True}
+                            {"name": member_name, "value": value, "skipped": True}
                         )
                         skipped_count += 1
                         continue
@@ -172,24 +172,24 @@ def enum_upsert(
                     )
                     conflict_count += 1
                     continue
-                member_results.append({"name": member_name, "value": value, "ok": True, "created": True})
+                member_results.append({"name": member_name, "value": value, "created": True})
                 created_count += 1
 
-            results.append(
-                {
-                    "name": enum_name,
-                    "enum_id": hex(enum_id),
-                    "ok": conflict_count == 0,
-                    "created": created,
-                    "bitfield": bitfield,
-                    "members": member_results,
-                    "summary": {
-                        "created": created_count,
-                        "skipped": skipped_count,
-                        "conflicts": conflict_count,
-                    },
-                }
-            )
+            result_dict: dict = {
+                "name": enum_name,
+                "enum_id": hex(enum_id),
+                "created": created,
+                "bitfield": bitfield,
+                "members": member_results,
+                "summary": {
+                    "created": created_count,
+                    "skipped": skipped_count,
+                    "conflicts": conflict_count,
+                },
+            }
+            if conflict_count > 0:
+                result_dict["error"] = f"{conflict_count} member conflict(s)"
+            results.append(result_dict)
         except Exception as exc:
             results.append({"name": enum_name, "error": str(exc)})
 
@@ -607,7 +607,6 @@ def type_query(
                 "data": page["data"],
                 "next_offset": page["next_offset"],
                 "total": len(output_rows),
-                "error": None,
             }
         )
 
@@ -667,7 +666,6 @@ def type_inspect(
                 "is_udt": tif.is_udt(),
                 "members": None,
                 "member_count": 0,
-                "error": None,
             }
 
             if include_members and tif.is_udt():
@@ -829,12 +827,10 @@ def _apply_type_edit(edit: dict) -> dict:
             signature = str(edit.get("signature") or type_text).strip()
             tif = _parse_function_tinfo(signature)
             ok = ida_typeinf.apply_tinfo(func.start_ea, tif, ida_typeinf.PT_SIL)
-            return {
-                "edit": edit,
-                "kind": kind,
-                "ok": ok,
-                "error": None if ok else "Failed to apply function type",
-            }
+            result = {"edit": edit, "kind": kind, "ok": ok}
+            if not ok:
+                result["error"] = "Failed to apply function type"
+            return result
 
         if kind == "global":
             ea = idaapi.BADADDR
@@ -853,12 +849,10 @@ def _apply_type_edit(edit: dict) -> dict:
 
             tif = _parse_type_tinfo(type_text)
             ok = ida_typeinf.apply_tinfo(ea, tif, ida_typeinf.PT_SIL)
-            return {
-                "edit": edit,
-                "kind": kind,
-                "ok": ok,
-                "error": None if ok else "Failed to apply global type",
-            }
+            result = {"edit": edit, "kind": kind, "ok": ok}
+            if not ok:
+                result["error"] = "Failed to apply global type"
+            return result
 
         if kind == "local":
             addr_text = str(edit.get("addr", "")).strip()
@@ -875,12 +869,10 @@ def _apply_type_edit(edit: dict) -> dict:
             new_tif = _parse_type_tinfo(type_text)
             modifier = my_modifier_t(var_name, new_tif)
             ok = ida_hexrays.modify_user_lvars(func.start_ea, modifier)
-            return {
-                "edit": edit,
-                "kind": kind,
-                "ok": ok,
-                "error": None if ok else "Failed to apply local variable type",
-            }
+            result = {"edit": edit, "kind": kind, "ok": ok}
+            if not ok:
+                result["error"] = "Failed to apply local variable type"
+            return result
 
         if kind == "stack":
             addr_text = str(edit.get("addr", "")).strip()
@@ -913,12 +905,10 @@ def _apply_type_edit(edit: dict) -> dict:
 
             tif = _parse_type_tinfo(type_text)
             ok = ida_frame.set_frame_member_type(func, offset, tif)
-            return {
-                "edit": edit,
-                "kind": kind,
-                "ok": ok,
-                "error": None if ok else "Failed to set stack member type",
-            }
+            result = {"edit": edit, "kind": kind, "ok": ok}
+            if not ok:
+                result["error"] = "Failed to set stack member type"
+            return result
 
         return {"edit": edit, "kind": kind, "error": f"Unknown kind: {kind}"}
     except Exception as e:

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any, TypedDict
 
 import idc
 import ida_typeinf
@@ -29,6 +29,123 @@ from .utils import (
 from . import compat
 
 
+class DeclareTypeResult(TypedDict, total=False):
+    decl: str
+    error: str
+
+
+class EnumMemberUpsertResult(TypedDict, total=False):
+    name: str
+    value: int
+    created: bool
+    skipped: bool
+    error: str
+
+
+class EnumUpsertSummaryResult(TypedDict):
+    created: int
+    skipped: int
+    conflicts: int
+
+
+class EnumUpsertResult(TypedDict, total=False):
+    name: str
+    enum_id: str
+    created: bool
+    bitfield: bool
+    members: list[EnumMemberUpsertResult]
+    summary: EnumUpsertSummaryResult
+    error: str
+
+
+class StructMemberValueResult(TypedDict):
+    offset: str
+    type: str
+    name: str
+    size: int
+    value: str
+
+
+class ReadStructResult(TypedDict, total=False):
+    addr: str | None
+    struct: str | None
+    members: list[StructMemberValueResult] | None
+    error: str
+
+
+class SearchStructResult(TypedDict):
+    name: str
+    size: int
+    cardinality: int
+    is_union: bool
+    ordinal: int
+
+
+class TypeCatalogMemberResult(TypedDict):
+    name: str
+    offset: str
+    size: int
+    type: str
+
+
+class TypeCatalogRow(TypedDict, total=False):
+    ordinal: int
+    name: str
+    size: int
+    kind: str
+    declaration: str
+    member_count: int
+    members: list[TypeCatalogMemberResult]
+    members_truncated: bool
+    related_count: int
+    related_types: list[str]
+    related_truncated: bool
+
+
+class TypeQueryResult(TypedDict):
+    kind: str
+    data: list[TypeCatalogRow]
+    next_offset: int | None
+    total: int
+
+
+class TypeInspectResult(TypedDict, total=False):
+    name: str
+    exists: bool
+    declaration: str
+    size: int
+    is_func: bool
+    is_ptr: bool
+    is_enum: bool
+    is_udt: bool
+    members: list[TypeCatalogMemberResult] | None
+    member_count: int
+    error: str
+
+
+class SetTypeResult(TypedDict, total=False):
+    edit: dict[str, Any]
+    kind: str
+    ok: bool
+    error: str
+
+
+class TypeApplyBatchResult(TypedDict):
+    ok: bool
+    applied: int
+    failed: int
+    stopped: bool
+    results: list[SetTypeResult]
+
+
+class InferTypeResult(TypedDict, total=False):
+    addr: str
+    inferred_type: str | None
+    method: str | None
+    confidence: str
+    error: str
+
+
 # ============================================================================
 # Type Declaration
 # ============================================================================
@@ -38,7 +155,7 @@ from . import compat
 @idasync
 def declare_type(
     decls: Annotated[list[str] | str, "C type declarations"],
-) -> list[dict]:
+) -> list[DeclareTypeResult]:
     """Declare C type definitions in local type library."""
     decls = normalize_list_input(decls)
     results = []
@@ -68,7 +185,7 @@ def enum_upsert(
         list[EnumUpsert] | EnumUpsert,
         "Create enums if missing and upsert enum members without destructive replacement",
     ],
-) -> list[dict]:
+) -> list[EnumUpsertResult]:
     """Create or extend local enums in an idempotent way."""
     queries = normalize_dict_list(queries)
     results = []
@@ -214,7 +331,9 @@ def _parse_enum_value(value: int | str | None) -> int:
 
 @tool
 @idasync
-def read_struct(queries: list[StructRead] | StructRead) -> list[dict]:
+def read_struct(
+    queries: list[StructRead] | StructRead,
+) -> list[ReadStructResult]:
     """Read struct fields from memory at address; auto-detect type when possible."""
 
     queries = normalize_dict_list(queries)
@@ -369,7 +488,7 @@ def search_structs(
     filter: Annotated[
         str, "Case-insensitive substring to search for in structure names"
     ],
-) -> list[dict]:
+) -> list[SearchStructResult]:
     """Search local structs/unions by name pattern."""
     results = []
     limit = compat.get_ordinal_limit()
@@ -459,7 +578,7 @@ def type_query(
         list[TypeQuery] | TypeQuery | str,
         "Type catalog query with filtering, pagination, and optional relationships",
     ],
-) -> list[dict]:
+) -> list[TypeQueryResult]:
     """Query local types with structured filters/projection-friendly output."""
     queries = normalize_dict_list(
         queries,
@@ -620,7 +739,7 @@ def type_inspect(
         list[TypeInspectQuery] | TypeInspectQuery | str,
         "Inspect named types and optionally include member layout",
     ],
-) -> list[dict]:
+) -> list[TypeInspectResult]:
     """Inspect named types (size/kind/declaration/members)."""
     queries = normalize_dict_list(
         queries,
@@ -811,7 +930,7 @@ def _infer_type_edit_kind(edit: dict) -> str:
     return "global"
 
 
-def _apply_type_edit(edit: dict) -> dict:
+def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
     try:
         kind = _infer_type_edit_kind(edit)
         type_text = _resolve_type_text(edit)
@@ -917,7 +1036,7 @@ def _apply_type_edit(edit: dict) -> dict:
 
 @tool
 @idasync
-def set_type(edits: list[TypeEdit] | TypeEdit) -> list[dict]:
+def set_type(edits: list[TypeEdit] | TypeEdit) -> list[SetTypeResult]:
     """Apply types (function/global/local/stack)"""
     normalized_edits = normalize_dict_list(edits, _parse_addr_type_shorthand)
     return [_apply_type_edit(edit) for edit in normalized_edits]
@@ -930,7 +1049,7 @@ def type_apply_batch(
         TypeApplyBatch | list[TypeEdit] | TypeEdit,
         "Batch type edits with optional stop_on_error behavior",
     ],
-) -> dict:
+) -> TypeApplyBatchResult:
     """Apply multiple type edits and return aggregate status."""
     if isinstance(batch, dict) and "edits" in batch:
         normalized_edits = normalize_dict_list(
@@ -963,7 +1082,7 @@ def type_apply_batch(
 @idasync
 def infer_types(
     addrs: Annotated[list[str] | str, "Addresses to infer types for"],
-) -> list[dict]:
+) -> list[InferTypeResult]:
     """Infer and apply likely types at target addresses."""
     addrs = normalize_list_input(addrs)
     results = []

--- a/src/ida_pro_mcp/ida_mcp/discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/discovery.py
@@ -1,0 +1,76 @@
+"""Instance discovery for IDA Pro MCP.
+
+IDA plugin instances register themselves by writing JSON files to
+{ida_user_dir}/mcp/instances/. The MCP server discovers running
+instances by reading these files and validating PID liveness.
+"""
+
+import datetime
+import json
+import os
+import sys
+import tempfile
+from typing import TypedDict
+
+
+class InstanceInfo(TypedDict):
+    host: str
+    port: int
+    pid: int
+    binary: str
+    idb_path: str
+    started_at: str
+
+
+def _get_ida_user_dir() -> str:
+    if sys.platform == "win32":
+        return os.path.join(os.environ["APPDATA"], "Hex-Rays", "IDA Pro")
+    return os.path.join(os.path.expanduser("~"), ".idapro")
+
+
+def get_instances_dir() -> str:
+    return os.path.join(_get_ida_user_dir(), "mcp", "instances")
+
+
+def _instance_file_path(port: int) -> str:
+    return os.path.join(get_instances_dir(), f"instance_{port}.json")
+
+
+def register_instance(
+    host: str, port: int, pid: int, binary: str, idb_path: str
+) -> str:
+    """Write an instance registration file. Returns the file path."""
+    info: InstanceInfo = {
+        "host": host,
+        "port": port,
+        "pid": pid,
+        "binary": binary,
+        "idb_path": idb_path,
+        "started_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    instances_dir = get_instances_dir()
+    os.makedirs(instances_dir, exist_ok=True)
+    file_path = _instance_file_path(port)
+    # Atomic write
+    fd, tmp_path = tempfile.mkstemp(dir=instances_dir, prefix=".tmp_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(info, f, indent=2)
+        os.replace(tmp_path, file_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return file_path
+
+
+def unregister_instance(port: int) -> bool:
+    """Remove an instance registration file. Returns True if removed."""
+    file_path = _instance_file_path(port)
+    try:
+        os.unlink(file_path)
+        return True
+    except OSError:
+        return False

--- a/src/ida_pro_mcp/ida_mcp/discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/discovery.py
@@ -6,8 +6,10 @@ instances by reading these files and validating PID liveness.
 """
 
 import datetime
+import glob
 import json
 import os
+import socket
 import sys
 import tempfile
 from typing import TypedDict
@@ -74,3 +76,86 @@ def unregister_instance(port: int) -> bool:
         return True
     except OSError:
         return False
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Check if a process is still running."""
+    if sys.platform == "win32":
+        import ctypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        handle = ctypes.windll.kernel32.OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        if handle:
+            ctypes.windll.kernel32.CloseHandle(handle)
+            return True
+        return False
+    else:
+        try:
+            os.kill(pid, 0)
+            return True
+        except PermissionError:
+            return True  # Process exists, we lack permission
+        except ProcessLookupError:
+            return False
+        except OSError:
+            return False
+
+
+def probe_instance(host: str, port: int, timeout: float = 2.0) -> bool:
+    """Check if an instance is reachable via TCP."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (OSError, socket.timeout):
+        return False
+
+
+def discover_instances() -> list[InstanceInfo]:
+    """Scan for registered instances, cleaning up stale entries."""
+    instances_dir = get_instances_dir()
+    if not os.path.isdir(instances_dir):
+        return []
+
+    result: list[InstanceInfo] = []
+    pattern = os.path.join(instances_dir, "instance_*.json")
+    for file_path in glob.glob(pattern):
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                info: InstanceInfo = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            try:
+                os.unlink(file_path)
+            except OSError:
+                pass
+            continue
+
+        if not all(k in info for k in ("host", "port", "pid")):
+            try:
+                os.unlink(file_path)
+            except OSError:
+                pass
+            continue
+
+        if not is_pid_alive(info["pid"]):
+            try:
+                os.unlink(file_path)
+            except OSError:
+                pass
+            continue
+
+        # Secondary check: verify the instance is actually listening.
+        # Catches PID reuse (Windows can recycle PIDs quickly) and
+        # cases where the process is alive but the server crashed.
+        if not probe_instance(info["host"], info["port"], timeout=1.0):
+            try:
+                os.unlink(file_path)
+            except OSError:
+                pass
+            continue
+
+        result.append(info)
+
+    result.sort(key=lambda x: x.get("started_at", ""))
+    return result

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -47,6 +47,7 @@ def handle_enabled_tools(registry: McpRpcRegistry, config_key: str):
     enabled_tools = config_json_get(
         config_key, {name: True for name in original_tools.keys()}
     )
+    original_enabled_tools = enabled_tools.copy()
     new_tools = [name for name in original_tools if name not in enabled_tools]
 
     removed_tools = [name for name in enabled_tools if name not in original_tools]
@@ -56,6 +57,17 @@ def handle_enabled_tools(registry: McpRpcRegistry, config_key: str):
 
     if new_tools:
         enabled_tools.update({name: True for name in new_tools})
+
+    try:
+        from .api_discovery import _LOCAL_TOOL_NAMES as PROTECTED_TOOLS
+    except Exception:
+        PROTECTED_TOOLS = set()
+
+    for name in PROTECTED_TOOLS:
+        if name in original_tools:
+            enabled_tools[name] = True
+
+    if enabled_tools != original_enabled_tools:
         config_json_set(config_key, enabled_tools)
 
     registry.methods = {

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -384,8 +384,11 @@ input[type="submit"]:hover {
         config_json_set("cors_policy", cors_policy)
         self.update_cors_policy()
 
-        # Update the server's tools
+        # Update the server's tools (discovery tools cannot be disabled)
+        from .api_discovery import _LOCAL_TOOL_NAMES as PROTECTED_TOOLS
         enabled_tools = {name: name in postvars for name in ORIGINAL_TOOLS.keys()}
+        for name in PROTECTED_TOOLS:
+            enabled_tools[name] = True
         self.mcp_server.tools.methods = {
             name: func
             for name, func in ORIGINAL_TOOLS.items()

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -104,7 +104,13 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
                 return
             self._handle_config_post()
         else:
-            super().do_POST()
+            # Mark proxied requests so _redirecting_dispatch won't re-proxy (loop prevention)
+            from .api_discovery import PROXY_HEADER, set_request_proxied
+            set_request_proxied(self.headers.get(PROXY_HEADER) == "1")
+            try:
+                super().do_POST()
+            finally:
+                set_request_proxied(False)
 
     def do_GET(self):
         """Handles GET requests."""

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
@@ -24,6 +24,7 @@ class _SavedState:
         self._lhost = api_discovery._LOCAL_HOST
         self._lport = api_discovery._LOCAL_PORT
         self._proxied = api_discovery.is_request_proxied()
+        self._session = getattr(api_discovery.MCP_SERVER._transport_session_id, "data", None)
         return self
     def __exit__(self, *exc):
         api_discovery._redirect_host = self._host
@@ -31,6 +32,7 @@ class _SavedState:
         api_discovery._LOCAL_HOST = self._lhost
         api_discovery._LOCAL_PORT = self._lport
         api_discovery.set_request_proxied(self._proxied)
+        api_discovery.MCP_SERVER._transport_session_id.data = self._session
 
 
 def _make_jsonrpc(method, params=None, id=1):
@@ -132,6 +134,30 @@ def test_select_instance_unreachable_returns_error():
         assert result["success"] is False
         assert "not reachable" in result.get("error", "")
         assert api_discovery.get_redirect_target() is None
+
+
+@test()
+def test_select_instance_redirect_is_scoped_to_transport_session():
+    """Each MCP transport session should keep its own selected redirect target."""
+    with _SavedState():
+        original_probe = api_discovery.probe_instance
+        api_discovery.probe_instance = lambda host, port: True
+        try:
+            api_discovery.MCP_SERVER._transport_session_id.data = "http:session-a"
+            result_a = api_discovery.select_instance(port=11111, host="127.0.0.1")
+            assert result_a["success"] is True
+
+            api_discovery.MCP_SERVER._transport_session_id.data = "http:session-b"
+            result_b = api_discovery.select_instance(port=22222, host="127.0.0.1")
+            assert result_b["success"] is True
+
+            api_discovery.MCP_SERVER._transport_session_id.data = "http:session-a"
+            assert api_discovery.get_redirect_target() == ("127.0.0.1", 11111)
+
+            api_discovery.MCP_SERVER._transport_session_id.data = "http:session-b"
+            assert api_discovery.get_redirect_target() == ("127.0.0.1", 22222)
+        finally:
+            api_discovery.probe_instance = original_probe
 
 
 # ---------------------------------------------------------------------------

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
@@ -1,0 +1,309 @@
+"""Tests for the discovery API module (api_discovery.py).
+
+Tests dispatch routing decisions, loop prevention, select_instance state
+machine, tools/list merge logic, and IDB file discovery.
+"""
+
+import json
+import os
+import tempfile
+
+from ..framework import test
+from .. import api_discovery
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _SavedState:
+    """Context manager that snapshots and restores api_discovery globals."""
+    def __enter__(self):
+        self._host = api_discovery._redirect_host
+        self._port = api_discovery._redirect_port
+        self._lhost = api_discovery._LOCAL_HOST
+        self._lport = api_discovery._LOCAL_PORT
+        self._proxied = api_discovery.is_request_proxied()
+        return self
+    def __exit__(self, *exc):
+        api_discovery._redirect_host = self._host
+        api_discovery._redirect_port = self._port
+        api_discovery._LOCAL_HOST = self._lhost
+        api_discovery._LOCAL_PORT = self._lport
+        api_discovery.set_request_proxied(self._proxied)
+
+
+def _make_jsonrpc(method, params=None, id=1):
+    """Build a minimal JSON-RPC 2.0 request dict."""
+    req = {"jsonrpc": "2.0", "method": method, "id": id}
+    if params is not None:
+        req["params"] = params
+    return req
+
+
+def _is_local_registry_response(result):
+    """True if this looks like a response from the local JSON-RPC registry.
+
+    Local registry errors use standard JSON-RPC codes (-32601 method not found,
+    -32602 invalid params, etc.). Proxy errors use -32000. A successful result
+    has a "result" key. This lets us distinguish "went local" from "went proxy."
+    """
+    if result is None:
+        return False  # notification
+    if "result" in result:
+        return True
+    err = result.get("error", {})
+    # Standard JSON-RPC error codes from the local registry
+    return err.get("code", 0) in (-32600, -32601, -32602, -32603, -32700)
+
+
+def _is_proxy_error(result):
+    """True if this is a proxy failure response (code -32000)."""
+    if result is None:
+        return False
+    return result.get("error", {}).get("code") == -32000
+
+
+# ---------------------------------------------------------------------------
+# IDB file discovery
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_find_existing_idb_prefers_i64_over_idb():
+    """_find_existing_idb prefers .i64 over .idb when both exist."""
+    with tempfile.TemporaryDirectory() as tmp:
+        base = os.path.join(tmp, "sample")
+        binary = base + ".exe"
+        i64 = base + ".i64"
+        idb = base + ".idb"
+        for path in (binary, i64, idb):
+            with open(path, "w") as f:
+                f.write("")
+        assert api_discovery._find_existing_idb(binary) == i64
+
+
+@test()
+def test_find_existing_idb_returns_none_when_missing():
+    """_find_existing_idb returns None when no IDB exists."""
+    with tempfile.TemporaryDirectory() as tmp:
+        binary = os.path.join(tmp, "sample.exe")
+        with open(binary, "w") as f:
+            f.write("")
+        assert api_discovery._find_existing_idb(binary) is None
+
+
+# ---------------------------------------------------------------------------
+# select_instance state machine
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_select_instance_port_zero_resets_redirect():
+    """select_instance(port=0) clears redirect and returns success."""
+    with _SavedState():
+        api_discovery._redirect_host = "10.0.0.1"
+        api_discovery._redirect_port = 9999
+        result = api_discovery.select_instance(port=0)
+        assert result["success"] is True
+        assert api_discovery.get_redirect_target() is None
+
+
+@test()
+def test_select_instance_local_port_clears_redirect():
+    """Selecting the local instance's own port clears redirect."""
+    with _SavedState():
+        api_discovery.set_local_instance("127.0.0.1", 13337)
+        api_discovery._redirect_host = "10.0.0.1"
+        api_discovery._redirect_port = 9999
+        result = api_discovery.select_instance(port=13337, host="127.0.0.1")
+        assert result["success"] is True
+        assert "local" in result.get("message", "").lower()
+        assert api_discovery.get_redirect_target() is None
+
+
+@test()
+def test_select_instance_unreachable_returns_error():
+    """Selecting an unreachable port returns success=False without changing state."""
+    with _SavedState():
+        api_discovery._redirect_host = None
+        api_discovery._redirect_port = None
+        result = api_discovery.select_instance(port=1, host="127.0.0.1")
+        assert result["success"] is False
+        assert "not reachable" in result.get("error", "")
+        assert api_discovery.get_redirect_target() is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing — _redirecting_dispatch
+#
+# Strategy: the local JSON-RPC registry returns standard error codes
+# (-32601 method not found, -32602 invalid params). The proxy error path
+# returns -32000. We use this to distinguish which path was taken.
+# Redirect targets point at unreachable addresses so proxy attempts fail
+# fast rather than hang.
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_dispatch_no_redirect_goes_local():
+    """When no redirect is active, tools/call dispatches to the local registry."""
+    with _SavedState():
+        api_discovery._redirect_host = None
+        api_discovery._redirect_port = None
+        req = _make_jsonrpc("tools/call", {"name": "decompile", "arguments": {}})
+        result = api_discovery._redirecting_dispatch(req)
+        # Local registry returns -32602 (missing required 'addr' param),
+        # NOT -32000 (proxy error).
+        assert _is_local_registry_response(result), f"Expected local response, got: {result}"
+
+
+@test()
+def test_dispatch_initialize_always_local():
+    """initialize is always handled locally even when redirect is active."""
+    with _SavedState():
+        api_discovery._redirect_host = "10.0.0.99"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("initialize", {"capabilities": {}})
+        result = api_discovery._redirecting_dispatch(req)
+        # initialize hits the local registry (returns error for missing params,
+        # but it's a registry error, not a proxy error).
+        assert _is_local_registry_response(result), f"Expected local response, got: {result}"
+
+
+@test()
+def test_dispatch_notification_always_local():
+    """notifications/* are handled locally even when redirect is active.
+
+    Notifications have no id and return None from the registry. The key
+    assertion is that no ConnectionRefusedError is raised — the request
+    never touches the network.
+    """
+    with _SavedState():
+        api_discovery._redirect_host = "10.0.0.99"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("notifications/initialized")
+        req.pop("id")  # notifications have no id
+        result = api_discovery._redirecting_dispatch(req)
+        # Registry returns None for notifications (no response expected).
+        # If it had tried to proxy to 10.0.0.99:1, it would have raised.
+        assert result is None
+
+
+@test()
+def test_dispatch_local_tool_stays_local_when_redirecting():
+    """tools/call for list_instances dispatches locally even when redirect is active."""
+    with _SavedState():
+        api_discovery._redirect_host = "10.0.0.99"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("tools/call", {"name": "list_instances", "arguments": {}})
+        result = api_discovery._redirecting_dispatch(req)
+        # list_instances is a registered tool, so local dispatch succeeds.
+        assert "result" in result, f"Expected success result, got: {result}"
+        assert not _is_proxy_error(result)
+
+
+@test()
+def test_dispatch_non_local_tool_proxied_when_redirecting():
+    """tools/call for a non-local tool attempts to proxy when redirect is active."""
+    with _SavedState():
+        api_discovery._redirect_host = "127.0.0.1"
+        api_discovery._redirect_port = 1  # unreachable
+        req = _make_jsonrpc("tools/call", {"name": "decompile", "arguments": {"addr": "0x1000"}})
+        result = api_discovery._redirecting_dispatch(req)
+        # Proxy fails → -32000 error, not a local registry error
+        assert _is_proxy_error(result), f"Expected proxy error, got: {result}"
+        assert result["id"] == 1
+
+
+@test()
+def test_dispatch_loop_prevention_proxied_request_goes_local():
+    """When is_request_proxied() is True, dispatch goes local even with redirect active.
+
+    This prevents A->B->A proxy loops: if instance B receives a proxied request
+    from A, it must not follow its own redirect back to A.
+    """
+    with _SavedState():
+        api_discovery._redirect_host = "10.0.0.99"
+        api_discovery._redirect_port = 1
+        api_discovery.set_request_proxied(True)
+        req = _make_jsonrpc("tools/call", {"name": "decompile", "arguments": {}})
+        result = api_discovery._redirecting_dispatch(req)
+        assert _is_local_registry_response(result), f"Expected local response, got: {result}"
+        assert not _is_proxy_error(result)
+
+
+@test()
+def test_dispatch_proxy_error_preserves_request_id():
+    """When proxy fails, the JSON-RPC error response preserves the request id."""
+    with _SavedState():
+        api_discovery._redirect_host = "127.0.0.1"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("tools/call", {"name": "rename", "arguments": {}}, id=42)
+        result = api_discovery._redirecting_dispatch(req)
+        assert result["id"] == 42
+        assert _is_proxy_error(result)
+
+
+@test()
+def test_dispatch_proxy_notification_error_returns_none():
+    """When a proxied tools/call has no id (notification-style), proxy error returns None."""
+    with _SavedState():
+        api_discovery._redirect_host = "127.0.0.1"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("tools/call", {"name": "rename", "arguments": {}})
+        del req["id"]
+        result = api_discovery._redirecting_dispatch(req)
+        assert result is None
+
+
+@test()
+def test_dispatch_unknown_method_proxied_with_fallback():
+    """Non-tool methods (e.g. resources/list) proxy first; on failure, fall back to local."""
+    with _SavedState():
+        api_discovery._redirect_host = "127.0.0.1"
+        api_discovery._redirect_port = 1
+        req = _make_jsonrpc("resources/list", {})
+        result = api_discovery._redirecting_dispatch(req)
+        # Proxy to port 1 fails; fallback gives us a local registry response
+        assert _is_local_registry_response(result), f"Expected local fallback, got: {result}"
+        assert not _is_proxy_error(result)
+
+
+# ---------------------------------------------------------------------------
+# tools/list merge — deduplication of local tool names
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_dispatch_tools_list_returns_local_tools_when_redirect_unreachable():
+    """tools/list still returns local discovery tools when the redirect target is down."""
+    with _SavedState():
+        api_discovery._redirect_host = "127.0.0.1"
+        api_discovery._redirect_port = 1  # unreachable
+        req = _make_jsonrpc("tools/list", {})
+        result = api_discovery._redirecting_dispatch(req)
+        # Should still get a successful response with local tools
+        assert "result" in result, f"Expected result, got: {result}"
+        tools = result["result"].get("tools", [])
+        tool_names = {t["name"] for t in tools}
+        # The local discovery tools should always be present
+        assert "list_instances" in tool_names
+        assert "select_instance" in tool_names
+        assert "open_file" in tool_names
+
+
+@test()
+def test_dispatch_tools_list_without_redirect_returns_all_tools():
+    """tools/list without redirect returns the full local tool catalog."""
+    with _SavedState():
+        api_discovery._redirect_host = None
+        api_discovery._redirect_port = None
+        req = _make_jsonrpc("tools/list", {})
+        result = api_discovery._redirecting_dispatch(req)
+        assert "result" in result
+        tools = result["result"].get("tools", [])
+        tool_names = {t["name"] for t in tools}
+        # Should have all registered IDA tools + discovery tools
+        assert "list_instances" in tool_names
+        assert "decompile" in tool_names

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
@@ -21,6 +21,7 @@ class _SavedState:
     def __enter__(self):
         self._host = api_discovery._redirect_host
         self._port = api_discovery._redirect_port
+        self._targets = api_discovery._redirect_targets.copy()
         self._lhost = api_discovery._LOCAL_HOST
         self._lport = api_discovery._LOCAL_PORT
         self._proxied = api_discovery.is_request_proxied()
@@ -29,6 +30,8 @@ class _SavedState:
     def __exit__(self, *exc):
         api_discovery._redirect_host = self._host
         api_discovery._redirect_port = self._port
+        api_discovery._redirect_targets.clear()
+        api_discovery._redirect_targets.update(self._targets)
         api_discovery._LOCAL_HOST = self._lhost
         api_discovery._LOCAL_PORT = self._lport
         api_discovery.set_request_proxied(self._proxied)
@@ -64,6 +67,45 @@ def _is_proxy_error(result):
     if result is None:
         return False
     return result.get("error", {}).get("code") == -32000
+
+
+class _FakeHttpResponse:
+    status = 200
+    reason = "OK"
+
+    def __init__(self, body=b'{"jsonrpc":"2.0","result":{}}'):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+
+class _RecordingConnection:
+    calls = []
+
+    def __init__(self, host, port, timeout=None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def request(self, method, path, body=None, headers=None):
+        self.__class__.calls.append(
+            {
+                "host": self.host,
+                "port": self.port,
+                "timeout": self.timeout,
+                "method": method,
+                "path": path,
+                "body": body,
+                "headers": headers or {},
+            }
+        )
+
+    def getresponse(self):
+        return _FakeHttpResponse()
+
+    def close(self):
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +311,27 @@ def test_dispatch_proxy_error_preserves_request_id():
         result = api_discovery._redirecting_dispatch(req)
         assert result["id"] == 42
         assert _is_proxy_error(result)
+
+
+@test()
+def test_api_discovery_proxy_to_instance_forwards_session_and_extensions():
+    """Forwarded proxy requests should preserve MCP session and enabled extensions."""
+    with _SavedState():
+        original_conn = api_discovery.http.client.HTTPConnection
+        _RecordingConnection.calls = []
+        api_discovery.http.client.HTTPConnection = _RecordingConnection
+        api_discovery.MCP_SERVER._transport_session_id.data = "http:session-123"
+        api_discovery.MCP_SERVER._enabled_extensions.data = {"dbg"}
+        try:
+            api_discovery.proxy_to_instance("127.0.0.1", 13337, b"{}")
+            assert len(_RecordingConnection.calls) == 1
+            call = _RecordingConnection.calls[0]
+            assert call["path"] == "/mcp?ext=dbg"
+            assert call["headers"].get(api_discovery.PROXY_HEADER) == "1"
+            assert call["headers"].get("Mcp-Session-Id") == "session-123"
+        finally:
+            api_discovery.http.client.HTTPConnection = original_conn
+            api_discovery.MCP_SERVER._enabled_extensions.data = set()
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_memory.py
@@ -71,7 +71,7 @@ def test_get_int_reads_common_integer_sizes():
         entry = result[0]
         assert entry["addr"] == start_addr
         assert entry["ty"].startswith(ty)
-        assert entry["error"] is None
+        assert "error" not in entry
         assert isinstance(entry["value"], int)
 
 
@@ -124,7 +124,7 @@ def test_patch_roundtrip_changes_and_restores_bytes():
 
     try:
         patched = patch({"addr": data_addr, "data": replacement})[0]
-        assert patched.get("ok") is True
+        assert "error" not in patched
         changed = get_bytes({"addr": data_addr, "size": 4})[0]
         assert _plain_hex_bytes(changed["data"]) == replacement.replace(" ", "")
     finally:
@@ -168,14 +168,14 @@ def test_put_int_roundtrip_u64():
         written = put_int(
             {"addr": CRACKME_DSO_HANDLE, "ty": "u64", "value": hex(new_value)}
         )[0]
-        assert written["ok"] is True
+        assert "error" not in written
         roundtrip = get_int({"addr": CRACKME_DSO_HANDLE, "ty": "u64"})[0]
         assert roundtrip["value"] == new_value
     finally:
         restore = put_int(
             {"addr": CRACKME_DSO_HANDLE, "ty": "u64", "value": hex(original_value)}
         )[0]
-        assert restore["ok"] is True
+        assert "error" not in restore
 
     restored = get_int({"addr": CRACKME_DSO_HANDLE, "ty": "u64"})[0]
     assert restored["value"] == original_value
@@ -194,7 +194,7 @@ def test_put_int_roundtrip_signed_i16():
 
     try:
         written = put_int({"addr": data_addr, "ty": "i16", "value": "-2"})[0]
-        assert written["ok"] is True
+        assert "error" not in written
         roundtrip = get_int({"addr": data_addr, "ty": "i16"})[0]
         assert roundtrip["value"] == -2
     finally:
@@ -212,7 +212,7 @@ def test_put_int_overflow():
         skip_test("binary has no data segment")
 
     result = put_int({"addr": data_addr, "ty": "u8", "value": "0x100"})[0]
-    assert result["ok"] is False
+    assert "error" in result
     assert_error(result, contains="does not fit")
 
 
@@ -220,7 +220,7 @@ def test_put_int_overflow():
 def test_put_int_invalid_address():
     """put_int rejects writes to unmapped addresses."""
     result = put_int({"addr": get_unmapped_address(), "ty": "u32", "value": "1"})[0]
-    assert result["ok"] is False
+    assert "error" in result
     assert_error(result, contains="Address not mapped")
 
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
@@ -54,7 +54,7 @@ def test_set_comment_roundtrip():
     try:
         result = set_comments({"addr": fn_addr, "comment": "__TEST_COMMENT__"})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
         assert idaapi.get_cmt(int(fn_addr, 16), False) == "__TEST_COMMENT__"
     finally:
         set_comments({"addr": fn_addr, "comment": original})
@@ -73,7 +73,7 @@ def test_set_comment_interior_address_roundtrip():
     try:
         result = set_comments({"addr": hex(addr), "comment": "__INNER_COMMENT__"})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
         assert idaapi.get_cmt(addr, False) == "__INNER_COMMENT__"
     finally:
         set_comments({"addr": hex(addr), "comment": original})
@@ -97,10 +97,10 @@ def test_append_comment_function_dedupes():
         first = append_comments({"addr": fn_addr, "comment": "__APPEND_COMMENT__", "scope": "func"})
         second = append_comments({"addr": fn_addr, "comment": "__APPEND_COMMENT__", "scope": "func"})
         assert_is_list(first, min_length=1)
-        assert first[0].get("ok") is True
+        assert "error" not in first[0]
         assert first[0].get("appended") is True
         assert_is_list(second, min_length=1)
-        assert second[0].get("ok") is True
+        assert "error" not in second[0]
         assert second[0].get("skipped") is True
         updated = idc.get_func_cmt(addr, False) or ""
         assert updated.count("__APPEND_COMMENT__") == 1
@@ -123,7 +123,7 @@ def test_append_comment_function_dedupe_does_not_skip_substrings():
         idc.set_func_cmt(addr, "foobar", False)
         result = append_comments({"addr": fn_addr, "comment": "foo", "scope": "func"})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
         assert result[0].get("appended") is True
         updated = idc.get_func_cmt(addr, False) or ""
         assert updated == "foobar\nfoo"
@@ -141,7 +141,7 @@ def test_append_comment_interior_address_roundtrip():
     try:
         result = append_comments({"addr": hex(addr), "comment": "__LINE_APPEND__", "scope": "line"})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
         assert "__LINE_APPEND__" in (idaapi.get_cmt(addr, False) or "")
     finally:
         idaapi.set_cmt(addr, original, False)
@@ -165,7 +165,7 @@ def test_patch_asm_roundtrip():
     try:
         result = patch_asm({"addr": CRACKME_PATCH_ASM_ADDR, "asm": "sub eax, eax"})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
         changed = get_bytes({"addr": CRACKME_PATCH_ASM_ADDR, "size": 2})[0]
         assert _plain_hex_bytes(changed["data"]) == "29c0"
         assert _plain_hex_bytes(changed["data"]) != original_plain
@@ -198,7 +198,7 @@ def test_rename_function_roundtrip():
 
     try:
         result = rename({"func": [{"addr": fn_addr, "name": new_name}]})
-        assert result["func"][0]["ok"] is True
+        assert "error" not in result["func"][0]
         renamed = lookup_funcs(fn_addr)[0]
         assert renamed["fn"]["name"] == new_name
     finally:
@@ -222,7 +222,7 @@ def test_rename_data_roundtrip():
 
     try:
         result = rename({"data": [{"old": original_name, "new": new_name}]})
-        assert result["data"][0]["ok"] is True
+        assert "error" not in result["data"][0]
         assert idaapi.get_name_ea(idaapi.BADADDR, new_name) == int(addr, 16)
     finally:
         rename({"data": [{"old": new_name, "new": original_name}]})
@@ -280,7 +280,7 @@ def test_rename_local_error_handling():
         }
     )
     assert "local" in result
-    assert result["local"][0]["ok"] is False
+    assert "error" in result["local"][0]
     assert_error(result["local"][0])
 
 
@@ -296,7 +296,7 @@ def test_rename_local_roundtrip():
             }
         )
         assert (
-            result["local"][0].get("ok") is True
+            "error" not in result["local"][0]
             or result["local"][0].get("error") == "Rename failed"
         )
     finally:
@@ -322,7 +322,7 @@ def test_rename_stack_roundtrip():
                 ]
             }
         )
-        assert result["stack"][0]["ok"] is True
+        assert "error" not in result["stack"][0]
         names = {var["name"] for var in stack_frame(TYPED_FIXTURE_USE_WRAPPER)[0]["vars"]}
         assert "rhs_stack" in names
     finally:
@@ -339,7 +339,7 @@ def test_rename_stack_roundtrip():
 def test_rename_stack_missing_member_error():
     """rename(stack=...) reports missing frame members explicitly."""
     result = rename({"stack": [{"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "nope", "new": "x"}]})
-    assert result["stack"][0]["ok"] is False
+    assert "error" in result["stack"][0]
     assert_error(result["stack"][0], contains="not found")
 
 
@@ -349,7 +349,7 @@ def test_rename_stack_special_member_error():
     result = rename(
         {"stack": [{"func_addr": TYPED_FIXTURE_USE_WRAPPER, "old": "__return_address", "new": "x"}]}
     )
-    assert result["stack"][0]["ok"] is False
+    assert "error" in result["stack"][0]
     assert_error(result["stack"][0], contains="Special frame member")
 
 
@@ -357,7 +357,7 @@ def test_rename_stack_special_member_error():
 def test_rename_local_missing_function_error():
     """rename(local=...) reports missing functions cleanly."""
     result = rename({"local": [{"func_addr": "0xdeadbeef", "old": "a", "new": "b"}]})
-    assert result["local"][0]["ok"] is False
+    assert "error" in result["local"][0]
     assert_error(result["local"][0], contains="No function found")
 
 
@@ -375,14 +375,14 @@ def test_define_undefine_func_roundtrip():
 
     try:
         undef_result = undefine({"addr": hex(start_ea), "end": hex(end_ea)})[0]
-        assert undef_result.get("ok") is True
+        assert "error" not in undef_result
         assert idaapi.get_func(start_ea) is None
 
         define_result = define_func({"addr": hex(start_ea), "end": hex(end_ea)})[0]
-        if define_result.get("ok") is not True:
+        if "error" in define_result:
             define_code({"addr": hex(start_ea)})
             define_result = define_func({"addr": hex(start_ea), "end": hex(end_ea)})[0]
-        assert define_result.get("ok") is True
+        assert "error" not in define_result
         recreated = idaapi.get_func(start_ea)
         assert recreated is not None
         assert recreated.start_ea == start_ea
@@ -425,7 +425,7 @@ def test_define_code_on_existing_code():
     result = define_code({"addr": fn_addr})[0]
     assert result["addr"] == fn_addr
     assert (
-        result.get("ok") is True
+        "error" not in result
         or result.get("length") is not None
         or result.get("error") is not None
     )
@@ -435,7 +435,7 @@ def test_define_code_on_existing_code():
 def test_rename_global_missing_symbol():
     """rename(data=...) reports a clean error when the global symbol is absent."""
     result = rename({"data": [{"old": "nope", "new": "x"}]})
-    assert result["data"][0]["ok"] is False
+    assert "error" in result["data"][0]
     assert_error(result["data"][0], contains="not found")
 
 
@@ -444,7 +444,7 @@ def test_rename_function_same_name_is_stable():
     """rename(func=...) with the same current name succeeds or stays stable without crashing."""
     result = rename({"func": [{"addr": "0x1013ef0", "name": "main"}]})
     entry = result["func"][0]
-    assert entry.get("ok") is True or entry.get("error") is None
+    assert "error" not in entry
 
 
 @test(binary="typed_fixture.elf")
@@ -460,7 +460,7 @@ def test_undefine_single_byte_and_restore():
 
     try:
         result = undefine({"addr": hex(addr), "size": 1})[0]
-        assert result.get("ok") is True
+        assert "error" not in result
     finally:
         define_code({"addr": hex(addr)})
         if idaapi.get_func(addr) is None:
@@ -481,7 +481,7 @@ def test_undefine_batch():
     try:
         result = undefine([{"addr": hex(start_ea), "end": hex(end_ea)}])
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is True
+        assert "error" not in result[0]
     finally:
         if idaapi.get_func(start_ea) is None:
             define_code({"addr": hex(start_ea)})

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_python.py
@@ -1,7 +1,22 @@
 """Tests for api_python API functions."""
 
+import contextlib
+import os
+import tempfile
+
 from ..framework import test
-from ..api_python import py_eval
+from ..api_python import py_eval, py_exec_file
+
+
+@contextlib.contextmanager
+def _tmp_script(content):
+    """Write content to a temporary .py file, yield its path, then clean up."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as f:
+        f.write(content)
+    try:
+        yield f.name
+    finally:
+        os.unlink(f.name)
 
 
 @test()
@@ -55,3 +70,48 @@ def test_py_eval_exception_goes_to_stderr():
     assert result["result"] == ""
     assert result["stdout"] == ""
     assert "RuntimeError: boom" in result["stderr"]
+
+
+@test()
+def test_py_exec_file_runs_script_and_captures_stdout():
+    """py_exec_file executes a script file and captures its stdout."""
+    with _tmp_script('print("hello from file")\nresult = 42\n') as path:
+        out = py_exec_file(path)
+        assert out["stdout"] == "hello from file\n"
+        assert out["result"] == "42"
+        assert out["stderr"] == ""
+
+
+@test()
+def test_py_exec_file_returns_error_for_missing_file():
+    """py_exec_file returns an error in stderr when the file doesn't exist."""
+    out = py_exec_file("/nonexistent/script.py")
+    assert "File not found" in out["stderr"]
+    assert out["result"] == ""
+
+
+@test()
+def test_py_exec_file_shared_globals():
+    """py_exec_file uses shared globals so top-level defs are visible later in the script."""
+    with _tmp_script('def add(a, b): return a + b\nresult = add(3, 4)\n') as path:
+        out = py_exec_file(path)
+        assert out["result"] == "7"
+        assert out["stderr"] == ""
+
+
+@test()
+def test_py_exec_file_sets_dunder_file():
+    """py_exec_file sets __file__ in the execution context."""
+    with _tmp_script('result = __file__\n') as path:
+        out = py_exec_file(path)
+        assert out["result"] == path
+        assert out["stderr"] == ""
+
+
+@test()
+def test_py_exec_file_captures_exception_in_stderr():
+    """py_exec_file captures script exceptions in stderr."""
+    with _tmp_script('raise ValueError("script error")\n') as path:
+        out = py_exec_file(path)
+        assert "ValueError: script error" in out["stderr"]
+        assert out["result"] == ""

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_python.py
@@ -109,6 +109,16 @@ def test_py_exec_file_sets_dunder_file():
 
 
 @test()
+def test_py_exec_file_sets_dunder_name_main():
+    """py_exec_file should execute scripts as __main__ so __name__ guards run."""
+    script = 'if __name__ == "__main__":\n    result = "ran"\nelse:\n    result = __name__\n'
+    with _tmp_script(script) as path:
+        out = py_exec_file(path)
+        assert out["result"] == "ran"
+        assert out["stderr"] == ""
+
+
+@test()
 def test_py_exec_file_captures_exception_in_stderr():
     """py_exec_file captures script exceptions in stderr."""
     with _tmp_script('raise ValueError("script error")\n') as path:

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
@@ -59,7 +59,7 @@ def test_declare_delete_stack_roundtrip():
         declared = declare_stack(
             {"addr": CRACKME_MAIN, "name": TEST_STACK_VAR, "offset": -8, "ty": "int"}
         )[0]
-        assert declared.get("ok") is True
+        assert "error" not in declared
         during = stack_frame(CRACKME_MAIN)[0]
         assert TEST_STACK_VAR in [var["name"] for var in during["vars"]]
     finally:
@@ -91,7 +91,7 @@ def test_stack_frame_batch_on_typed_fixture():
     result = stack_frame(["0x1013dc0", "0x1069f80"])
     assert_is_list(result, min_length=2)
     assert result[0]["addr"] == "0x1013dc0"
-    assert result[0].get("error") in (None, "")
+    assert "error" not in result[0]
     assert any(var["name"] == "rhs_handle" for var in result[0]["vars"])
     assert result[1]["addr"] == "0x1069f80"
     assert result[1].get("vars") is None
@@ -109,7 +109,7 @@ def test_declare_delete_stack_roundtrip_typed_fixture():
         declared = declare_stack(
             {"addr": "0x1013dc0", "name": TEST_STACK_VAR, "offset": -0x18, "ty": "int"}
         )[0]
-        assert declared.get("ok") is True
+        assert "error" not in declared
         during = stack_frame("0x1013dc0")[0]
         assert TEST_STACK_VAR in [var["name"] for var in during["vars"]]
     finally:

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
@@ -56,7 +56,7 @@ def create_test_struct(name: str = TEST_STRUCT_NAME) -> bool:
         return False
 
     entry = result[0]
-    if entry.get("ok"):
+    if "error" not in entry:
         return True
 
     search_result = search_structs(name)
@@ -229,7 +229,6 @@ def test_type_query():
     assert "data" in page
     assert "next_offset" in page
     assert "total" in page
-    assert "error" in page
     if page["data"]:
         assert "ordinal" in page["data"][0]
         assert "name" in page["data"][0]
@@ -249,7 +248,7 @@ def test_type_inspect():
     r = result[0]
     assert r["name"] == tname
     assert r["exists"] is True
-    assert r["error"] is None
+    assert "error" not in r
     assert r.get("member_count", 0) >= 0
 
 
@@ -290,11 +289,11 @@ def test_enum_upsert_creates_and_replays_idempotently():
             }
         )
         assert_is_list(first, min_length=1)
-        assert first[0].get("ok") is True
+        assert "error" not in first[0]
         assert first[0].get("created") is True
         assert first[0]["summary"]["created"] == 2
         assert_is_list(second, min_length=1)
-        assert second[0].get("ok") is True
+        assert "error" not in second[0]
         assert second[0]["summary"]["skipped"] == 2
     finally:
         enum_id = idc.get_enum(enum_name)
@@ -316,7 +315,7 @@ def test_enum_upsert_reports_conflicting_member_value():
         enum_upsert({"name": enum_name, "members": [{"name": "__TEST_ENUM_CONFLICT__", "value": 1}]})
         result = enum_upsert({"name": enum_name, "members": [{"name": "__TEST_ENUM_CONFLICT__", "value": 2}]})
         assert_is_list(result, min_length=1)
-        assert result[0].get("ok") is False
+        assert "error" in result[0]
         assert result[0]["summary"]["conflicts"] == 1
         assert "conflict" in (result[0]["members"][0].get("error") or "").lower()
     finally:
@@ -332,7 +331,7 @@ def test_set_type_applies_named_global_type():
     assert_is_list(result, min_length=1)
     entry = result[0]
     assert entry["edit"]["addr"] == CRACKME_DSO_HANDLE
-    assert entry.get("ok") is True or entry.get("error") is None
+    assert "error" not in entry
 
 
 @test()
@@ -348,7 +347,7 @@ def test_set_type_global_by_name_branch():
     """set_type(kind=global) can resolve the target by symbol name instead of address."""
     result = set_type({"name": "g_point", "ty": "Point", "kind": "global"})
     assert_is_list(result, min_length=1)
-    assert result[0].get("ok") is True
+    assert "error" not in result[0]
 
 
 @test(binary="typed_fixture.elf")
@@ -363,7 +362,7 @@ def test_set_type_global_invalid_type_name():
 def test_type_apply_batch():
     """type_apply_batch applies edits and returns summary counters"""
     result = type_apply_batch({"edits": [{"addr": _require_any_function(), "ty": TYPE_APPLY_SIGNATURE}]})
-    assert "ok" in result
+    assert "error" not in result
     assert "applied" in result
     assert "failed" in result
     assert "stopped" in result
@@ -437,7 +436,7 @@ def test_set_type_function_branch():
         }
     )
     assert_is_list(result, min_length=1)
-    assert result[0].get("ok") is True
+    assert "error" not in result[0]
 
 
 @test(binary="typed_fixture.elf")
@@ -467,7 +466,7 @@ def test_set_type_local_branch():
     )
     assert_is_list(result, min_length=1)
     assert (
-        result[0].get("ok") is True
+        "error" not in result[0]
         or result[0].get("error") == "Failed to apply local variable type"
     )
 
@@ -499,7 +498,7 @@ def test_set_type_stack_branch():
         }
     )
     assert_is_list(result, min_length=1)
-    assert result[0].get("ok") is True
+    assert "error" not in result[0]
 
 
 @test(binary="typed_fixture.elf")

--- a/src/ida_pro_mcp/ida_mcp/tests/test_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_discovery.py
@@ -1,0 +1,191 @@
+"""Tests for the instance discovery module (discovery.py).
+
+Exercises registration/unregistration round-trips, the multi-stage staleness
+pipeline in discover_instances, and sort-order guarantees that server.py
+relies on for auto-selection.
+"""
+
+import contextlib
+import json
+import os
+import tempfile
+
+from ..framework import test
+from .. import discovery
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@contextlib.contextmanager
+def _tmp_instances_dir():
+    """Redirect discovery.get_instances_dir to a temp directory, then restore."""
+    with tempfile.TemporaryDirectory() as tmp:
+        original = discovery.get_instances_dir
+        discovery.get_instances_dir = lambda: tmp
+        try:
+            yield tmp
+        finally:
+            discovery.get_instances_dir = original
+
+
+@contextlib.contextmanager
+def _patched_instances_dir(path):
+    """Redirect discovery.get_instances_dir to an arbitrary path, then restore."""
+    original = discovery.get_instances_dir
+    discovery.get_instances_dir = lambda: path
+    try:
+        yield
+    finally:
+        discovery.get_instances_dir = original
+
+
+# ---------------------------------------------------------------------------
+# Registration / unregistration round-trips
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_register_unregister_roundtrip():
+    """register_instance creates a file that unregister_instance removes."""
+    with _tmp_instances_dir():
+        path = discovery.register_instance("127.0.0.1", 55000, os.getpid(), "test.exe", "/tmp/test.idb")
+        assert os.path.isfile(path)
+        assert discovery.unregister_instance(55000) is True
+        assert not os.path.isfile(path)
+
+
+@test()
+def test_unregister_nonexistent_returns_false():
+    """unregister_instance returns False when no registration exists."""
+    with _tmp_instances_dir():
+        assert discovery.unregister_instance(99999) is False
+
+
+@test()
+def test_register_overwrites_existing():
+    """Re-registering the same port atomically replaces the previous entry."""
+    with _tmp_instances_dir() as tmp:
+        discovery.register_instance("127.0.0.1", 55005, os.getpid(), "first.bin", "first.idb")
+        discovery.register_instance("127.0.0.1", 55005, os.getpid(), "second.bin", "second.idb")
+        with open(os.path.join(tmp, "instance_55005.json"), "r") as f:
+            data = json.load(f)
+        assert data["binary"] == "second.bin"
+
+
+# ---------------------------------------------------------------------------
+# PID liveness
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_is_pid_alive_current_process():
+    """is_pid_alive returns True for the current (known-alive) process."""
+    assert discovery.is_pid_alive(os.getpid()) is True
+
+
+@test()
+def test_is_pid_alive_bogus_pid():
+    """is_pid_alive returns False for a PID that cannot exist."""
+    assert discovery.is_pid_alive(4_000_000) is False
+
+
+# ---------------------------------------------------------------------------
+# TCP probe
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_probe_instance_unreachable():
+    """probe_instance returns False for a port nothing listens on."""
+    assert discovery.probe_instance("127.0.0.1", 1, timeout=0.5) is False
+
+
+# ---------------------------------------------------------------------------
+# discover_instances staleness pipeline
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_discover_cleans_up_dead_pid():
+    """discover_instances removes registrations whose PID is dead."""
+    with _tmp_instances_dir() as tmp:
+        discovery.register_instance("127.0.0.1", 55002, 4_000_000, "dead.bin", "dead.idb")
+        assert discovery.discover_instances() == []
+        assert not os.path.isfile(os.path.join(tmp, "instance_55002.json"))
+
+
+@test()
+def test_discover_cleans_up_corrupt_json():
+    """discover_instances removes files with invalid JSON."""
+    with _tmp_instances_dir() as tmp:
+        corrupt_path = os.path.join(tmp, "instance_55003.json")
+        with open(corrupt_path, "w") as f:
+            f.write("not json{{{")
+        assert discovery.discover_instances() == []
+        assert not os.path.isfile(corrupt_path)
+
+
+@test()
+def test_discover_cleans_up_missing_required_keys():
+    """discover_instances removes registrations missing host/port/pid."""
+    with _tmp_instances_dir() as tmp:
+        path = os.path.join(tmp, "instance_55004.json")
+        with open(path, "w") as f:
+            json.dump({"host": "127.0.0.1"}, f)
+        assert discovery.discover_instances() == []
+        assert not os.path.isfile(path)
+
+
+@test()
+def test_discover_skips_alive_pid_unreachable_port():
+    """discover_instances removes entries with alive PID but no listening server."""
+    with _tmp_instances_dir():
+        discovery.register_instance("127.0.0.1", 1, os.getpid(), "no_server.bin", "no.idb")
+        assert discovery.discover_instances() == []
+
+
+@test()
+def test_discover_returns_empty_when_dir_missing():
+    """discover_instances returns [] when the instances directory doesn't exist."""
+    with _patched_instances_dir("/nonexistent/path/that/does/not/exist"):
+        assert discovery.discover_instances() == []
+
+
+# ---------------------------------------------------------------------------
+# Sort order — server.py picks instances[0], so order matters
+# ---------------------------------------------------------------------------
+
+
+@test()
+def test_discover_sorts_by_started_at():
+    """discover_instances returns results sorted by started_at (oldest first).
+
+    server.py auto-selects instances[0], so this order determines which
+    instance gets auto-connected when multiple are running.
+    """
+    with _tmp_instances_dir() as tmp:
+        for port, ts in [(55010, "2025-01-01T00:00:02+00:00"),
+                         (55011, "2025-01-01T00:00:01+00:00")]:
+            info = {
+                "host": "127.0.0.1", "port": port,
+                "pid": os.getpid(), "binary": f"bin_{port}",
+                "idb_path": f"/tmp/{port}.idb", "started_at": ts,
+            }
+            path = os.path.join(tmp, f"instance_{port}.json")
+            with open(path, "w") as f:
+                json.dump(info, f)
+
+        orig_pid = discovery.is_pid_alive
+        orig_probe = discovery.probe_instance
+        discovery.is_pid_alive = lambda pid: True
+        discovery.probe_instance = lambda h, p, timeout=2.0: True
+        try:
+            results = discovery.discover_instances()
+            assert len(results) == 2
+            assert results[0]["port"] == 55011
+            assert results[1]["port"] == 55010
+        finally:
+            discovery.is_pid_alive = orig_pid
+            discovery.probe_instance = orig_probe

--- a/src/ida_pro_mcp/ida_mcp/tests/test_framework_helpers.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_framework_helpers.py
@@ -23,14 +23,12 @@ def test_framework_assert_shape_with_optional_and_list_of():
     value = {
         "addr": "0x123e",
         "items": [{"name": "main"}, {"name": "check_pw"}],
-        "error": None,
     }
     assert_shape(
         value,
         {
             "addr": is_hex_address,
             "items": list_of({"name": str}, min_length=2),
-            "error": optional(str),
         },
     )
 
@@ -64,7 +62,7 @@ def test_framework_assert_typed_dict():
 @test(binary="crackme03.elf")
 def test_framework_assert_ok_and_error_helpers():
     """assert_ok and assert_error capture success/error response contracts."""
-    assert_ok({"error": None, "value": 1}, "value")
+    assert_ok({"value": 1}, "value")
     assert_error({"error": "boom"}, contains="boom")
 
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_http.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_http.py
@@ -1,0 +1,37 @@
+"""Tests for HTTP/config helpers that are not tied to a specific binary."""
+
+from ..framework import test
+from .. import http as http_mod
+
+
+class _FakeRegistry:
+    def __init__(self, methods):
+        self.methods = methods
+
+
+@test()
+def test_handle_enabled_tools_keeps_discovery_tools_enabled_on_startup():
+    """Saved config should not be able to hide discovery/recovery tools at startup."""
+    original_get = http_mod.config_json_get
+    original_set = http_mod.config_json_set
+    registry = _FakeRegistry(
+        {
+            "list_instances": object(),
+            "select_instance": object(),
+            "open_file": object(),
+            "decompile": object(),
+        }
+    )
+    saved_config = {name: False for name in registry.methods}
+
+    http_mod.config_json_get = lambda key, default: saved_config.copy()
+    http_mod.config_json_set = lambda key, value: None
+    try:
+        http_mod.handle_enabled_tools(registry, "enabled_tools")
+        assert "list_instances" in registry.methods
+        assert "select_instance" in registry.methods
+        assert "open_file" in registry.methods
+        assert "decompile" not in registry.methods
+    finally:
+        http_mod.config_json_get = original_get
+        http_mod.config_json_set = original_set

--- a/src/ida_pro_mcp/ida_mcp/tests/test_idalib_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_idalib_server.py
@@ -1,0 +1,61 @@
+"""Tests for idalib_server integration helpers."""
+
+import os
+import sys
+
+from ..framework import test
+
+try:
+    from ida_pro_mcp import idalib_server
+except ImportError:
+    _parent = os.path.join(os.path.dirname(__file__), "..", "..")
+    sys.path.insert(0, _parent)
+    try:
+        import idalib_server  # type: ignore
+    finally:
+        sys.path.remove(_parent)
+
+
+@test()
+def test_idalib_health_treats_successful_server_health_as_ready():
+    """idalib_health should report ready when server_health returns a healthy payload."""
+    original_get_session_manager = idalib_server.get_session_manager
+    original_resolve_context = idalib_server._resolve_effective_context_id
+    original_context_fields = idalib_server._context_response_fields
+    original_server_health = idalib_server.server_health
+
+    class _FakeSession:
+        def to_dict(self):
+            return {"session_id": "sess-1", "input_path": "dummy.bin"}
+
+    class _FakeManager:
+        def get_context_session(self, context_id):
+            return _FakeSession()
+
+        def activate_context(self, context_id):
+            self.activated = context_id
+
+    idalib_server.get_session_manager = lambda: _FakeManager()
+    idalib_server._resolve_effective_context_id = lambda: "ctx-1"
+    idalib_server._context_response_fields = lambda context_id: {
+        "context_id": context_id,
+        "transport_context_id": None,
+        "isolated_contexts": False,
+    }
+    idalib_server.server_health = lambda: {
+        "uptime_sec": 1.0,
+        "module": "dummy.bin",
+        "imagebase": "0x0",
+        "strings_cache_ready": True,
+        "hexrays_ready": False,
+    }
+    try:
+        result = idalib_server.idalib_health()
+        assert result["error"] is None
+        assert result["health"]["module"] == "dummy.bin"
+        assert result["ready"] is True
+    finally:
+        idalib_server.get_session_manager = original_get_session_manager
+        idalib_server._resolve_effective_context_id = original_resolve_context
+        idalib_server._context_response_fields = original_context_fields
+        idalib_server.server_health = original_server_health

--- a/src/ida_pro_mcp/ida_mcp/tests/test_installer.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_installer.py
@@ -1,0 +1,74 @@
+"""Tests for installer config generation changes.
+
+Verifies that stdio configs no longer hardcode --ida-rpc (enabling auto-discovery)
+while HTTP/SSE configs still embed the RPC address.
+"""
+
+import os
+import sys
+
+from ..framework import test
+
+try:
+    from ida_pro_mcp.installer import generate_mcp_config, SERVER_SCRIPT, IDA_HOST, IDA_PORT
+except ImportError:
+    _parent = os.path.join(os.path.dirname(__file__), "..", "..")
+    sys.path.insert(0, _parent)
+    try:
+        from installer import generate_mcp_config, SERVER_SCRIPT, IDA_HOST, IDA_PORT
+    finally:
+        sys.path.remove(_parent)
+
+
+@test()
+def test_stdio_config_has_no_ida_rpc_arg():
+    """stdio config omits --ida-rpc so the server can auto-discover instances."""
+    config = generate_mcp_config(client_name="Generic", transport="stdio")
+    args = config.get("args", [])
+    combined = " ".join(str(a) for a in ([config.get("command", "")] + args))
+    assert "--ida-rpc" not in combined
+
+
+@test()
+def test_stdio_config_contains_server_script():
+    """stdio config includes the server script path."""
+    config = generate_mcp_config(client_name="Generic", transport="stdio")
+    args = config.get("args", [])
+    assert SERVER_SCRIPT in args
+
+
+@test()
+def test_streamable_http_config_contains_url():
+    """streamable-http config generates a URL with the current host:port."""
+    config = generate_mcp_config(client_name="Generic", transport="streamable-http")
+    assert "url" in config
+    assert f"{IDA_HOST}:{IDA_PORT}" in config["url"]
+
+
+@test()
+def test_sse_config_claude_preserves_sse_path():
+    """Claude SSE config preserves /sse path; Generic forces /mcp."""
+    claude_config = generate_mcp_config(client_name="Claude", transport="sse")
+    assert claude_config["url"].endswith("/sse")
+    assert claude_config["type"] == "sse"
+    generic_config = generate_mcp_config(client_name="Generic", transport="sse")
+    assert generic_config["url"].endswith("/mcp")
+
+
+@test()
+def test_opencode_stdio_uses_command_list():
+    """Opencode stdio config uses a command list (no separate args key)."""
+    config = generate_mcp_config(client_name="Opencode", transport="stdio")
+    assert "command" in config
+    assert isinstance(config["command"], list)
+    assert SERVER_SCRIPT in config["command"]
+    combined = " ".join(str(a) for a in config["command"])
+    assert "--ida-rpc" not in combined
+
+
+@test()
+def test_claude_http_config_has_type_field():
+    """Claude client HTTP config includes the 'type' field."""
+    config = generate_mcp_config(client_name="Claude", transport="streamable-http")
+    assert config.get("type") == "http"
+    assert "url" in config

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -17,16 +17,59 @@ except ImportError:
         sys.path.remove(_parent)
 
 
+class _FakeHttpResponse:
+    status = 200
+    reason = "OK"
+
+    def __init__(self, body=b'{"jsonrpc":"2.0","result":{}}'):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+
+class _RecordingConnection:
+    calls = []
+
+    def __init__(self, host, port, timeout=None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def request(self, method, path, body=None, headers=None):
+        self.__class__.calls.append(
+            {
+                "host": self.host,
+                "port": self.port,
+                "timeout": self.timeout,
+                "method": method,
+                "path": path,
+                "body": body,
+                "headers": headers or {},
+            }
+        )
+
+    def getresponse(self):
+        return _FakeHttpResponse()
+
+    def close(self):
+        pass
+
+
 @contextlib.contextmanager
 def _saved_target():
     """Preserve the currently selected IDA target across assertions."""
     old_host = server.IDA_HOST
     old_port = server.IDA_PORT
+    old_session = getattr(server.mcp._transport_session_id, "data", None)
+    old_exts = getattr(server.mcp._enabled_extensions, "data", set())
     try:
         yield
     finally:
         server.IDA_HOST = old_host
         server.IDA_PORT = old_port
+        server.mcp._transport_session_id.data = old_session
+        server.mcp._enabled_extensions.data = old_exts
 
 
 @test()
@@ -42,3 +85,22 @@ def test_tools_list_keeps_discovery_and_launch_tools_when_ida_unreachable():
         assert "select_instance" in tool_names
         assert "list_instances" in tool_names
         assert "open_file" in tool_names
+
+
+@test()
+def test_server_proxy_to_instance_forwards_session_and_extensions():
+    """Top-level proxy requests should preserve MCP session and enabled extensions."""
+    with _saved_target():
+        original_conn = server.http.client.HTTPConnection
+        _RecordingConnection.calls = []
+        server.http.client.HTTPConnection = _RecordingConnection
+        server.mcp._transport_session_id.data = "http:session-456"
+        server.mcp._enabled_extensions.data = {"dbg"}
+        try:
+            server._proxy_to_instance("127.0.0.1", 13337, b"{}")
+            assert len(_RecordingConnection.calls) == 1
+            call = _RecordingConnection.calls[0]
+            assert call["path"] == "/mcp?ext=dbg"
+            assert call["headers"].get("Mcp-Session-Id") == "session-456"
+        finally:
+            server.http.client.HTTPConnection = original_conn

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -1,0 +1,44 @@
+"""Tests for the top-level stdio proxy server (server.py)."""
+
+import contextlib
+import os
+import sys
+
+from ..framework import test
+
+try:
+    from ida_pro_mcp import server
+except ImportError:
+    _parent = os.path.join(os.path.dirname(__file__), "..", "..")
+    sys.path.insert(0, _parent)
+    try:
+        import server  # type: ignore
+    finally:
+        sys.path.remove(_parent)
+
+
+@contextlib.contextmanager
+def _saved_target():
+    """Preserve the currently selected IDA target across assertions."""
+    old_host = server.IDA_HOST
+    old_port = server.IDA_PORT
+    try:
+        yield
+    finally:
+        server.IDA_HOST = old_host
+        server.IDA_PORT = old_port
+
+
+@test()
+def test_tools_list_keeps_discovery_and_launch_tools_when_ida_unreachable():
+    """tools/list should still expose local discovery/recovery tools when IDA is down."""
+    with _saved_target():
+        server.IDA_HOST = "127.0.0.1"
+        server.IDA_PORT = 1  # unreachable
+        req = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+        result = server.dispatch_proxy(req)
+        assert "result" in result, f"Expected successful tools/list response, got: {result}"
+        tool_names = {tool["name"] for tool in result["result"].get("tools", [])}
+        assert "select_instance" in tool_names
+        assert "list_instances" in tool_names
+        assert "open_file" in tool_names

--- a/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
@@ -132,7 +132,7 @@ def test_typed_fixture_put_int_roundtrip():
     original_plain = _plain_hex_bytes(original)
     try:
         written = put_int({"addr": G_NUMBERS, "ty": "u32", "value": "99"})[0]
-        assert written["ok"] is True
+        assert "error" not in written
         roundtrip = get_int({"addr": G_NUMBERS, "ty": "u32"})[0]
         assert roundtrip["value"] == 99
     finally:
@@ -148,7 +148,7 @@ def test_typed_fixture_struct_types_and_resources():
     assert any(item["name"] == "Wrapper" for item in wrapper_matches)
 
     set_point = set_type({"addr": G_POINT, "ty": "Point"})[0]
-    assert set_point.get("ok") is True
+    assert "error" not in set_point
     auto = read_struct({"addr": G_POINT})[0]
     assert auto["struct"] == "Point"
     members = {m["name"]: m["value"] for m in auto["members"]}
@@ -156,7 +156,7 @@ def test_typed_fixture_struct_types_and_resources():
     assert members["y"].endswith("(22)")
 
     wrapper = struct_name_resource("Wrapper")
-    assert wrapper.get("error") is None
+    assert "error" not in wrapper
     assert len(wrapper["members"]) == 2
 
     inferred = infer_types(G_POINT)[0]
@@ -170,14 +170,14 @@ def test_typed_fixture_set_type_local_and_stack_paths():
         {"addr": USE_WRAPPER, "kind": "local", "variable": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
     )[0]
     assert (
-        local.get("ok") is True
+        "error" not in local
         or local.get("error") == "Failed to apply local variable type"
     )
 
     stack = set_type(
         {"addr": USE_WRAPPER, "kind": "stack", "name": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
     )[0]
-    assert stack.get("ok") is True
+    assert "error" not in stack
 
 
 @test(binary="typed_fixture.elf")
@@ -192,7 +192,7 @@ def test_typed_fixture_rename_local_and_stack_paths():
             }
         )
         assert (
-            local["local"][0].get("ok") is True
+            "error" not in local["local"][0]
             or local["local"][0].get("error") == "Rename failed"
         )
         stack = rename(
@@ -202,7 +202,7 @@ def test_typed_fixture_rename_local_and_stack_paths():
                 ]
             }
         )
-        assert stack["stack"][0]["ok"] is True
+        assert "error" not in stack["stack"][0]
         frame = stack_frame(USE_WRAPPER)[0]
         names = {var["name"] for var in frame["vars"]}
         assert "rhs_stack" in names

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -118,7 +118,7 @@ class GlobalRename(TypedDict):
 class LocalRename(TypedDict):
     """Local variable rename operation"""
 
-    func_addr: Annotated[str, "Function address containing the local variable"]
+    func_addr: Annotated[str, "Function address"]
     old: Annotated[str, "Current variable name"]
     new: Annotated[str, "New variable name"]
 
@@ -126,7 +126,7 @@ class LocalRename(TypedDict):
 class StackRename(TypedDict):
     """Stack variable rename operation"""
 
-    func_addr: Annotated[str, "Function address containing the stack variable"]
+    func_addr: Annotated[str, "Function address"]
     old: Annotated[str, "Current variable name"]
     new: Annotated[str, "New variable name"]
 
@@ -147,12 +147,9 @@ class RenameBatch(TypedDict, total=False):
     stack: Annotated[
         list[StackRename] | StackRename | None, "Stack variable rename operations"
     ]
-    stop_on_error: Annotated[bool, "Stop processing remaining items on first failure"]
-    dry_run: Annotated[bool, "Validate only; report what would change"]
-    allow_overwrite: Annotated[
-        bool,
-        "Allow renaming even if target name already exists when backend supports force mode",
-    ]
+    stop_on_error: Annotated[bool, "Stop on first failure"]
+    dry_run: Annotated[bool, "Validate only, no changes"]
+    allow_overwrite: Annotated[bool, "Force overwrite existing names"]
 
 
 class StructFieldQuery(TypedDict):
@@ -165,138 +162,121 @@ class StructFieldQuery(TypedDict):
 class XrefQuery(TypedDict, total=False):
     """Generic cross-reference query"""
 
-    query: Annotated[str, "Address or name to resolve"]
-    direction: Annotated[str, "to|from|both (default: both)"]
-    xref_type: Annotated[str, "any|code|data (default: any)"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum results (default: 200, max: 5000)"]
-    include_fn: Annotated[bool, "Include function metadata when available"]
-    dedup: Annotated[bool, "Deduplicate by address/type (default: true)"]
-    sort_by: Annotated[str, "Sort key: addr|type (default: addr)"]
-    descending: Annotated[bool, "Sort descending (default: false)"]
+    query: Annotated[str, "Address or name"]
+    direction: Annotated[str, "to|from|both"]
+    xref_type: Annotated[str, "any|code|data"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (max: 5000)"]
+    include_fn: Annotated[bool, "Include function metadata"]
+    dedup: Annotated[bool, "Deduplicate by addr/type"]
+    sort_by: Annotated[str, "Sort: addr|type"]
+    descending: Annotated[bool, "Descending"]
 
 
 class ListQuery(TypedDict, total=False):
     """Pagination query for listing operations"""
 
-    filter: Annotated[str, "Optional glob pattern to filter results"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
+    filter: Annotated[str, "Glob filter"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
 
 
 class FunctionQuery(TypedDict, total=False):
     """Function query with richer filtering"""
 
-    filter: Annotated[str, "Optional function name glob/regex filter"]
-    name_regex: Annotated[str, "Optional regex to apply to function names"]
-    min_size: Annotated[int, "Minimum function size in bytes (inclusive)"]
-    max_size: Annotated[int, "Maximum function size in bytes (inclusive)"]
-    has_type: Annotated[bool, "Require function type information to be present"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
-    sort_by: Annotated[str, "Sort key: addr|name|size (default: addr)"]
-    descending: Annotated[bool, "Sort descending (default: false)"]
+    filter: Annotated[str, "Name glob/regex"]
+    name_regex: Annotated[str, "Name regex"]
+    min_size: Annotated[int, "Min size in bytes"]
+    max_size: Annotated[int, "Max size in bytes"]
+    has_type: Annotated[bool, "Require type info"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
+    sort_by: Annotated[str, "Sort: addr|name|size"]
+    descending: Annotated[bool, "Descending"]
 
 
 class EntityQuery(TypedDict, total=False):
     """Generic IDB entity query with filtering, projection, and pagination"""
 
-    kind: Annotated[str, "Entity kind: functions|globals|imports|strings|names"]
-    filter: Annotated[str, "Optional glob/regex filter (name/text depending on kind)"]
-    regex: Annotated[str, "Optional regex applied to the primary text field"]
-    min_addr: Annotated[str, "Optional minimum address bound (hex/decimal)"]
-    max_addr: Annotated[str, "Optional maximum address bound (hex/decimal)"]
-    segment: Annotated[str, "Optional segment filter for address-backed entities"]
-    module: Annotated[str, "Optional import module filter (imports only)"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum number of results (default: 100, 0 for all)"]
-    sort_by: Annotated[str, "Sort key, e.g. addr|name|size|length"]
-    descending: Annotated[bool, "Sort descending (default: false)"]
-    fields: Annotated[
-        list[str] | str,
-        "Optional projection list; only selected fields are returned",
-    ]
+    kind: Annotated[str, "functions|globals|imports|strings|names"]
+    filter: Annotated[str, "Glob/regex filter"]
+    regex: Annotated[str, "Regex on primary text field"]
+    min_addr: Annotated[str, "Min address bound"]
+    max_addr: Annotated[str, "Max address bound"]
+    segment: Annotated[str, "Segment filter"]
+    module: Annotated[str, "Import module filter"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
+    sort_by: Annotated[str, "Sort: addr|name|size|length"]
+    descending: Annotated[bool, "Descending"]
+    fields: Annotated[list[str] | str, "Projection field list"]
 
 
 class FuncProfileQuery(TypedDict, total=False):
     """Function profiling query with pagination and optional detail lists"""
 
-    query: Annotated[str, "Address/name or '*' for all functions"]
-    filter: Annotated[str, "Optional function-name glob/regex filter"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum number of results (default: 50, 0 for all)"]
-    sort_by: Annotated[str, "Sort key: addr|name|size (default: addr)"]
-    descending: Annotated[bool, "Sort descending (default: false)"]
-    include_lists: Annotated[bool, "Include sampled callers/callees/strings/constants"]
-    max_items: Annotated[int, "Max sampled items per list when include_lists=true"]
-    include_prototype: Annotated[bool, "Include recovered function prototype text"]
+    query: Annotated[str, "Address/name or '*'"]
+    filter: Annotated[str, "Name glob/regex"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
+    sort_by: Annotated[str, "Sort: addr|name|size"]
+    descending: Annotated[bool, "Descending"]
+    include_lists: Annotated[bool, "Include callers/callees/strings/constants"]
+    max_items: Annotated[int, "Max items per list"]
+    include_prototype: Annotated[bool, "Include prototype"]
 
 
 class AnalyzeBatchQuery(TypedDict, total=False):
     """Comprehensive function analysis request"""
 
     query: Annotated[str, "Function address or name"]
-    include_decompile: Annotated[bool, "Include decompiler output (default: true)"]
-    include_disasm: Annotated[
-        bool, "Include disassembly lines (default: false, use max_disasm_insns)"
-    ]
-    include_xrefs: Annotated[bool, "Include xrefs-to/from summary (default: true)"]
-    include_callers: Annotated[bool, "Include caller list (default: true)"]
-    include_callees: Annotated[bool, "Include callee list (default: true)"]
-    include_strings: Annotated[bool, "Include referenced strings (default: true)"]
-    include_constants: Annotated[
-        bool, "Include immediate constants referenced in function (default: true)"
-    ]
-    include_basic_blocks: Annotated[
-        bool, "Include CFG basic blocks (default: true, capped by max_blocks)"
-    ]
-    include_proto: Annotated[bool, "Include recovered prototype (default: true)"]
-    max_disasm_insns: Annotated[
-        int, "Maximum disassembly instructions when include_disasm=true (default: 300)"
-    ]
-    max_callers: Annotated[int, "Maximum callers returned (default: 100)"]
-    max_callees: Annotated[int, "Maximum callees returned (default: 100)"]
-    max_strings: Annotated[int, "Maximum string refs returned (default: 100)"]
-    max_constants: Annotated[int, "Maximum constants returned (default: 200)"]
-    max_blocks: Annotated[int, "Maximum basic blocks returned (default: 500)"]
+    include_decompile: Annotated[bool, "Include decompiler output"]
+    include_disasm: Annotated[bool, "Include disassembly"]
+    include_xrefs: Annotated[bool, "Include xrefs-to/from"]
+    include_callers: Annotated[bool, "Include callers"]
+    include_callees: Annotated[bool, "Include callees"]
+    include_strings: Annotated[bool, "Include strings"]
+    include_constants: Annotated[bool, "Include constants"]
+    include_basic_blocks: Annotated[bool, "Include basic blocks"]
+    include_proto: Annotated[bool, "Include prototype"]
+    max_disasm_insns: Annotated[int, "Max disasm instructions"]
+    max_callers: Annotated[int, "Max callers"]
+    max_callees: Annotated[int, "Max callees"]
+    max_strings: Annotated[int, "Max strings"]
+    max_constants: Annotated[int, "Max constants"]
+    max_blocks: Annotated[int, "Max blocks"]
 
 
 class ImportQuery(TypedDict, total=False):
     """Import query with filtering and pagination"""
 
-    filter: Annotated[str, "Optional import name glob/regex filter"]
-    module: Annotated[str, "Optional module name glob/regex filter"]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum number of results (default: 100, 0 for all)"]
+    filter: Annotated[str, "Name glob/regex"]
+    module: Annotated[str, "Module glob/regex"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
 
 
 class TypeInspectQuery(TypedDict, total=False):
     """Type inspection request"""
 
     name: Annotated[str, "Type name"]
-    include_members: Annotated[bool, "Include member details for UDT types"]
-    max_members: Annotated[int, "Maximum members to include (default: 128)"]
+    include_members: Annotated[bool, "Include UDT member details"]
+    max_members: Annotated[int, "Max members"]
 
 
 class TypeQuery(TypedDict, total=False):
     """Type catalog query with filtering, pagination, and optional relationships"""
 
-    filter: Annotated[str, "Optional type name glob/regex filter"]
-    kind: Annotated[
-        str,
-        "any|struct|union|enum|typedef|func|ptr|udt (default: any)",
-    ]
-    offset: Annotated[int, "Starting index (default: 0)"]
-    count: Annotated[int, "Maximum results (default: 100, 0 for all)"]
-    sort_by: Annotated[str, "Sort key: name|size|ordinal (default: name)"]
-    descending: Annotated[bool, "Sort descending (default: false)"]
-    include_decl: Annotated[bool, "Include declaration text (default: true)"]
-    include_members: Annotated[bool, "Include UDT member details (default: false)"]
-    max_members: Annotated[int, "Maximum members per UDT (default: 64)"]
-    include_relationships: Annotated[
-        bool,
-        "Include related/member type names to support type navigation (default: false)",
-    ]
+    filter: Annotated[str, "Name glob/regex"]
+    kind: Annotated[str, "any|struct|union|enum|typedef|func|ptr|udt"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max results (0=all)"]
+    sort_by: Annotated[str, "Sort: name|size|ordinal"]
+    descending: Annotated[bool, "Descending"]
+    include_decl: Annotated[bool, "Include declaration text"]
+    include_members: Annotated[bool, "Include UDT member details"]
+    max_members: Annotated[int, "Max members per UDT"]
+    include_relationships: Annotated[bool, "Include related type names"]
 
 
 class BreakpointOp(TypedDict):
@@ -309,30 +289,21 @@ class BreakpointOp(TypedDict):
 class InsnPattern(TypedDict, total=False):
     """Instruction pattern for operand search"""
 
-    mnem: Annotated[str, "Instruction mnemonic to match"]
-    op0: Annotated[int, "Value to match in first operand"]
-    op1: Annotated[int, "Value to match in second operand"]
-    op2: Annotated[int, "Value to match in third operand"]
-    op_any: Annotated[int, "Value to match in any operand"]
-    func: Annotated[str, "Function address to scope the scan"]
-    segment: Annotated[str, "Segment name to scope the scan"]
-    start: Annotated[str, "Start address (hex/dec) to scope the scan"]
-    end: Annotated[str, "End address (hex/dec, exclusive) to scope the scan"]
-    offset: Annotated[int, "Starting match index (default: 0)"]
-    count: Annotated[int, "Maximum matches to return (default: 100, max: 5000)"]
-    max_scan_insns: Annotated[
-        int, "Max instructions to scan (default: 200000, max: 2000000)"
-    ]
-    include_fn: Annotated[
-        bool, "Include containing function metadata for each match (default: false)"
-    ]
-    include_disasm: Annotated[
-        bool, "Include disassembly text for each match (default: false)"
-    ]
-    allow_broad: Annotated[
-        bool,
-        "Allow scans without scope (default: false). Use with care on large binaries.",
-    ]
+    mnem: Annotated[str, "Mnemonic to match"]
+    op0: Annotated[int, "Match first operand"]
+    op1: Annotated[int, "Match second operand"]
+    op2: Annotated[int, "Match third operand"]
+    op_any: Annotated[int, "Match any operand"]
+    func: Annotated[str, "Scope: function address"]
+    segment: Annotated[str, "Scope: segment name"]
+    start: Annotated[str, "Scope: start address"]
+    end: Annotated[str, "Scope: end address (exclusive)"]
+    offset: Annotated[int, "Start index"]
+    count: Annotated[int, "Max matches (max: 5000)"]
+    max_scan_insns: Annotated[int, "Max instructions to scan"]
+    include_fn: Annotated[bool, "Include function metadata"]
+    include_disasm: Annotated[bool, "Include disassembly text"]
+    allow_broad: Annotated[bool, "Allow scopeless scan"]
 
 
 class NumberConversion(TypedDict, total=False):
@@ -349,21 +320,19 @@ class StructRead(TypedDict, total=False):
     to auto-detect from type information already applied at the address.
     """
 
-    addr: Annotated[str, "Memory address (hex or decimal)"]
-    struct: Annotated[
-        NotRequired[str], "Structure name (optional, auto-detect if omitted)"
-    ]
+    addr: Annotated[str, "Address"]
+    struct: Annotated[NotRequired[str], "Struct name (auto-detect if omitted)"]
 
 
 class TypeEdit(TypedDict, total=False):
     """Type application operation"""
 
-    addr: Annotated[str, "Memory address"]
+    addr: Annotated[str, "Address"]
     name: Annotated[str, "Variable/function name"]
     ty: Annotated[str, "Type name or declaration"]
-    kind: Annotated[str, "Type of entity (auto-detected if omitted)"]
-    signature: Annotated[str, "Function signature (for kind=function)"]
-    variable: Annotated[str, "Local variable name (for kind=local)"]
+    kind: Annotated[str, "Entity kind (auto-detected)"]
+    signature: Annotated[str, "Function signature"]
+    variable: Annotated[str, "Local variable name"]
 
 
 class EnumMemberUpsert(TypedDict, total=False):
@@ -378,14 +347,14 @@ class EnumUpsert(TypedDict, total=False):
 
     name: Annotated[str, "Enum type name"]
     members: Annotated[list[EnumMemberUpsert] | EnumMemberUpsert, "Members to upsert"]
-    bitfield: Annotated[bool, "Whether the enum is a bitfield (default: false)"]
+    bitfield: Annotated[bool, "Bitfield enum"]
 
 
 class TypeApplyBatch(TypedDict, total=False):
     """Batch type application configuration"""
 
     edits: Annotated[list[TypeEdit] | TypeEdit, "Type edits to apply"]
-    stop_on_error: Annotated[bool, "Stop processing remaining edits on first failure"]
+    stop_on_error: Annotated[bool, "Stop on first failure"]
 
 
 class StackVarDecl(TypedDict):

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -411,11 +411,20 @@ class McpServer:
             request_handler,
             bind_and_activate=False
         )
-        # allow_reuse_address=True allows fast restarts (skip TCP TIME_WAIT).
-        # Do NOT set allow_reuse_port: on macOS SO_REUSEPORT lets multiple
-        # processes silently bind the same port, causing request mis-routing
-        # and SIGPIPE crashes when one instance closes.
-        self._http_server.allow_reuse_address = True
+        # Fast restarts: skip TCP TIME_WAIT so a port can be reused immediately
+        # after the server stops. On Windows, SO_REUSEADDR is dangerous (allows
+        # multiple processes to bind the same port silently), so we use
+        # SO_EXCLUSIVEADDRUSE instead, which still allows TIME_WAIT reuse but
+        # prevents port hijacking. On Unix, SO_REUSEADDR is the correct option.
+        import sys
+        if sys.platform == "win32":
+            import socket
+            self._http_server.allow_reuse_address = False
+            self._http_server.socket.setsockopt(
+                socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1  # type: ignore[attr-defined]
+            )
+        else:
+            self._http_server.allow_reuse_address = True
 
         # Set the MCPServer instance on the handler class
         setattr(self._http_server, "mcp_server", self)

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -4,16 +4,101 @@ import logging
 import signal
 import sys
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional, TypedDict
 
 # idapro must go first to initialize idalib
 import idapro
 import ida_loader
 
 from ida_pro_mcp.ida_mcp import MCP_SERVER
-from ida_pro_mcp.ida_mcp.api_core import server_health, server_warmup
+from ida_pro_mcp.ida_mcp.api_core import (
+    ServerHealthResult,
+    ServerWarmupResult,
+    server_health,
+    server_warmup,
+)
 from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, tool
 from ida_pro_mcp.idalib_session_manager import get_session_manager
+
+class IdalibContextFields(TypedDict):
+    context_id: str
+    transport_context_id: str | None
+    isolated_contexts: bool
+
+
+class IdalibSessionInfo(TypedDict):
+    session_id: str
+    input_path: str
+    filename: str
+    created_at: str
+    last_accessed: str
+    is_analyzing: bool
+    metadata: dict[str, Any]
+
+
+class IdalibOpenResult(IdalibContextFields, total=False):
+    success: bool
+    session: IdalibSessionInfo
+    message: str
+    error: str
+
+
+class IdalibCloseResult(TypedDict, total=False):
+    success: bool
+    message: str
+    error: str
+
+
+class IdalibSwitchResult(IdalibContextFields, total=False):
+    success: bool
+    session: IdalibSessionInfo
+    message: str
+    error: str
+
+
+class IdalibUnbindResult(IdalibContextFields, total=False):
+    success: bool
+    message: str
+    error: str
+
+
+class IdalibListResult(IdalibContextFields, total=False):
+    sessions: list[IdalibSessionInfo]
+    count: int
+    current_context_session_id: str | None
+    error: str
+
+
+class IdalibCurrentResult(IdalibContextFields, total=False):
+    session_id: str
+    input_path: str
+    filename: str
+    created_at: str
+    last_accessed: str
+    is_analyzing: bool
+    metadata: dict[str, Any]
+    error: str
+
+
+class IdalibSaveResult(IdalibContextFields, total=False):
+    ok: bool
+    path: str
+    error: str | None
+
+
+class IdalibHealthResult(IdalibContextFields, total=False):
+    ready: bool
+    session: IdalibSessionInfo | None
+    health: ServerHealthResult | None
+    error: str | None
+
+
+class IdalibWarmupResult(IdalibContextFields, total=False):
+    ready: bool
+    session: IdalibSessionInfo | None
+    warmup: ServerWarmupResult | None
+    error: str | None
+
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +136,7 @@ def _resolve_effective_context_id() -> str:
     return SHARED_FALLBACK_CONTEXT_ID
 
 
-def _context_response_fields(context_id: str) -> dict:
+def _context_response_fields(context_id: str) -> IdalibContextFields:
     return {
         "context_id": context_id,
         "transport_context_id": get_current_transport_session_id(),
@@ -113,7 +198,7 @@ def idalib_open(
     session_id: Annotated[
         Optional[str], "Custom session ID (auto-generated if not provided)"
     ] = None,
-) -> dict:
+) -> IdalibOpenResult:
     """Open a binary and bind it to the active idalib context policy."""
 
     try:
@@ -139,7 +224,9 @@ def idalib_open(
 
 
 @tool
-def idalib_close(session_id: Annotated[str, "Session ID to close"]) -> dict:
+def idalib_close(
+    session_id: Annotated[str, "Session ID to close"]
+) -> IdalibCloseResult:
     """Close an IDA session and remove all context bindings targeting it."""
 
     try:
@@ -154,7 +241,7 @@ def idalib_close(session_id: Annotated[str, "Session ID to close"]) -> dict:
 @tool
 def idalib_switch(
     session_id: Annotated[str, "Session ID to bind to active context"],
-) -> dict:
+) -> IdalibSwitchResult:
     """Bind the active idalib context to a session and activate it."""
 
     try:
@@ -178,7 +265,7 @@ def idalib_switch(
 
 
 @tool
-def idalib_unbind() -> dict:
+def idalib_unbind() -> IdalibUnbindResult:
     """Unbind the active idalib context from any session."""
 
     try:
@@ -200,7 +287,7 @@ def idalib_unbind() -> dict:
 
 
 @tool
-def idalib_list() -> dict:
+def idalib_list() -> IdalibListResult:
     """List sessions with context-binding and active-database metadata."""
 
     try:
@@ -219,7 +306,7 @@ def idalib_list() -> dict:
 
 
 @tool
-def idalib_current() -> dict:
+def idalib_current() -> IdalibCurrentResult:
     """Return the session bound to the active idalib context policy."""
 
     try:
@@ -254,7 +341,7 @@ def idalib_save(
     session_id: Annotated[
         Optional[str], "Optional session to activate before saving"
     ] = None,
-) -> dict:
+) -> IdalibSaveResult:
     """Save the active (or requested) IDA session database to disk."""
 
     try:
@@ -292,7 +379,7 @@ def idalib_health(
     session_id: Annotated[
         Optional[str], "Optional session to bind/activate before probing health"
     ] = None,
-) -> dict:
+) -> IdalibHealthResult:
     """Health/ready probe for idalib context + core server status."""
     try:
         manager = get_session_manager()
@@ -318,7 +405,11 @@ def idalib_health(
 
         health = server_health()
         return {
-            "ready": bool(health.get("status") == "ok"),
+            "ready": bool(
+                isinstance(health, dict)
+                and health.get("status", "ok") == "ok"
+                and not health.get("error")
+            ),
             **_context_response_fields(context_id),
             "session": session.to_dict() if session is not None else None,
             "health": health,
@@ -336,7 +427,7 @@ def idalib_warmup(
     wait_auto_analysis: Annotated[bool, "Wait for auto analysis queue"] = True,
     build_caches: Annotated[bool, "Build core caches"] = True,
     init_hexrays: Annotated[bool, "Initialize Hex-Rays plugin"] = True,
-) -> dict:
+) -> IdalibWarmupResult:
     """Warm up idalib context and core subsystems."""
     try:
         manager = get_session_manager()

--- a/src/ida_pro_mcp/installer.py
+++ b/src/ida_pro_mcp/installer.py
@@ -124,14 +124,13 @@ def infer_http_transport_type(transport_url: str) -> str:
 
 def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
     if transport == "stdio":
+        # No --ida-rpc: server auto-discovers running IDA instances
         if client_name == "Opencode":
             mcp_config = {
                 "type": "local",
                 "command": [
                     get_python_executable(),
                     SERVER_SCRIPT,
-                    "--ida-rpc",
-                    f"http://{IDA_HOST}:{IDA_PORT}",
                 ],
             }
         else:
@@ -139,8 +138,6 @@ def generate_mcp_config(*, client_name: str, transport: str = "stdio"):
                 "command": get_python_executable(),
                 "args": [
                     SERVER_SCRIPT,
-                    "--ida-rpc",
-                    f"http://{IDA_HOST}:{IDA_PORT}",
                 ],
             }
         env = {}

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from ida_pro_mcp.ida_mcp.zeromcp import McpServer
     from ida_pro_mcp.ida_mcp.zeromcp.jsonrpc import JsonRpcRequest, JsonRpcResponse
+    from ida_pro_mcp.ida_mcp.discovery import InstanceInfo
 else:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ida_mcp"))
     from zeromcp import McpServer
@@ -66,6 +67,7 @@ def _proxy_to_ida(payload: bytes | str | dict) -> dict:
         return json.loads(raw_data)
     finally:
         conn.close()
+
 
 
 def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -165,6 +165,41 @@ def select_instance(
 DEFAULT_IDA_RPC = f"http://{IDA_HOST}:{IDA_PORT}"
 
 
+def _resolve_ida_rpc(args) -> None:
+    """Resolve the IDA RPC target: explicit --ida-rpc, or auto-discovery."""
+    global IDA_HOST, IDA_PORT
+
+    if args.ida_rpc is not None:
+        # Explicit --ida-rpc: use directly (backwards compatible)
+        ida_rpc = urlparse(args.ida_rpc)
+        if ida_rpc.hostname is None or ida_rpc.port is None:
+            raise Exception(f"Invalid IDA RPC server: {args.ida_rpc}")
+        IDA_HOST = ida_rpc.hostname
+        IDA_PORT = ida_rpc.port
+        set_ida_rpc(IDA_HOST, IDA_PORT)
+        return
+
+    # Auto-discover running IDA instances
+    instances = discover_instances()
+    if len(instances) == 0:
+        print(f"[MCP] No IDA instances discovered, using default {IDA_HOST}:{IDA_PORT}", file=sys.stderr)
+    elif len(instances) == 1:
+        inst = instances[0]
+        IDA_HOST = inst["host"]
+        IDA_PORT = inst["port"]
+        print(f"[MCP] Auto-connected to: {inst['binary']} at {IDA_HOST}:{IDA_PORT}", file=sys.stderr)
+    else:
+        print(f"[MCP] Found {len(instances)} IDA instances:", file=sys.stderr)
+        for i, inst in enumerate(instances):
+            print(f"  [{i}] {inst['binary']} at {inst['host']}:{inst['port']}", file=sys.stderr)
+        inst = instances[0]
+        IDA_HOST = inst["host"]
+        IDA_PORT = inst["port"]
+        print(f"[MCP] Auto-selected: {inst['binary']}. Use select_instance tool to switch.", file=sys.stderr)
+
+    set_ida_rpc(IDA_HOST, IDA_PORT)
+
+
 def main():
     global IDA_HOST, IDA_PORT
 
@@ -213,8 +248,8 @@ def main():
     parser.add_argument(
         "--ida-rpc",
         type=str,
-        default=f"http://{IDA_HOST}:{IDA_PORT}",
-        help=f"IDA RPC server to use (default: http://{IDA_HOST}:{IDA_PORT})",
+        default=None,
+        help=f"IDA RPC server (default: auto-discover, fallback: {DEFAULT_IDA_RPC})",
     )
     parser.add_argument(
         "--config", action="store_true", help="Generate MCP config JSON"
@@ -231,13 +266,8 @@ def main():
         list_available_clients()
         return
 
-    # Parse IDA RPC server argument
-    ida_rpc = urlparse(args.ida_rpc)
-    if ida_rpc.hostname is None or ida_rpc.port is None:
-        raise Exception(f"Invalid IDA RPC server: {args.ida_rpc}")
-    IDA_HOST = ida_rpc.hostname
-    IDA_PORT = ida_rpc.port
-    set_ida_rpc(IDA_HOST, IDA_PORT)
+    # Resolve IDA RPC target (explicit or auto-discovery)
+    _resolve_ida_rpc(args)
 
     is_install = args.install is not None
     is_uninstall = args.uninstall is not None

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING
+from typing import Annotated, TYPE_CHECKING
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -22,11 +22,24 @@ try:
 except ImportError:
     from installer import list_available_clients, print_mcp_config, run_install_command, set_ida_rpc
 
+try:
+    from .ida_mcp.discovery import discover_instances, probe_instance
+except ImportError:
+    try:
+        from ida_mcp.discovery import discover_instances, probe_instance
+    except ImportError:
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ida_mcp"))
+        from discovery import discover_instances, probe_instance
+
+        sys.path.pop(0)
+
 IDA_HOST = "127.0.0.1"
 IDA_PORT = 13337
 
 mcp = McpServer("ida-pro-mcp")
 dispatch_original = mcp.registry.dispatch
+
+LOCAL_TOOLS = {"select_instance"}
 
 
 def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:
@@ -92,6 +105,35 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
 
 
 mcp.registry.dispatch = dispatch_proxy
+
+
+# ============================================================================
+# Local tools (handled by the proxy, not forwarded to IDA)
+# ============================================================================
+
+
+@mcp.tool
+def select_instance(
+    port: Annotated[int, "Port number of the IDA instance to connect to"],
+    host: Annotated[str, "Host address of the IDA instance"] = "127.0.0.1",
+) -> dict:
+    """Switch this MCP server to proxy requests to a different IDA Pro instance.
+
+    Use list_instances first to see available instances, then select one by port.
+    All subsequent tool calls will be routed to the selected instance.
+    """
+    global IDA_HOST, IDA_PORT
+    if not probe_instance(host, port):
+        return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
+    IDA_HOST = host
+    IDA_PORT = port
+    set_ida_rpc(IDA_HOST, IDA_PORT)
+    return {"success": True, "host": host, "port": port}
+
+
+# ============================================================================
+
+DEFAULT_IDA_RPC = f"http://{IDA_HOST}:{IDA_PORT}"
 
 
 def main():

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -4,13 +4,12 @@ import json
 import os
 import sys
 import traceback
-from typing import Annotated, TYPE_CHECKING
+from typing import Annotated, Any, TYPE_CHECKING, TypedDict
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from ida_pro_mcp.ida_mcp.zeromcp import McpServer
     from ida_pro_mcp.ida_mcp.zeromcp.jsonrpc import JsonRpcRequest, JsonRpcResponse
-    from ida_pro_mcp.ida_mcp.discovery import InstanceInfo
 else:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ida_mcp"))
     from zeromcp import McpServer
@@ -19,9 +18,19 @@ else:
     sys.path.pop(0)
 
 try:
-    from .installer import list_available_clients, print_mcp_config, run_install_command, set_ida_rpc
+    from .installer import (
+        list_available_clients,
+        print_mcp_config,
+        run_install_command,
+        set_ida_rpc,
+    )
 except ImportError:
-    from installer import list_available_clients, print_mcp_config, run_install_command, set_ida_rpc
+    from installer import (
+        list_available_clients,
+        print_mcp_config,
+        run_install_command,
+        set_ida_rpc,
+    )
 
 try:
     from .ida_mcp.discovery import discover_instances, probe_instance
@@ -34,29 +43,79 @@ except ImportError:
 
         sys.path.pop(0)
 
+class ProxyInstanceInfo(TypedDict, total=False):
+    host: str
+    port: int
+    pid: int
+    binary: str
+    idb_path: str
+    started_at: str
+    reachable: bool
+    active: bool
+
+
+class ProxySelectResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    message: str
+    error: str
+
+
+class ProxyOpenFileResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    binary: str
+    pid: int
+    switched: bool
+    message: str
+    error: str
+    result: Any
+
+
 IDA_HOST = "127.0.0.1"
 IDA_PORT = 13337
 
 mcp = McpServer("ida-pro-mcp")
 dispatch_original = mcp.registry.dispatch
 
-LOCAL_TOOLS = {"select_instance"}
+LOCAL_TOOLS = {"list_instances", "select_instance", "open_file"}
 
 
-def _proxy_to_ida(payload: bytes | str | dict) -> dict:
-    """Send a JSON-RPC request to the active IDA instance and return the response."""
+def _get_proxy_request_path() -> str:
+    """Build the proxied MCP path, preserving enabled extensions."""
+    enabled = sorted(getattr(mcp._enabled_extensions, "data", set()))
+    if enabled:
+        return f"/mcp?ext={','.join(enabled)}"
+    return "/mcp"
+
+
+def _get_proxy_request_headers() -> dict[str, str]:
+    """Build proxy request headers, preserving HTTP MCP session identity."""
+    headers = {"Content-Type": "application/json"}
+    transport_session_id = mcp.get_current_transport_session_id()
+    if transport_session_id and transport_session_id.startswith("http:"):
+        session_id = transport_session_id.split(":", 1)[1]
+        if session_id and session_id != "anonymous":
+            headers["Mcp-Session-Id"] = session_id
+    return headers
+
+
+def _proxy_to_instance(host: str, port: int, payload: bytes | str | dict) -> dict:
+    """Send a JSON-RPC request to a specific IDA instance and return the response."""
     if isinstance(payload, dict):
         payload = json.dumps(payload)
     elif isinstance(payload, str):
         payload = payload.encode("utf-8")
 
-    conn = http.client.HTTPConnection(IDA_HOST, IDA_PORT, timeout=30)
+    conn = http.client.HTTPConnection(host, port, timeout=30)
     try:
         conn.request(
             "POST",
-            "/mcp",
+            _get_proxy_request_path(),
             payload,
-            {"Content-Type": "application/json"},
+            _get_proxy_request_headers(),
         )
         response = conn.getresponse()
         raw_data = response.read().decode()
@@ -68,6 +127,37 @@ def _proxy_to_ida(payload: bytes | str | dict) -> dict:
     finally:
         conn.close()
 
+
+def _proxy_to_ida(payload: bytes | str | dict) -> dict:
+    """Send a JSON-RPC request to the active IDA instance and return the response."""
+    return _proxy_to_instance(IDA_HOST, IDA_PORT, payload)
+
+
+def _call_ida_tool(host: str, port: int, name: str, arguments: dict[str, Any]) -> Any:
+    """Call an MCP tool on a specific IDA instance and return structured content."""
+    response = _proxy_to_instance(
+        host,
+        port,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    )
+    if "error" in response:
+        raise RuntimeError(response["error"].get("message", "Unknown error"))
+
+    result = response.get("result", {})
+    if result.get("isError"):
+        content = result.get("content", [])
+        message = (
+            content[0].get("text", "Unknown tool error")
+            if content
+            else "Unknown tool error"
+        )
+        raise RuntimeError(message)
+    return result.get("structuredContent")
 
 
 def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:
@@ -93,16 +183,25 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
     if request_obj["method"] == "tools/list":
         # Get local tools (always available)
         local_result = dispatch_original(request)
-        local_tool_names = {t["name"] for t in local_result.get("result", {}).get("tools", [])} if local_result else set()
+        local_tool_names = (
+            {t["name"] for t in local_result.get("result", {}).get("tools", [])}
+            if local_result
+            else set()
+        )
         # Try to get IDA tools and merge them in
         try:
             ida_result = _proxy_to_ida(request)
             if ida_result and "result" in ida_result:
                 # Filter out IDA tools that duplicate local tools (e.g. select_instance)
-                ida_tools = [t for t in ida_result["result"].get("tools", [])
-                             if t.get("name") not in local_tool_names]
+                ida_tools = [
+                    t
+                    for t in ida_result["result"].get("tools", [])
+                    if t.get("name") not in local_tool_names
+                ]
                 if local_result and "result" in local_result:
-                    local_result["result"]["tools"] = ida_tools + local_result["result"].get("tools", [])
+                    local_result["result"]["tools"] = (
+                        ida_tools + local_result["result"].get("tools", [])
+                    )
         except Exception:
             pass  # IDA unreachable — local tools still work
         return local_result
@@ -144,22 +243,111 @@ mcp.registry.dispatch = dispatch_proxy
 
 
 @mcp.tool
+def list_instances() -> list[ProxyInstanceInfo]:
+    """List discovered IDA Pro instances and indicate which one is active."""
+    result = []
+    for inst in discover_instances():
+        reachable = probe_instance(inst["host"], inst["port"])
+        result.append(
+            {
+                **inst,
+                "reachable": reachable,
+                "active": inst["host"] == IDA_HOST and inst["port"] == IDA_PORT,
+            }
+        )
+    return result
+
+
+@mcp.tool
 def select_instance(
     port: Annotated[int, "Port number of the IDA instance to connect to"],
     host: Annotated[str, "Host address of the IDA instance"] = "127.0.0.1",
-) -> dict:
+) -> ProxySelectResult:
     """Switch this MCP server to proxy requests to a different IDA Pro instance.
 
     Use list_instances first to see available instances, then select one by port.
     All subsequent tool calls will be routed to the selected instance.
     """
     global IDA_HOST, IDA_PORT
+    if port == 0:
+        IDA_HOST = "127.0.0.1"
+        IDA_PORT = 13337
+        set_ida_rpc(IDA_HOST, IDA_PORT)
+        return {
+            "success": True,
+            "host": IDA_HOST,
+            "port": IDA_PORT,
+            "message": "Reset to default IDA target",
+        }
     if not probe_instance(host, port):
         return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
     IDA_HOST = host
     IDA_PORT = port
     set_ida_rpc(IDA_HOST, IDA_PORT)
     return {"success": True, "host": host, "port": port}
+
+
+@mcp.tool
+def open_file(
+    file_path: Annotated[
+        str, "Absolute path to the binary file to open in a new IDA instance"
+    ],
+    switch: Annotated[
+        bool, "Automatically switch to the new instance once it starts"
+    ] = True,
+    autonomous: Annotated[
+        bool, "Run in autonomous mode (-A flag), suppressing all dialogs"
+    ] = False,
+    new_database: Annotated[
+        bool, "Force creating a new database even if one exists"
+    ] = False,
+    timeout: Annotated[
+        int, "Seconds to wait for the new instance to register (0 = don't wait)"
+    ] = 30,
+) -> ProxyOpenFileResult:
+    """Open a file in a new IDA Pro instance.
+
+    This proxy-side tool delegates to any reachable IDA instance's local open_file
+    implementation so discovery/launch remains available even when the currently
+    selected instance is down.
+    """
+    target_host = IDA_HOST
+    target_port = IDA_PORT
+    if not probe_instance(target_host, target_port):
+        target_host = ""
+        target_port = 0
+        for inst in discover_instances():
+            if probe_instance(inst["host"], inst["port"]):
+                target_host = inst["host"]
+                target_port = inst["port"]
+                break
+
+    if not target_host or target_port == 0:
+        return {
+            "success": False,
+            "error": (
+                "No running IDA instance is available to launch a new file. "
+                "Start one instance first or specify --ida-rpc explicitly."
+            ),
+        }
+
+    try:
+        result = _call_ida_tool(
+            target_host,
+            target_port,
+            "open_file",
+            {
+                "file_path": file_path,
+                "switch": switch,
+                "autonomous": autonomous,
+                "new_database": new_database,
+                "timeout": timeout,
+            },
+        )
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    return result if isinstance(result, dict) else {"success": True, "result": result}
 
 
 # ============================================================================
@@ -184,12 +372,18 @@ def _resolve_ida_rpc(args) -> None:
     # Auto-discover running IDA instances
     instances = discover_instances()
     if len(instances) == 0:
-        print(f"[MCP] No IDA instances discovered, using default {IDA_HOST}:{IDA_PORT}", file=sys.stderr)
+        print(
+            f"[MCP] No IDA instances discovered, using default {IDA_HOST}:{IDA_PORT}",
+            file=sys.stderr,
+        )
     elif len(instances) == 1:
         inst = instances[0]
         IDA_HOST = inst["host"]
         IDA_PORT = inst["port"]
-        print(f"[MCP] Auto-connected to: {inst['binary']} at {IDA_HOST}:{IDA_PORT}", file=sys.stderr)
+        print(
+            f"[MCP] Auto-connected to: {inst['binary']} at {IDA_HOST}:{IDA_PORT}",
+            file=sys.stderr,
+        )
     else:
         print(f"[MCP] Found {len(instances)} IDA instances:", file=sys.stderr)
         for i, inst in enumerate(instances):
@@ -197,7 +391,11 @@ def _resolve_ida_rpc(args) -> None:
         inst = instances[0]
         IDA_HOST = inst["host"]
         IDA_PORT = inst["port"]
-        print(f"[MCP] Auto-selected: {inst['binary']}. Use select_instance tool to switch.", file=sys.stderr)
+        print(
+            f"[MCP] Auto-selected: {inst['binary']}. "
+            "Use select_instance tool to switch.",
+            file=sys.stderr,
+        )
 
     set_ida_rpc(IDA_HOST, IDA_PORT)
 

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -42,6 +42,32 @@ dispatch_original = mcp.registry.dispatch
 LOCAL_TOOLS = {"select_instance"}
 
 
+def _proxy_to_ida(payload: bytes | str | dict) -> dict:
+    """Send a JSON-RPC request to the active IDA instance and return the response."""
+    if isinstance(payload, dict):
+        payload = json.dumps(payload)
+    elif isinstance(payload, str):
+        payload = payload.encode("utf-8")
+
+    conn = http.client.HTTPConnection(IDA_HOST, IDA_PORT, timeout=30)
+    try:
+        conn.request(
+            "POST",
+            "/mcp",
+            payload,
+            {"Content-Type": "application/json"},
+        )
+        response = conn.getresponse()
+        raw_data = response.read().decode()
+        if response.status >= 400:
+            raise RuntimeError(
+                f"HTTP {response.status} {response.reason}: {raw_data}"
+            )
+        return json.loads(raw_data)
+    finally:
+        conn.close()
+
+
 def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:
     """Dispatch JSON-RPC requests to the MCP server registry."""
     if not isinstance(request, dict):
@@ -54,30 +80,33 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
     if request_obj["method"].startswith("notifications/"):
         return dispatch_original(request)
 
-    payload: bytes | str | dict = request
-    if isinstance(payload, dict):
-        payload = json.dumps(payload)
-    elif isinstance(payload, str):
-        payload = payload.encode("utf-8")
+    # Handle local tools (instance discovery) without proxying to IDA
+    if request_obj["method"] == "tools/call":
+        params = request_obj.get("params", {})
+        tool_name = params.get("name", "")
+        if tool_name in LOCAL_TOOLS:
+            return dispatch_original(request)
+
+    # Handle tools/list locally: always include local tools, merge IDA tools when available
+    if request_obj["method"] == "tools/list":
+        # Get local tools (always available)
+        local_result = dispatch_original(request)
+        local_tool_names = {t["name"] for t in local_result.get("result", {}).get("tools", [])} if local_result else set()
+        # Try to get IDA tools and merge them in
+        try:
+            ida_result = _proxy_to_ida(request)
+            if ida_result and "result" in ida_result:
+                # Filter out IDA tools that duplicate local tools (e.g. select_instance)
+                ida_tools = [t for t in ida_result["result"].get("tools", [])
+                             if t.get("name") not in local_tool_names]
+                if local_result and "result" in local_result:
+                    local_result["result"]["tools"] = ida_tools + local_result["result"].get("tools", [])
+        except Exception:
+            pass  # IDA unreachable — local tools still work
+        return local_result
 
     try:
-        conn = http.client.HTTPConnection(IDA_HOST, IDA_PORT, timeout=30)
-        try:
-            conn.request(
-                "POST",
-                "/mcp",
-                payload,
-                {"Content-Type": "application/json"},
-            )
-            response = conn.getresponse()
-            raw_data = response.read().decode()
-            if response.status >= 400:
-                raise RuntimeError(
-                    f"HTTP {response.status} {response.reason}: {raw_data}"
-                )
-            return json.loads(raw_data)
-        finally:
-            conn.close()
+        return _proxy_to_ida(request)
     except Exception as e:
         full_info = traceback.format_exc()
         request_id = request_obj.get("id")


### PR DESCRIPTION
- Plugin autostarts MCP server on IDA open (configurable via netnode)
- Each instance registers to `%APPDATA%/Hex-Rays/IDA Pro/mcp/instances/`
- Auto-finds available port with `SO_EXCLUSIVEADDRUSE` on Windows
- New tools: `list_instances`, `select_instance`, `open_file`, `py_exec_file`
- Any IDA instance can proxy tool calls to another (`X-MCP-Proxied` loop prevention)
- `server.py` auto-discovers instances when `--ida-rpc` is not specified
- Installer no longer hardcodes `--ida-rpc` in generated stdio configs
- Discovery tools protected from being disabled in config form
- Stale registrations cleaned via PID + TCP probe during discovery
- Refactored `py_eval` globals into shared `_make_exec_globals` helper