### PR TITLE
Fix parse_decl return value checks for IDA 9.0+

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -739,7 +739,8 @@ def _parse_type_tinfo(type_text: str) -> ida_typeinf.tinfo_t:
         for candidate in candidates:
             tif = ida_typeinf.tinfo_t()
             try:
-                if parse_decl(tif, None, candidate, flags):
+                # parse_decl returns '' on success in IDA 9.0, check is not None
+                if parse_decl(tif, None, candidate, flags) is not None and not tif.empty():
                     return tif
             except Exception:
                 continue
@@ -773,7 +774,8 @@ def _parse_function_tinfo(signature_text: str) -> ida_typeinf.tinfo_t:
         for candidate in candidates:
             tif = ida_typeinf.tinfo_t()
             try:
-                if parse_decl(tif, None, candidate, flags) and tif.is_func():
+                # parse_decl returns '' on success in IDA 9.0, check is not None
+                if parse_decl(tif, None, candidate, flags) is not None and tif.is_func():
                     return tif
             except Exception:
                 continue

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_stack.py
@@ -126,7 +126,8 @@ def test_declare_stack_invalid_type_error():
         {"addr": "0x1013dc0", "name": "x", "offset": -0x18, "ty": "NoSuchType"}
     )
     assert_is_list(result, min_length=1)
-    assert_error(result[0], contains="Invalid input data")
+    # Error message may vary: "Unable to retrieve ... type info object" or similar
+    assert_error(result[0], contains="NoSuchType")
 
 
 @test(binary="typed_fixture.elf")

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -799,6 +799,7 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         "int64",
         "__int64",
         "int64_t",
+        "signed __int64",
         "long long",
         "long long int",
         "signed long long",
@@ -810,6 +811,7 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         "__uint64",
         "uint64_t",
         "unsigned int64",
+        "unsigned __int64",
         "unsigned long long",
         "unsigned long long int",
         "qword",
@@ -850,7 +852,12 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
         return tif
     if tif.get_named_type(None, type_name, ida_typeinf.BTF_UNION):
         return tif
-    if tif := ida_typeinf.tinfo_t(type_name):
+
+    # Try parse_decl for arbitrary type expressions (works in IDA 9.0+)
+    tif = ida_typeinf.tinfo_t()
+    flags = ida_typeinf.PT_SIL | ida_typeinf.PT_TYP
+    candidate = type_name if type_name.endswith(";") else type_name + ";"
+    if ida_typeinf.parse_decl(tif, None, candidate, flags) is not None and not tif.empty():
         return tif
 
     raise IDAError(f"Unable to retrieve {type_name} type info object")


### PR DESCRIPTION
In IDA 9.0+, parse_decl() returns an empty string '' on success instead of a truthy value. This caused type parsing to fail because:
- bool('') is False, so 'if parse_decl(...)' failed
- '' is not None is True, so 'if parse_decl(...) is not None' works

Changes:
- api_types.py: Changed parse_decl checks from 'if parse_decl(...)' to 'if parse_decl(...) is not None and not tif.empty()'
- utils.py: Fixed get_type_by_name fallback to use parse_decl properly
- utils.py: Added 'signed __int64' and 'unsigned __int64' to type lookup
- test_api_stack.py: Updated test to check for type name in error message

Tested: IDA 9.0 SP1 and IDA 9.3 - all tests pass