### PR TITLE
Add loader args in idalib_open

### DIFF
--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -110,6 +110,10 @@ def _install_context_activation_hooks() -> None:
 def idalib_open(
     input_path: Annotated[str, "Path to the binary file to analyze"],
     run_auto_analysis: Annotated[bool, "Run automatic analysis on the binary"] = True,
+    args: Annotated[
+        Optional[str],
+        "Optional IDA command-line style loader arguments (for example '-parm')",
+    ] = None,
     session_id: Annotated[
         Optional[str], "Custom session ID (auto-generated if not provided)"
     ] = None,
@@ -120,7 +124,10 @@ def idalib_open(
         manager = get_session_manager()
         context_id = _resolve_effective_context_id()
         opened_session_id = manager.open_binary(
-            Path(input_path), run_auto_analysis=run_auto_analysis, session_id=session_id
+            Path(input_path),
+            run_auto_analysis=run_auto_analysis,
+            loader_args=args,
+            session_id=session_id,
         )
         session = manager.bind_context(context_id, opened_session_id, activate=True)
         return {

--- a/src/ida_pro_mcp/idalib_session_manager.py
+++ b/src/ida_pro_mcp/idalib_session_manager.py
@@ -27,6 +27,7 @@ class IDASession:
     created_at: datetime = field(default_factory=datetime.now)
     last_accessed: datetime = field(default_factory=datetime.now)
     is_analyzing: bool = False
+    loader_args: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -38,6 +39,7 @@ class IDASession:
             "created_at": self.created_at.isoformat(),
             "last_accessed": self.last_accessed.isoformat(),
             "is_analyzing": self.is_analyzing,
+            "loader_args": self.loader_args,
             "metadata": self.metadata,
         }
 
@@ -62,6 +64,7 @@ class IDASessionManager:
         self,
         input_path: Path | str,
         run_auto_analysis: bool = True,
+        loader_args: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> str:
         """Open a binary file and create a new session
@@ -99,13 +102,18 @@ class IDASessionManager:
 
             # Open the database
             logger.info(f"Opening database: {input_path} (session: {session_id})")
-            self._activate_database_path(str(input_path), run_auto_analysis)
+            self._activate_database_path(
+                str(input_path),
+                run_auto_analysis=run_auto_analysis,
+                loader_args=loader_args,
+            )
 
             # Create session object
             session = IDASession(
                 session_id=session_id,
                 input_path=input_path,
                 is_analyzing=run_auto_analysis,
+                loader_args=loader_args,
             )
 
             self._sessions[session_id] = session
@@ -271,17 +279,30 @@ class IDASessionManager:
         session = self._sessions.get(session_id)
         if session is None:
             raise ValueError(f"Session not found: {session_id}")
-        self._activate_database_path(str(session.input_path), run_auto_analysis=False)
+        self._activate_database_path(
+            str(session.input_path),
+            run_auto_analysis=False,
+            loader_args=session.loader_args,
+        )
         self._active_session_id = session_id
         logger.info("Activated session %s (%s)", session_id, session.input_path.name)
 
-    def _activate_database_path(self, input_path: str, run_auto_analysis: bool) -> None:
+    def _activate_database_path(
+        self,
+        input_path: str,
+        run_auto_analysis: bool,
+        loader_args: Optional[str] = None,
+    ) -> None:
         if self._active_session_id is not None:
             logger.debug("Closing active database before opening %s", input_path)
             idapro.close_database()
             self._active_session_id = None
 
-        if idapro.open_database(input_path, run_auto_analysis=run_auto_analysis):
+        if idapro.open_database(
+            input_path,
+            run_auto_analysis=run_auto_analysis,
+            args=loader_args,
+        ):
             raise RuntimeError(f"Failed to open database: {input_path}")
 
     def _unbind_session_everywhere_locked(self, session_id: str) -> None:


### PR DESCRIPTION
Agent will be able to choose architecture and other load options during binary open in idalib-mcp. More work is needed later to teach agent how to do it in annotations.