### PR TITLE
fix: gate unsafe tools in idalib via --unsafe flag (#185)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -1,10 +1,11 @@
-"""Tests for the top-level stdio proxy server (server.py)."""
+"""Tests for the top-level stdio proxy server (server.py) and unsafe tool gating."""
 
 import contextlib
 import os
 import sys
 
 from ..framework import test
+from ..rpc import MCP_SERVER, MCP_UNSAFE
 
 try:
     from ida_pro_mcp import server
@@ -104,3 +105,66 @@ def test_server_proxy_to_instance_forwards_session_and_extensions():
             assert call["headers"].get("Mcp-Session-Id") == "session-456"
         finally:
             server.http.client.HTTPConnection = original_conn
+
+
+# ---------------------------------------------------------------------------
+# Unsafe tool gating (idalib registry-removal approach, mirrors idalib_server)
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _saved_tools():
+    """Save and restore the tools registry so removal tests are non-destructive."""
+    original = MCP_SERVER.tools.methods.copy()
+    try:
+        yield
+    finally:
+        MCP_SERVER.tools.methods = original
+
+
+@test()
+def test_unsafe_tools_registered():
+    """@unsafe decorator should populate MCP_UNSAFE with known tool names."""
+    assert len(MCP_UNSAFE) > 0, "MCP_UNSAFE is empty — no tools marked @unsafe"
+    assert "py_eval" in MCP_UNSAFE, "py_eval should be marked @unsafe"
+    assert "py_exec_file" in MCP_UNSAFE, "py_exec_file should be marked @unsafe"
+
+
+@test()
+def test_unsafe_tools_present_by_default():
+    """Unsafe tools should be in the registry by default (plugin behavior)."""
+    tool_names = set(MCP_SERVER.tools.methods)
+    for name in ("py_eval", "py_exec_file"):
+        assert name in tool_names, f"{name} should be present by default"
+
+
+@test()
+def test_unsafe_tools_hidden_after_removal():
+    """tools/list should exclude tools removed from the registry (idalib --unsafe behavior)."""
+    with _saved_tools():
+        for name in MCP_UNSAFE:
+            MCP_SERVER.tools.methods.pop(name, None)
+        result = MCP_SERVER._mcp_tools_list()
+        tool_names = {t["name"] for t in result.get("tools", [])}
+        leaked = MCP_UNSAFE & tool_names
+        assert not leaked, f"Removed unsafe tools still listed: {leaked}"
+
+
+@test()
+def test_unsafe_tool_call_rejected_after_removal():
+    """tools/call for a removed tool should return an error."""
+    with _saved_tools():
+        for name in MCP_UNSAFE:
+            MCP_SERVER.tools.methods.pop(name, None)
+        result = MCP_SERVER._mcp_tools_call("py_eval", {"code": "pass"})
+        assert result.get("isError"), f"Expected error for removed tool, got: {result}"
+
+
+@test()
+def test_safe_tools_unaffected_by_unsafe_removal():
+    """Non-unsafe tools should remain callable after unsafe removal."""
+    with _saved_tools():
+        for name in MCP_UNSAFE:
+            MCP_SERVER.tools.methods.pop(name, None)
+        assert "decompile" not in MCP_UNSAFE, "decompile should not be unsafe"
+        assert "decompile" in MCP_SERVER.tools.methods, "decompile should survive removal"

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, Optional, TypedDict
 import idapro
 import ida_loader
 
-from ida_pro_mcp.ida_mcp import MCP_SERVER
+from ida_pro_mcp.ida_mcp import MCP_SERVER, MCP_UNSAFE
 from ida_pro_mcp.ida_mcp.api_core import (
     ServerHealthResult,
     ServerWarmupResult,
@@ -556,6 +556,14 @@ def main():
 
     # In isolated mode we require Streamable HTTP session semantics.
     MCP_SERVER.require_streamable_http_session = _ISOLATED_CONTEXTS_ENABLED
+
+    # Gate unsafe tools: remove them from the registry unless --unsafe is set.
+    if not args.unsafe:
+        for name in MCP_UNSAFE:
+            MCP_SERVER.tools.methods.pop(name, None)
+        if MCP_UNSAFE:
+            logger.info("Unsafe tools disabled (start with --unsafe to enable)")
+
     _install_context_activation_hooks()
 
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging


### PR DESCRIPTION
Partially addresses #185 (idalib `--unsafe` flag only; plugin UI dialog deferred to separate PR)

The `--unsafe` flag was parsed by argparse in `idalib_server.py` but never wired up, so `@unsafe`-decorated tools were always available regardless of the flag.

### Changes

- **`idalib_server.py`**: when `--unsafe` is not passed, remove `@unsafe` tools from `MCP_SERVER.tools.methods` before serving
- **`test_server.py`**: 5 new tests verify registration, hiding, rejection, and that safe tools are unaffected

No changes to `zeromcp/mcp.py` or `rpc.py` — the generic MCP layer stays unaware of unsafe semantics. The IDA plugin is unaffected: everything stays enabled by default per the existing per-tool config UI design.

### Verified
- Plugin (IDA 9.3 GUI): 61 tools listed, `py_eval` callable ✅
- idalib `crackme03.elf`: 252 passed ✅
- idalib `typed_fixture.elf`: 248 passed, 1 skipped ✅