### PR TITLE
Suppresses the MCP plugin's autostart when running under idalib mode

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -130,7 +130,7 @@ class MCPUIHooks(ida_kernwin.UI_Hooks):
         # Skip autostart when running under idalib – the idalib_server manages
         # the MCP server lifecycle itself and would otherwise hit a port conflict
         # because unload_package creates a separate MCP_SERVER instance.
-        if self.plugin.autostart and "idapro" not in sys.modules:
+        if self.plugin.autostart and ida_kernwin.is_idaq():
             print("[MCP] Autostarting server...")
             self.plugin.run(0)
         self.unhook()
@@ -156,9 +156,9 @@ class MCP(idaapi.plugin_t):
         self.port = self.DEFAULT_PORT
         self.autostart = _get_autostart()
 
-        if self.autostart and "idapro" not in sys.modules:
+        if self.autostart and ida_kernwin.is_idaq():
             print("[MCP] Plugin loaded, server will start automatically")
-        elif "idapro" in sys.modules:
+        elif not ida_kernwin.is_idaq():
             print("[MCP] Plugin loaded (idalib mode, server managed externally)")
         else:
             print(


### PR DESCRIPTION
Fix #342 

In idalib mode, the idapro module is always imported first (it's required to initialize idalib), so this reliably detects the headless context.

## What's happening

`ida_mcp.py`: `unload_package("ida_mcp")`

This re-imports ida_mcp and creates a new MCP_SERVER instance.

So:

`idalib_server.py` imports MCP_SERVER (instance A)

Plugin autostart calls `unload_package("ida_mcp")`, then re-imports to get MCP_SERVER (instance B)

Plugin starts instance B on port 13337 → success

idalib_server.py tries to start instance A on port 13337 → port conflict

The fix is to skip the plugin autostart in idalib mode, since `idalib_server.py` manages the server lifecycle. When running under idalib, the `idapro` module is always in `sys.modules`.

## Fix: Checks added in `ida_mcp.py`

Use `ida_kernwin.is_idaq()` — the official IDA SDK API that returns True when hosted by the IDA GUI (IDAQ) and False in headless/idalib mode to check if we should suppresses the autostart.