### PR TITLE
Feature/sigmaker support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Important API modules:
 - `api_types.py`: structs, type inference, type application
 - `api_modify.py`: comments, renaming, asm patching
 - `api_stack.py`: stack frame operations
+- `api_sigmaker.py`: signature creation, scanning, xref signatures (uses sigmaker.py)
 - `api_debug.py`: debugger control, unsafe / low priority for tests
 - `api_python.py`: execute Python in IDA context
 - `api_resources.py`: `ida://` MCP resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "idapro>=0.0.7",
     "tomli-w>=1.0.0",
-    "sigmaker",
+
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "idapro>=0.0.7",
     "tomli-w>=1.0.0",
+    "sigmaker",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 dependencies = [
     "idapro>=0.0.7",
     "tomli-w>=1.0.0",
-
 ]
 
 [dependency-groups]

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -8,7 +8,7 @@ Architecture:
 - mcp.py: MCP protocol server (HTTP/SSE)
 - sync.py: IDA synchronization decorator (@idasync)
 - utils.py: Shared helpers and TypedDict definitions
-- api_*.py: Modular API implementations (71 tools + 24 resources)
+- api_*.py: Modular API implementations (76 tools + 24 resources)
 """
 
 # Ignore SIGPIPE to prevent IDA from being killed when an MCP client
@@ -37,6 +37,7 @@ from . import api_resources
 from . import api_survey
 from . import api_composite
 from . import api_discovery
+from . import api_sigmaker
 
 # Re-export key components for external use
 from .sync import idasync, IDAError, IDASyncError, CancelledError
@@ -63,6 +64,7 @@ __all__ = [
     "api_survey",
     "api_composite",
     "api_discovery",
+    "api_sigmaker",
     # Re-exported components
     "idasync",
     "IDAError",

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -8,7 +8,7 @@ Architecture:
 - mcp.py: MCP protocol server (HTTP/SSE)
 - sync.py: IDA synchronization decorator (@idasync)
 - utils.py: Shared helpers and TypedDict definitions
-- api_*.py: Modular API implementations (76 tools + 24 resources)
+- api_*.py: Modular API implementations (75 tools + 24 resources)
 """
 
 # Ignore SIGPIPE to prevent IDA from being killed when an MCP client

--- a/src/ida_pro_mcp/ida_mcp/_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/_sigmaker.py
@@ -1,0 +1,1026 @@
+"""
+Vendored sigmaker core — signature creation and scanning engine.
+
+Original: sigmaker.py - IDA Python Signature Maker
+https://github.com/mahmoudimus/ida-sigmaker
+by @mahmoudimus (Mahmoud Abdelkader)
+
+This is a stripped-down, self-contained copy of the sigmaker library
+with GUI/plugin code removed.  Only the engine classes are kept so that
+api_sigmaker.py can use them without an external dependency.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import dataclasses
+import enum
+import functools
+import logging
+import pathlib
+import re
+import string
+import typing
+
+import idaapi
+import idc
+
+__author__ = "mahmoudimus"
+__version__ = "1.6.0"
+
+
+WILDCARD_POLICY_CTX: contextvars.ContextVar["WildcardPolicy"] = contextvars.ContextVar(
+    "wildcard_policy"
+)
+
+
+SIMD_SPEEDUP_AVAILABLE = False
+with contextlib.suppress(ImportError):
+    try:
+        from sigmaker._speedups import simd_scan
+    except ImportError:
+        from _sigmaker._speedups import simd_scan  # type: ignore[import-not-found]
+
+    _SimdSignature = simd_scan.Signature
+    _simd_scan_bytes = simd_scan.scan_bytes
+
+    SIMD_SPEEDUP_AVAILABLE = True
+
+
+def configure_logging(
+    logger=None,
+    logging_name="sigmaker",
+    level=logging.INFO,
+    handler_filters=None,
+    fmt_str="[%(levelname)s] @ %(message)s",
+):
+    if logger is None:
+        logger = logging.getLogger(logging_name)
+
+    logger.propagate = False
+    logger.setLevel(level)
+    formatter = logging.Formatter(fmt_str)
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    handler.setLevel(level)
+
+    if handler_filters is not None:
+        for _filter in handler_filters:
+            handler.addFilter(_filter)
+
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+
+    if not logger.handlers:
+        logger.addHandler(handler)
+    return logger
+
+
+LOGGER = configure_logging()
+
+
+class Unexpected(Exception):
+    """Exception type used throughout the module to indicate unexpected errors."""
+
+
+@functools.total_ordering
+@dataclasses.dataclass(frozen=True)
+class IDAVersionInfo:
+    major: int
+    minor: int
+    sdk_version: int
+
+    def __eq__(self, other):
+        if isinstance(other, IDAVersionInfo):
+            return (self.major, self.minor) == (other.major, other.minor)
+        if isinstance(other, tuple):
+            return (self.major, self.minor) == tuple(other[:2])
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, IDAVersionInfo):
+            return (self.major, self.minor) < (other.major, other.minor)
+        if isinstance(other, tuple):
+            return (self.major, self.minor) < tuple(other[:2])
+        return NotImplemented
+
+    @staticmethod
+    @functools.cache
+    def ida_version():
+        version_str: str = idaapi.get_kernel_version()
+        sdk_version: int = idaapi.IDA_SDK_VERSION
+        major, minor = map(int, version_str.split("."))
+        return IDAVersionInfo(major, minor, sdk_version)
+
+
+ida_version = IDAVersionInfo.ida_version
+
+
+def is_address_marked_as_code(ea: int) -> bool:
+    return idaapi.is_code(idaapi.get_flags(ea))
+
+
+@dataclasses.dataclass(slots=True)
+class InMemoryBuffer:
+    class LoadMode(enum.Enum):
+        SEGMENTS = "segments"
+        FILE = "file"
+
+    file_path: pathlib.Path
+    mode: LoadMode = dataclasses.field(default=LoadMode.SEGMENTS)
+    _buffer: bytearray = dataclasses.field(
+        default_factory=bytearray, init=False, repr=False
+    )
+
+    @property
+    def file_size(self) -> int:
+        return idaapi.retrieve_input_file_size()
+
+    @property
+    def imagebase(self) -> int:
+        return idaapi.get_imagebase()
+
+    def _load_segments(self):
+        buf = self._buffer
+        seg = idaapi.get_first_seg()
+        while seg:
+            size = seg.end_ea - seg.start_ea
+            data = idaapi.get_bytes(seg.start_ea, size)
+            if data:
+                buf.extend(data)
+            seg = idaapi.get_next_seg(seg.start_ea)
+
+    def _load_input_file(self):
+        if not self.file_path.exists():
+            raise RuntimeError(f"Input file {self.file_path} does not exist.")
+        with self.file_path.open("rb") as f:
+            self._buffer = bytearray(f.read())
+
+    @classmethod
+    def load(
+        cls,
+        file_path: str | pathlib.Path | None = None,
+        mode: "InMemoryBuffer.LoadMode" = LoadMode.SEGMENTS,
+    ) -> "InMemoryBuffer":
+        if file_path is None:
+            file_path = idaapi.get_input_file_path()
+        if isinstance(file_path, str):
+            file_path = pathlib.Path(file_path)
+        instance = cls(file_path=file_path, mode=mode)
+        if mode == cls.LoadMode.FILE:
+            instance._load_input_file()
+        else:
+            instance._load_segments()
+        return instance
+
+    def data(self) -> memoryview:
+        return memoryview(self._buffer)
+
+    def clear(self):
+        self._buffer.clear()
+
+    def file_offset_to_ida_addr(self, file_offset: int) -> int:
+        if self.mode != self.LoadMode.FILE:
+            raise RuntimeError("file_offset_to_ida_addr is only valid in 'file' mode.")
+        return self.imagebase + file_offset
+
+    def ida_addr_to_file_offset(self, ida_addr: int) -> int:
+        if self.mode != self.LoadMode.FILE:
+            raise RuntimeError("ida_addr_to_file_offset is only valid in 'file' mode.")
+        return ida_addr - self.imagebase
+
+    def segment_offset_to_ida_addr(self, seg_offset: int) -> int:
+        if self.mode != self.LoadMode.SEGMENTS:
+            raise RuntimeError(
+                "segment_offset_to_ida_addr is only valid in 'segments' mode."
+            )
+        return self.imagebase + seg_offset
+
+    def ida_addr_to_segment_offset(self, ida_addr: int) -> int:
+        if self.mode != self.LoadMode.SEGMENTS:
+            raise RuntimeError(
+                "ida_addr_to_segment_offset is only valid in 'segments' mode."
+            )
+        return ida_addr - self.imagebase
+
+
+@dataclasses.dataclass
+class SigMakerConfig:
+    output_format: SignatureType
+    wildcard_operands: bool
+    continue_outside_of_function: bool
+    wildcard_optimized: bool
+    ask_longer_signature: bool = True
+    print_top_x: int = 5
+    max_single_signature_length: int = 100
+    max_xref_signature_length: int = 250
+
+
+@dataclasses.dataclass(slots=True, frozen=True, repr=False)
+class Match:
+    address: int
+
+    def __repr__(self) -> str:
+        return f"Match(address={hex(self.address)})"
+
+    def __str__(self) -> str:
+        return hex(self.address)
+
+    def __int__(self) -> int:
+        return self.address
+
+    __index__ = __int__
+
+
+class SignatureType(enum.Enum):
+    IDA = "ida"
+    x64Dbg = "x64dbg"
+    Mask = "mask"
+    BitMask = "bitmask"
+
+    @classmethod
+    def at(cls, index: int) -> "SignatureType":
+        return list(cls.__members__.values())[index]
+
+
+class SignatureByte(typing.NamedTuple):
+    value: int
+    is_wildcard: bool
+
+
+class Signature(list[SignatureByte]):
+    def add_byte_to_signature(self, address: int, is_wildcard: bool) -> None:
+        byte_value = idaapi.get_byte(address)
+        self.append(SignatureByte(byte_value, is_wildcard))
+
+    def add_bytes_to_signature(
+        self, address: int, count: int, is_wildcard: bool
+    ) -> None:
+        bytes_data = idaapi.get_bytes(address, count)
+        if bytes_data:
+            self.extend(SignatureByte(b, is_wildcard) for b in bytes_data)
+
+    def trim_signature(self) -> None:
+        n = len(self)
+        while n > 0 and self[n - 1].is_wildcard:
+            n -= 1
+        del self[n:]
+
+    def __str__(self) -> str:
+        return self.__format__("")
+
+    def __format__(self, format_spec: str) -> str:
+        spec = format_spec.lower()
+        try:
+            formatter = FORMATTER_MAP[SignatureType(spec)]
+        except KeyError:
+            raise ValueError(
+                f"Unknown format code '{format_spec}' for object of type 'Signature'"
+            )
+        return formatter.format(self)
+
+
+class SignatureFormatter(typing.Protocol):
+    def format(self, signature: "Signature") -> str: ...
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class IdaFormatter:
+    wildcard_byte: str = "?"
+
+    def format(self, signature: "Signature") -> str:
+        parts = []
+        for byte in signature:
+            if byte.is_wildcard:
+                parts.append(self.wildcard_byte)
+            else:
+                parts.append(f"{byte.value:02X}")
+        return " ".join(parts)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class X64DbgFormatter(IdaFormatter):
+    wildcard_byte: str = "??"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class MaskedBytesFormatter:
+    wildcard_byte: str = "\\x00"
+    mask: str = "x"
+    wildcard_mask: str = "?"
+
+    @staticmethod
+    def build_signature_parts(
+        signature: "Signature",
+        byte_format: str,
+        wildcard_byte: str,
+        mask_char: str,
+        wildcard_mask_char: str,
+    ) -> tuple[list[str], list[str]]:
+        pattern_parts = []
+        mask_parts = []
+        for byte in signature:
+            if byte.is_wildcard:
+                pattern_parts.append(wildcard_byte)
+                mask_parts.append(wildcard_mask_char)
+            else:
+                pattern_parts.append(byte_format.format(byte.value))
+                mask_parts.append(mask_char)
+        return pattern_parts, mask_parts
+
+    def format(self, signature: "Signature") -> str:
+        pattern_parts, mask_parts = self.build_signature_parts(
+            signature,
+            "\\x{:02X}",
+            self.wildcard_byte,
+            self.mask,
+            self.wildcard_mask,
+        )
+        return "".join(pattern_parts) + " " + "".join(mask_parts)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ByteArrayBitmaskFormatter:
+    wildcard_byte: str = "0x00"
+    mask: str = "1"
+    wildcard_mask: str = "0"
+
+    def format(self, signature: "Signature") -> str:
+        pattern_parts, mask_parts = MaskedBytesFormatter.build_signature_parts(
+            signature,
+            "0x{:02X}",
+            self.wildcard_byte,
+            self.mask,
+            self.wildcard_mask,
+        )
+        pattern_str = ", ".join(pattern_parts)
+        mask_str = "".join(mask_parts)[::-1]
+        return f"{pattern_str} 0b{mask_str}"
+
+
+FORMATTER_MAP: typing.Dict[SignatureType, SignatureFormatter] = {
+    SignatureType.IDA: IdaFormatter(),
+    SignatureType.x64Dbg: X64DbgFormatter(),
+    SignatureType.Mask: MaskedBytesFormatter(),
+    SignatureType.BitMask: ByteArrayBitmaskFormatter(),
+}
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class WildcardPolicy:
+    allowed_types: frozenset[int]
+    _ctx = WILDCARD_POLICY_CTX
+
+    class RarelyWildcardable(enum.IntEnum):
+        VOID = idaapi.o_void
+        REG = idaapi.o_reg
+
+    class BaseKind(enum.IntEnum):
+        MEM = idaapi.o_mem
+        PHRASE = idaapi.o_phrase
+        DISPL = idaapi.o_displ
+        IMM = idaapi.o_imm
+        FAR = idaapi.o_far
+        NEAR = idaapi.o_near
+
+    class X86Kind(enum.IntEnum):
+        TRREG = idaapi.o_idpspec0
+        DBREG = idaapi.o_idpspec1
+        CRREG = idaapi.o_idpspec2
+        FPREG = idaapi.o_idpspec3
+        MMX = idaapi.o_idpspec4
+        XMM = idaapi.o_idpspec5
+        YMM = idaapi.o_idpspec5 + 1
+        ZMM = idaapi.o_idpspec5 + 2
+        KREG = idaapi.o_idpspec5 + 3
+
+    class ARMKind(enum.IntEnum):
+        REGLIST = idaapi.o_idpspec1
+        CREGLIST = idaapi.o_idpspec2
+        CREG = idaapi.o_idpspec3
+        FPREGLIST = idaapi.o_idpspec4
+        TEXT = idaapi.o_idpspec5
+        COND = idaapi.o_idpspec5 + 1
+
+    class MIPSKind(enum.IntEnum):
+        pass
+
+    class PPCKind(enum.IntEnum):
+        SPR = idaapi.o_idpspec0
+        TWOFPR = idaapi.o_idpspec1
+        SHMBME = idaapi.o_idpspec2
+        CRF = idaapi.o_idpspec3
+        CRB = idaapi.o_idpspec4
+        DCR = idaapi.o_idpspec5
+
+    @dataclasses.dataclass(slots=True)
+    class _Use:
+        policy: "WildcardPolicy"
+        policy_class: type["WildcardPolicy"]
+        token: contextvars.Token | None = None
+
+        def __enter__(self):
+            self.token = self.policy_class.set_current(self.policy)
+            return self.policy
+
+        def __exit__(self, exc_type, exc, tb):
+            if self.token is not None:
+                self.policy_class.reset_current(self.token)
+
+    @classmethod
+    def for_x86(cls) -> "WildcardPolicy":
+        return cls(frozenset(cls.BaseKind) | frozenset(cls.X86Kind))
+
+    @classmethod
+    def for_arm(cls) -> "WildcardPolicy":
+        return cls(frozenset(cls.BaseKind) | frozenset(cls.ARMKind))
+
+    @classmethod
+    def for_mips(cls) -> "WildcardPolicy":
+        return cls(frozenset({cls.BaseKind.MEM, cls.BaseKind.FAR, cls.BaseKind.NEAR}))
+
+    @classmethod
+    def for_ppc(cls) -> "WildcardPolicy":
+        return cls(frozenset(cls.BaseKind) | frozenset(cls.PPCKind))
+
+    @classmethod
+    def default_generic(cls) -> "WildcardPolicy":
+        return cls(frozenset(cls.BaseKind))
+
+    @classmethod
+    def detect_from_processor(cls) -> "WildcardPolicy":
+        arch = idaapi.ph_get_id()
+        if arch == idaapi.PLFM_386:
+            return cls.for_x86()
+        if arch == idaapi.PLFM_ARM:
+            return cls.for_arm()
+        if arch == idaapi.PLFM_MIPS:
+            return cls.for_mips()
+        if arch == idaapi.PLFM_PPC:
+            return cls.for_ppc()
+        return cls.default_generic()
+
+    def allows_type(self, op_type: int) -> bool:
+        return op_type in self.allowed_types
+
+    def to_mask(self) -> int:
+        return sum(1 << int(t) for t in self.allowed_types)
+
+    @classmethod
+    def from_mask(cls, mask: int) -> "WildcardPolicy":
+        types = {t for t in range(0, 64) if (mask >> t) & 1}
+        return cls(frozenset(types))
+
+    @classmethod
+    def current(cls) -> "WildcardPolicy":
+        policy = cls._ctx.get(cls.detect_from_processor())
+        cls._ctx.set(policy)
+        return policy
+
+    @classmethod
+    def set_current(cls, policy: "WildcardPolicy") -> contextvars.Token:
+        return cls._ctx.set(policy)
+
+    @classmethod
+    def reset_current(cls, token: contextvars.Token) -> None:
+        cls._ctx.reset(token)
+
+    @classmethod
+    def use(cls, policy: "WildcardPolicy") -> "WildcardPolicy._Use":
+        return cls._Use(policy, cls)
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class GeneratedSignature:
+    signature: Signature
+    address: Match | None = None
+
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, GeneratedSignature):
+            return NotImplemented
+        return len(self.signature) < len(other.signature)
+
+
+@dataclasses.dataclass(slots=True)
+class XrefGeneratedSignature:
+    signatures: list[GeneratedSignature]
+
+
+class SigText:
+    _HEX_SET = frozenset(string.hexdigits)
+    _TRANS = str.maketrans(
+        {
+            ",": " ",
+            ";": " ",
+            ":": " ",
+            "|": " ",
+            "_": " ",
+            "-": " ",
+            "\t": " ",
+            "\n": " ",
+            "\r": " ",
+            ".": "?",
+        }
+    )
+
+    @staticmethod
+    def _tok_is_hex(s: str) -> bool:
+        return len(s) > 0 and all(c in SigText._HEX_SET for c in s)
+
+    @staticmethod
+    def _split_hex_pairs(s: str) -> list[str]:
+        return [s[i : i + 2].upper() for i in range(0, len(s), 2)]
+
+    @staticmethod
+    def normalize(sig_str: str) -> tuple[str, list[tuple[int, bool]]]:
+        if not sig_str:
+            return "", []
+        s = sig_str.translate(SigText._TRANS)
+        raw = [t for t in s.split() if t]
+        toks: list[str] = []
+        for t in raw:
+            t = t.strip()
+            if t.startswith(("0x", "0X")):
+                t = t[2:]
+            if not t:
+                continue
+            toks.append(t)
+
+        out: list[str] = []
+        i = 0
+        while i < len(toks):
+            t = toks[i]
+
+            if t == "??":
+                out.append("??")
+                i += 1
+                continue
+
+            if len(t) == 2 and SigText._tok_is_hex(t):
+                out.append(t.upper())
+                i += 1
+                continue
+
+            if len(t) == 1 and t in SigText._HEX_SET:
+                out.append((t + "?").upper())
+                i += 1
+                continue
+
+            if t == "?":
+                out.append("??")
+                i += 1
+                continue
+
+            if SigText._tok_is_hex(t):
+                if (len(t) & 1) != 0:
+                    pairs = SigText._split_hex_pairs(t)
+                    pairs_len = len(pairs)
+                    if pairs and len(pairs[pairs_len - 1]) == 1:
+                        pairs[pairs_len - 1] = "?" + pairs[pairs_len - 1]
+                    out.extend(pairs)
+                    i += 1
+                    continue
+                else:
+                    out.extend(SigText._split_hex_pairs(t))
+                    i += 1
+                    continue
+
+            if len(t) == 2:
+                hi, lo = t[0], t[1]
+                if (hi in SigText._HEX_SET or hi == "?") and (
+                    lo in SigText._HEX_SET or lo == "?"
+                ):
+                    out.append((hi + lo).upper())
+                    i += 1
+                    continue
+
+            raise ValueError(f"invalid signature token: {t!r}")
+
+        pattern: list[tuple[int, bool]] = []
+        for tok in out:
+            hi, lo = tok[0], tok[1]
+            wild = (hi == "?") or (lo == "?")
+            hv = 0 if hi == "?" else int(hi, 16)
+            lv = 0 if lo == "?" else int(lo, 16)
+            pattern.append(((hv << 4) | lv, wild))
+
+        return " ".join(out), pattern
+
+
+class OperandProcessor:
+    def __init__(self):
+        self._is_arm = self._check_is_arm()
+
+    @staticmethod
+    def _check_is_arm() -> bool:
+        return idaapi.ph_get_id() == idaapi.PLFM_ARM
+
+    def _get_operand_offset_arm(
+        self, ins: idaapi.insn_t, off: typing.List[int], length: typing.List[int]
+    ) -> bool:
+        policy = WildcardPolicy.current()
+        for op in ins:
+            if op.type in policy.allowed_types:
+                off[0] = op.offb
+                length[0] = 3 if ins.size == 4 else (7 if ins.size == 8 else 0)
+                return True
+        return False
+
+    def get_operand(
+        self,
+        ins: idaapi.insn_t,
+        off: typing.List[int],
+        length: typing.List[int],
+        wildcard_optimized: bool,
+    ) -> bool:
+        policy = WildcardPolicy.current()
+        if self._is_arm:
+            return self._get_operand_offset_arm(ins, off, length)
+        for op in ins:
+            if op.type == idaapi.o_void:
+                continue
+            if not policy.allows_type(op.type):
+                continue
+            if op.offb == 0 and not wildcard_optimized:
+                continue
+            off[0] = op.offb
+            length[0] = ins.size - op.offb
+            return True
+        return False
+
+
+class InstructionProcessor:
+    def __init__(self, operand_processor: OperandProcessor):
+        self.operand_processor = operand_processor
+
+    def append_instruction_to_sig(
+        self,
+        sig: Signature,
+        ea: int,
+        ins: idaapi.insn_t,
+        wildcard_operands: bool,
+        wildcard_optimized: bool,
+    ) -> None:
+        if not wildcard_operands:
+            sig.add_bytes_to_signature(ea, ins.size, is_wildcard=False)
+            return
+
+        off, length = [0], [0]
+        has_operand = self.operand_processor.get_operand(
+            ins, off, length, wildcard_optimized
+        )
+        if not has_operand or length[0] <= 0:
+            sig.add_bytes_to_signature(ea, ins.size, is_wildcard=False)
+            return
+
+        if off[0] > 0:
+            sig.add_bytes_to_signature(ea, off[0], is_wildcard=False)
+
+        sig.add_bytes_to_signature(ea + off[0], length[0], is_wildcard=True)
+
+        remaining_len = ins.size - (off[0] + length[0])
+        if remaining_len > 0:
+            sig.add_bytes_to_signature(
+                ea + off[0] + length[0], remaining_len, is_wildcard=False
+            )
+
+
+@dataclasses.dataclass(slots=True)
+class InstructionWalker:
+    start_ea: int
+    end_ea: int = idaapi.BADADDR
+
+    cursor: int = dataclasses.field(init=False)
+    _instruction: idaapi.insn_t = dataclasses.field(
+        init=False, repr=False, default_factory=idaapi.insn_t
+    )
+
+    def __post_init__(self):
+        if self.start_ea == idaapi.BADADDR:
+            raise ValueError("Invalid start address for InstructionWalker")
+        self.cursor = self.start_ea
+
+    def __iter__(self):
+        self.cursor = self.start_ea
+        return self
+
+    def __next__(self) -> tuple[int, idaapi.insn_t, int]:
+        if self.end_ea != idaapi.BADADDR and self.cursor >= self.end_ea:
+            raise StopIteration
+
+        current_instruction_ea = self.cursor
+        ins_len = idaapi.decode_insn(self._instruction, current_instruction_ea)
+
+        if ins_len <= 0:
+            raise StopIteration
+
+        self.cursor += ins_len
+
+        return current_instruction_ea, self._instruction, ins_len
+
+
+class UniqueSignatureGenerator:
+    def __init__(self, processor: InstructionProcessor):
+        self.processor = processor
+
+    def generate(self, ea: int, cfg: SigMakerConfig) -> Signature:
+        if not is_address_marked_as_code(ea):
+            raise Unexpected("Cannot create code signature for data")
+
+        sig = Signature()
+        start_fn = idaapi.get_func(ea)
+        bytes_since_last_check = 0
+
+        for cur_ea, ins, ins_len in InstructionWalker(ea):
+            if bytes_since_last_check > cfg.max_single_signature_length:
+                if not cfg.ask_longer_signature:
+                    raise Unexpected("Signature not unique within length constraints")
+                bytes_since_last_check = 0
+
+            if (
+                not cfg.continue_outside_of_function
+                and start_fn
+                and cur_ea >= start_fn.end_ea
+            ):
+                raise Unexpected("Signature left function scope without being unique")
+
+            self.processor.append_instruction_to_sig(
+                sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
+            )
+            bytes_since_last_check += ins_len
+
+            if SignatureSearcher.is_unique(f"{sig:ida}"):
+                sig.trim_signature()
+                return sig
+
+        raise Unexpected("Signature not unique (reached end of analysis)")
+
+
+class RangeSignatureGenerator:
+    def __init__(self, processor: InstructionProcessor):
+        self.processor = processor
+
+    def generate(self, start_ea: int, end_ea: int, cfg: SigMakerConfig) -> Signature:
+        sig = Signature()
+
+        if not is_address_marked_as_code(start_ea):
+            sig.add_bytes_to_signature(start_ea, end_ea - start_ea, is_wildcard=False)
+            return sig
+
+        walker = InstructionWalker(start_ea, end_ea)
+        for cur_ea, ins, _ in walker:
+            self.processor.append_instruction_to_sig(
+                sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
+            )
+
+        if walker.cursor < end_ea:
+            remaining_bytes = end_ea - walker.cursor
+            sig.add_bytes_to_signature(
+                walker.cursor, remaining_bytes, is_wildcard=False
+            )
+
+        sig.trim_signature()
+        return sig
+
+
+@dataclasses.dataclass(slots=True)
+class SignatureMaker:
+    _operand_processor: OperandProcessor = dataclasses.field(
+        default_factory=OperandProcessor
+    )
+
+    _instruction_processor: InstructionProcessor = dataclasses.field(init=False)
+    _unique_generator: UniqueSignatureGenerator = dataclasses.field(init=False)
+    _range_generator: RangeSignatureGenerator = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self._instruction_processor = InstructionProcessor(self._operand_processor)
+        self._unique_generator = UniqueSignatureGenerator(self._instruction_processor)
+        self._range_generator = RangeSignatureGenerator(self._instruction_processor)
+
+    def make_signature(
+        self, ea: int | Match, cfg: SigMakerConfig, end: int | None = None
+    ) -> GeneratedSignature:
+        start_ea = int(ea)
+        if start_ea == idaapi.BADADDR:
+            raise Unexpected("Invalid start address")
+
+        if end is None:
+            sig = self._unique_generator.generate(start_ea, cfg)
+            return GeneratedSignature(sig, Match(start_ea))
+
+        if end <= start_ea:
+            raise Unexpected("End address must be after start address")
+
+        sig = self._range_generator.generate(start_ea, end, cfg)
+        return GeneratedSignature(sig)
+
+
+class XrefFinder:
+    """Handles finding and generating signatures for XREF addresses."""
+
+    def __init__(self):
+        self.signature_maker = SignatureMaker()
+
+    @classmethod
+    def iter_code_xrefs_to(cls, ea: int) -> typing.Iterable[int]:
+        xb = idaapi.xrefblk_t()
+        if not xb.first_to(ea, idaapi.XREF_ALL):
+            return
+
+        while True:
+            if is_address_marked_as_code(xb.frm):
+                yield xb.frm
+            if not xb.next_to():
+                break
+
+    @classmethod
+    def count_code_xrefs_to(cls, ea: int) -> int:
+        return sum(1 for _ in cls.iter_code_xrefs_to(ea))
+
+    def find_xrefs(self, ea: int, cfg: SigMakerConfig) -> XrefGeneratedSignature:
+        xref_signatures: list[GeneratedSignature] = []
+
+        total = self.count_code_xrefs_to(ea)
+        if total == 0:
+            return XrefGeneratedSignature([])
+
+        cfg_no_prompt = dataclasses.replace(cfg, ask_longer_signature=False)
+
+        shortest_len = cfg.max_xref_signature_length + 1
+
+        for i, frm_ea in enumerate(self.iter_code_xrefs_to(ea), start=1):
+            try:
+                result = self.signature_maker.make_signature(frm_ea, cfg_no_prompt)
+                sig: typing.Optional[Signature] = result.signature
+            except Exception:
+                sig = None
+
+            if sig is None:
+                continue
+
+            if len(sig) < shortest_len:
+                shortest_len = len(sig)
+            xref_signatures.append(GeneratedSignature(sig, Match(frm_ea)))
+
+        xref_signatures.sort()
+        return XrefGeneratedSignature(xref_signatures)
+
+
+@dataclasses.dataclass(slots=True)
+class SearchResults:
+    matches: list[Match]
+    signature_str: str
+
+
+class SignatureParser:
+    _HEX_PAIR = re.compile(r"^[0-9A-Fa-f]{2}$")
+    _ESCAPED_HEX = re.compile(r"\\x[0-9A-Fa-f]{2}")
+    _RUN_0X = re.compile(r"(?:0x[0-9A-Fa-f]{2})+")
+
+    _MASK_REGEX = re.compile(r"x(?:x|\?)+")
+    _BINARY_MASK_REGEX = re.compile(r"0b[01]+")
+
+    @classmethod
+    def parse(cls, input_str: str) -> str:
+        mask = cls._extract_mask(input_str)
+        parsed = ""
+        if mask:
+            bytestr: list[str] = []
+            if (bytestr := cls._ESCAPED_HEX.findall(input_str)) and len(bytestr) == len(
+                mask
+            ):
+                parsed = cls._masked_bytes_to_ida(bytestr, mask, slice_from=2)
+
+            elif (bytestr := cls._RUN_0X.findall(input_str)) and len(bytestr) == len(
+                mask
+            ):
+                parsed = cls._masked_bytes_to_ida(bytestr, mask, slice_from=2)
+            else:
+                LOGGER.warning(
+                    f'Detected mask "{mask}" but failed to match corresponding bytes'
+                )
+        else:
+            parsed = cls._normalize_loose_hex(input_str)
+        return parsed.strip()
+
+    @classmethod
+    def _extract_mask(cls, s: str) -> str:
+        m = cls._MASK_REGEX.search(s)
+        if m:
+            return m.group(0)
+
+        m = cls._BINARY_MASK_REGEX.search(s)
+        if not m:
+            return ""
+        bits = m.group(0)[2:]
+        return "".join("x" if b == "1" else "?" for b in bits[::-1])
+
+    @staticmethod
+    def _masked_bytes_to_ida(
+        byte_tokens: list[str], mask: str, *, slice_from: int
+    ) -> str:
+        sig = Signature(
+            [
+                SignatureByte(int(tok[slice_from:], 16), mask[i] == "?")
+                for i, tok in enumerate(byte_tokens)
+            ]
+        )
+        return f"{sig:ida}"
+
+    @classmethod
+    def _normalize_loose_hex(cls, input_str: str) -> str:
+        s = input_str
+        s = re.sub(r"[\)\(\[\]]+", "", s)
+        s = re.sub(r"^\s+", "", s)
+        s = re.sub(r"[? ]+$", "", s) + " "
+        s = re.sub(r"\\?\\x", "", s)
+        s = re.sub(r"\s+", " ", s)
+
+        tokens = [t.strip() for t in s.split() if t.strip()]
+        out: list[str] = []
+        for t in tokens:
+            if t == "?" or t == "??":
+                out.append("?")
+                continue
+            if t.lower().startswith("0x"):
+                t = t[2:]
+            if not cls._HEX_PAIR.match(t):
+                out.append("?")
+                continue
+            out.append(t.upper())
+
+        return (" ".join(out) + " ") if out else ""
+
+
+@dataclasses.dataclass(slots=True)
+class SignatureSearcher:
+    input_signature: str = ""
+
+    @classmethod
+    def from_signature(cls, input_signature: str) -> "SignatureSearcher":
+        return cls(input_signature=input_signature)
+
+    def search(self) -> SearchResults:
+        sig_str = SignatureParser.parse(self.input_signature)
+        if not sig_str:
+            return SearchResults([], "")
+        matches = self.find_all(sig_str)
+        return SearchResults(matches, sig_str)
+
+    @staticmethod
+    def _find_all_simd(
+        ida_signature: str, skip_more_than_one: bool = False
+    ) -> list[Match]:
+        simd_signature, _ = SigText.normalize(ida_signature)
+        buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+        data_mv = buf.data()
+
+        sig = _SimdSignature(simd_signature)
+        results: list[Match] = []
+        base = idaapi.inf_get_min_ea()
+        if (k := sig.size_bytes) == 0:
+            return [Match(base)]
+
+        n = len(data_mv)
+        off = 0
+        while off <= n - k:
+            idx = _simd_scan_bytes(data_mv[off:], sig)
+            if idx < 0:
+                break
+            ea = base + off + idx
+            results.append(Match(ea))
+            if skip_more_than_one and len(results) > 1:
+                break
+            off += idx + 1
+        return results
+
+    @staticmethod
+    def find_all(ida_signature: str) -> list[Match]:
+        if SIMD_SPEEDUP_AVAILABLE:
+            return SignatureSearcher._find_all_simd(ida_signature)
+        binary = idaapi.compiled_binpat_vec_t()
+        idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
+        out: list[Match] = []
+        ea = idaapi.inf_get_min_ea()
+        _bin_search = getattr(idaapi, "bin_search", None) or getattr(
+            idaapi, "bin_search3"
+        )
+        while True:
+            hit, _ = _bin_search(
+                ea,
+                idaapi.inf_get_max_ea(),
+                binary,
+                idaapi.BIN_SEARCH_NOCASE | idaapi.BIN_SEARCH_FORWARD,
+            )
+            if hit == idaapi.BADADDR:
+                break
+            out.append(Match(hit))
+            ea = hit + 1
+        return out
+
+    @classmethod
+    def is_unique(cls, ida_signature: str) -> bool:
+        return len(cls.find_all(ida_signature)) == 1

--- a/src/ida_pro_mcp/ida_mcp/_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/_sigmaker.py
@@ -8,6 +8,28 @@ by @mahmoudimus (Mahmoud Abdelkader)
 This is a stripped-down, self-contained copy of the sigmaker library
 with GUI/plugin code removed.  Only the engine classes are kept so that
 api_sigmaker.py can use them without an external dependency.
+
+MIT License
+
+Copyright (c) 2024 Mahmoud Abdelkader (@mahmoudimus)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 """
 
 from __future__ import annotations

--- a/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
@@ -1,0 +1,409 @@
+"""Signature creation and scanning tools for IDA Pro MCP.
+
+This module integrates sigmaker.py functionality to provide:
+- Unique signature generation for addresses/functions
+- Range-based signature generation (selection)
+- XREF-based signature discovery
+- Signature scanning/searching
+- Multiple output formats: IDA, x64dbg, mask, bitmask
+"""
+
+from typing import Annotated, NotRequired, TypedDict
+
+import idaapi
+import ida_funcs
+
+from .rpc import tool
+from .sync import idasync
+from .utils import parse_address, normalize_list_input
+
+# ---------------------------------------------------------------------------
+# Lazy import of sigmaker (lives in the IDA plugins dir or sys.path)
+# ---------------------------------------------------------------------------
+_sigmaker = None
+
+
+def _get_sigmaker():
+    global _sigmaker
+    if _sigmaker is None:
+        import sigmaker as _sm
+
+        _sigmaker = _sm
+    return _sigmaker
+
+
+# ---------------------------------------------------------------------------
+# Output format helpers
+# ---------------------------------------------------------------------------
+
+_FORMAT_ALIASES = {
+    "ida": "ida",
+    "x64dbg": "x64dbg",
+    "mask": "mask",
+    "bitmask": "bitmask",
+}
+
+
+def _resolve_format(fmt: str) -> "str":
+    key = fmt.lower().strip()
+    if key not in _FORMAT_ALIASES:
+        raise ValueError(
+            f"Unknown signature format '{fmt}'. "
+            f"Valid formats: ida, x64dbg, mask, bitmask"
+        )
+    return _FORMAT_ALIASES[key]
+
+
+def _make_config(
+    fmt: str,
+    wildcard_operands: bool = True,
+    continue_outside_function: bool = True,
+    max_length: int = 1000,
+) -> "object":
+    sm = _get_sigmaker()
+    return sm.SigMakerConfig(
+        output_format=sm.SignatureType(fmt),
+        wildcard_operands=wildcard_operands,
+        continue_outside_of_function=continue_outside_function,
+        wildcard_optimized=False,
+        ask_longer_signature=False,
+        max_single_signature_length=max_length,
+        max_xref_signature_length=max_length,
+    )
+
+
+def _resolve_addr(addr_str: str) -> int:
+    """Resolve an address string or name to an ea."""
+    try:
+        return parse_address(addr_str)
+    except Exception:
+        ea = idaapi.get_name_ea(idaapi.BADADDR, addr_str)
+        if ea == idaapi.BADADDR:
+            raise ValueError(f"Cannot resolve address or name: {addr_str}")
+        return ea
+
+
+def _format_sig(sig, fmt: str) -> str:
+    return format(sig, fmt)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class MakeSigResult(TypedDict):
+    query: str
+    addr: str | None
+    signature: str | None
+    format: str
+    unique: NotRequired[bool]
+    error: NotRequired[str]
+
+
+class MakeSigForFunctionResult(TypedDict):
+    query: str
+    addr: str | None
+    name: str | None
+    signature: str | None
+    format: str
+    error: NotRequired[str]
+
+
+class XrefSigResult(TypedDict):
+    query: str
+    addr: str | None
+    signatures: list[dict] | None
+    total_xrefs: NotRequired[int]
+    error: NotRequired[str]
+
+
+class ScanSigResult(TypedDict):
+    signature: str
+    matches: list[str]
+    n: int
+    unique: bool
+    error: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+@idasync
+def make_signature(
+    addrs: Annotated[
+        list[str] | str,
+        "Address(es) or name(s) to create unique signatures for "
+        "(e.g. '0x401000', 'main', or ['0x401000', 'sub_402000'])",
+    ],
+    format: Annotated[
+        str,
+        "Output format: 'ida' (default), 'x64dbg', 'mask', or 'bitmask'",
+    ] = "ida",
+    wildcard_operands: Annotated[
+        bool,
+        "Wildcard instruction operands for relocatable signatures (default: true)",
+    ] = True,
+    max_length: Annotated[
+        int,
+        "Maximum signature length in bytes before giving up (default: 1000)",
+    ] = 1000,
+) -> list[MakeSigResult]:
+    """Create unique byte signatures for addresses. Generates the shortest
+    unique signature starting at each address by walking instructions and
+    wildcarding operands. Useful for finding stable patterns that survive
+    recompilation."""
+    sm = _get_sigmaker()
+    fmt = _resolve_format(format)
+    cfg = _make_config(fmt, wildcard_operands=wildcard_operands, max_length=max_length)
+    maker = sm.SignatureMaker()
+    addrs_list = normalize_list_input(addrs)
+
+    results: list[MakeSigResult] = []
+    for addr_str in addrs_list:
+        try:
+            ea = _resolve_addr(addr_str)
+            result = maker.make_signature(ea, cfg)
+            sig_str = _format_sig(result.signature, fmt)
+            # Verify uniqueness
+            is_unique = sm.SignatureSearcher.is_unique(f"{result.signature:ida}")
+            results.append({
+                "query": addr_str,
+                "addr": hex(ea),
+                "signature": sig_str,
+                "format": format,
+                "unique": is_unique,
+            })
+        except Exception as e:
+            results.append({
+                "query": addr_str,
+                "addr": hex(ea) if 'ea' in dir() else None,
+                "signature": None,
+                "format": format,
+                "error": str(e),
+            })
+    return results
+
+
+@tool
+@idasync
+def make_signature_for_function(
+    addrs: Annotated[
+        list[str] | str,
+        "Function address(es) or name(s) to create signatures for "
+        "(e.g. 'main', '0x401000', or ['main', 'sub_402000'])",
+    ],
+    format: Annotated[
+        str,
+        "Output format: 'ida' (default), 'x64dbg', 'mask', or 'bitmask'",
+    ] = "ida",
+    wildcard_operands: Annotated[
+        bool,
+        "Wildcard instruction operands for relocatable signatures (default: true)",
+    ] = True,
+    max_length: Annotated[
+        int,
+        "Maximum signature length in bytes before giving up (default: 1000)",
+    ] = 1000,
+) -> list[MakeSigForFunctionResult]:
+    """Create unique byte signatures for function entry points. Resolves each
+    name/address to a function, then generates the shortest unique signature
+    starting at the function start."""
+    sm = _get_sigmaker()
+    fmt = _resolve_format(format)
+    cfg = _make_config(fmt, wildcard_operands=wildcard_operands, max_length=max_length)
+    maker = sm.SignatureMaker()
+    addrs_list = normalize_list_input(addrs)
+
+    results: list[MakeSigForFunctionResult] = []
+    for addr_str in addrs_list:
+        ea = None
+        try:
+            ea = _resolve_addr(addr_str)
+            func = ida_funcs.get_func(ea)
+            if not func:
+                results.append({
+                    "query": addr_str,
+                    "addr": hex(ea),
+                    "name": None,
+                    "signature": None,
+                    "format": format,
+                    "error": f"No function at {hex(ea)}",
+                })
+                continue
+
+            func_ea = func.start_ea
+            func_name = idaapi.get_func_name(func_ea) or None
+            result = maker.make_signature(func_ea, cfg)
+            sig_str = _format_sig(result.signature, fmt)
+            results.append({
+                "query": addr_str,
+                "addr": hex(func_ea),
+                "name": func_name,
+                "signature": sig_str,
+                "format": format,
+            })
+        except Exception as e:
+            results.append({
+                "query": addr_str,
+                "addr": hex(ea) if ea is not None else None,
+                "name": None,
+                "signature": None,
+                "format": format,
+                "error": str(e),
+            })
+    return results
+
+
+@tool
+@idasync
+def make_signature_for_range(
+    start: Annotated[str, "Start address or name (e.g. '0x401000')"],
+    end: Annotated[str, "End address or name (exclusive, e.g. '0x401020')"],
+    format: Annotated[
+        str,
+        "Output format: 'ida' (default), 'x64dbg', 'mask', or 'bitmask'",
+    ] = "ida",
+    wildcard_operands: Annotated[
+        bool,
+        "Wildcard instruction operands for relocatable signatures (default: true)",
+    ] = True,
+) -> MakeSigResult:
+    """Create a byte signature for a specific address range (e.g. a selected
+    region). Unlike make_signature, this does NOT guarantee uniqueness — it
+    simply encodes the bytes in the range with optional operand wildcarding."""
+    sm = _get_sigmaker()
+    fmt = _resolve_format(format)
+    cfg = _make_config(fmt, wildcard_operands=wildcard_operands)
+    maker = sm.SignatureMaker()
+
+    try:
+        start_ea = _resolve_addr(start)
+        end_ea = _resolve_addr(end)
+        result = maker.make_signature(start_ea, cfg, end=end_ea)
+        sig_str = _format_sig(result.signature, fmt)
+        is_unique = sm.SignatureSearcher.is_unique(f"{result.signature:ida}")
+        return {
+            "query": f"{start}-{end}",
+            "addr": hex(start_ea),
+            "signature": sig_str,
+            "format": format,
+            "unique": is_unique,
+        }
+    except Exception as e:
+        return {
+            "query": f"{start}-{end}",
+            "addr": None,
+            "signature": None,
+            "format": format,
+            "error": str(e),
+        }
+
+
+@tool
+@idasync
+def find_xref_signatures(
+    addrs: Annotated[
+        list[str] | str,
+        "Address(es) or name(s) to find XREF signatures for "
+        "(e.g. a data address referenced by code)",
+    ],
+    format: Annotated[
+        str,
+        "Output format: 'ida' (default), 'x64dbg', 'mask', or 'bitmask'",
+    ] = "ida",
+    top: Annotated[
+        int,
+        "Number of shortest signatures to return per address (default: 5)",
+    ] = 5,
+    max_length: Annotated[
+        int,
+        "Maximum signature length in bytes (default: 250)",
+    ] = 250,
+) -> list[XrefSigResult]:
+    """Find signatures for code locations that reference an address. For each
+    input address, finds all code cross-references TO it, generates a unique
+    signature at each xref site, and returns the shortest ones. Ideal for
+    creating signatures for data addresses, vtable entries, or string
+    references that can't be signatured directly."""
+    sm = _get_sigmaker()
+    fmt = _resolve_format(format)
+    cfg = _make_config(fmt, max_length=max_length)
+    cfg = __import__("dataclasses").replace(cfg, print_top_x=top)
+    finder = sm.XrefFinder()
+    addrs_list = normalize_list_input(addrs)
+
+    results: list[XrefSigResult] = []
+    for addr_str in addrs_list:
+        ea = None
+        try:
+            ea = _resolve_addr(addr_str)
+            xref_result = finder.find_xrefs(ea, cfg)
+
+            sigs = []
+            for gs in xref_result.signatures[:top]:
+                sig_str = _format_sig(gs.signature, fmt)
+                sigs.append({
+                    "xref_addr": hex(int(gs.address)) if gs.address else None,
+                    "signature": sig_str,
+                    "length": len(gs.signature),
+                })
+
+            results.append({
+                "query": addr_str,
+                "addr": hex(ea),
+                "signatures": sigs,
+                "total_xrefs": len(xref_result.signatures),
+            })
+        except Exception as e:
+            results.append({
+                "query": addr_str,
+                "addr": hex(ea) if ea is not None else None,
+                "signatures": None,
+                "error": str(e),
+            })
+    return results
+
+
+@tool
+@idasync
+def scan_signature(
+    signatures: Annotated[
+        list[str] | str,
+        "Signature pattern(s) to scan for. Supports multiple formats: "
+        "IDA style ('48 8B ? EC'), x64dbg style ('48 8B ?? EC'), "
+        "mask style ('\\x48\\x8B\\x00\\xEC xx?x'), hex ('0x48 0x8B'), etc.",
+    ],
+    limit: Annotated[int, "Max matches per signature (default: 100)"] = 100,
+) -> list[ScanSigResult]:
+    """Scan the IDB for matches of byte signature patterns. Accepts signatures
+    in IDA, x64dbg, mask, bitmask, or loose hex formats. Returns all match
+    addresses. Use this to verify a signature is unique or find all instances
+    of a pattern."""
+    sm = _get_sigmaker()
+    sigs_list = normalize_list_input(signatures)
+
+    results: list[ScanSigResult] = []
+    for sig_input in sigs_list:
+        try:
+            searcher = sm.SignatureSearcher.from_signature(sig_input)
+            search_results = searcher.search()
+            matches = [hex(int(m)) for m in search_results.matches[:limit]]
+            results.append({
+                "signature": search_results.signature_str or sig_input,
+                "matches": matches,
+                "n": len(search_results.matches),
+                "unique": len(search_results.matches) == 1,
+            })
+        except Exception as e:
+            results.append({
+                "signature": sig_input,
+                "matches": [],
+                "n": 0,
+                "unique": False,
+                "error": str(e),
+            })
+    return results

--- a/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
@@ -4,7 +4,6 @@ This module integrates sigmaker.py functionality to provide:
 - Unique signature generation for addresses/functions
 - Range-based signature generation (selection)
 - XREF-based signature discovery
-- Signature scanning/searching
 - Multiple output formats: IDA, x64dbg, mask, bitmask
 """
 
@@ -102,14 +101,6 @@ class XrefSigResult(TypedDict):
     addr: str | None
     signatures: list[dict] | None
     total_xrefs: NotRequired[int]
-    error: NotRequired[str]
-
-
-class ScanSigResult(TypedDict):
-    signature: str
-    matches: list[str]
-    n: int
-    unique: bool
     error: NotRequired[str]
 
 
@@ -351,47 +342,6 @@ def find_xref_signatures(
                 "query": addr_str,
                 "addr": hex(ea) if ea is not None else None,
                 "signatures": None,
-                "error": str(e),
-            })
-    return results
-
-
-@tool
-@idasync
-def scan_signature(
-    signatures: Annotated[
-        list[str] | str,
-        "Signature pattern(s) to scan for. Supports multiple formats: "
-        "IDA style ('48 8B ? EC'), x64dbg style ('48 8B ?? EC'), "
-        "mask style ('\\x48\\x8B\\x00\\xEC xx?x'), hex ('0x48 0x8B'), etc.",
-    ],
-    limit: Annotated[int, "Max matches per signature (default: 100)"] = 100,
-) -> list[ScanSigResult]:
-    """Scan the IDB for matches of byte signature patterns. Accepts signatures
-    in IDA, x64dbg, mask, bitmask, or loose hex formats. Returns all match
-    addresses. Use this to verify a signature is unique or find all instances
-    of a pattern."""
-    sm = _sm
-    sigs_list = normalize_list_input(signatures)
-
-    results: list[ScanSigResult] = []
-    for sig_input in sigs_list:
-        try:
-            searcher = sm.SignatureSearcher.from_signature(sig_input)
-            search_results = searcher.search()
-            matches = [hex(int(m)) for m in search_results.matches[:limit]]
-            results.append({
-                "signature": search_results.signature_str or sig_input,
-                "matches": matches,
-                "n": len(search_results.matches),
-                "unique": len(search_results.matches) == 1,
-            })
-        except Exception as e:
-            results.append({
-                "signature": sig_input,
-                "matches": [],
-                "n": 0,
-                "unique": False,
                 "error": str(e),
             })
     return results

--- a/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
@@ -17,19 +17,7 @@ from .rpc import tool
 from .sync import idasync
 from .utils import parse_address, normalize_list_input
 
-# ---------------------------------------------------------------------------
-# Lazy import of sigmaker (lives in the IDA plugins dir or sys.path)
-# ---------------------------------------------------------------------------
-_sigmaker = None
-
-
-def _get_sigmaker():
-    global _sigmaker
-    if _sigmaker is None:
-        import sigmaker as _sm
-
-        _sigmaker = _sm
-    return _sigmaker
+from . import _sigmaker as _sm
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +48,8 @@ def _make_config(
     continue_outside_function: bool = True,
     max_length: int = 1000,
 ) -> "object":
-    sm = _get_sigmaker()
-    return sm.SigMakerConfig(
-        output_format=sm.SignatureType(fmt),
+    return _sm.SigMakerConfig(
+        output_format=_sm.SignatureType(fmt),
         wildcard_operands=wildcard_operands,
         continue_outside_of_function=continue_outside_function,
         wildcard_optimized=False,
@@ -156,7 +143,7 @@ def make_signature(
     unique signature starting at each address by walking instructions and
     wildcarding operands. Useful for finding stable patterns that survive
     recompilation."""
-    sm = _get_sigmaker()
+    sm = _sm
     fmt = _resolve_format(format)
     cfg = _make_config(fmt, wildcard_operands=wildcard_operands, max_length=max_length)
     maker = sm.SignatureMaker()
@@ -212,7 +199,7 @@ def make_signature_for_function(
     """Create unique byte signatures for function entry points. Resolves each
     name/address to a function, then generates the shortest unique signature
     starting at the function start."""
-    sm = _get_sigmaker()
+    sm = _sm
     fmt = _resolve_format(format)
     cfg = _make_config(fmt, wildcard_operands=wildcard_operands, max_length=max_length)
     maker = sm.SignatureMaker()
@@ -275,7 +262,7 @@ def make_signature_for_range(
     """Create a byte signature for a specific address range (e.g. a selected
     region). Unlike make_signature, this does NOT guarantee uniqueness — it
     simply encodes the bytes in the range with optional operand wildcarding."""
-    sm = _get_sigmaker()
+    sm = _sm
     fmt = _resolve_format(format)
     cfg = _make_config(fmt, wildcard_operands=wildcard_operands)
     maker = sm.SignatureMaker()
@@ -329,10 +316,11 @@ def find_xref_signatures(
     signature at each xref site, and returns the shortest ones. Ideal for
     creating signatures for data addresses, vtable entries, or string
     references that can't be signatured directly."""
-    sm = _get_sigmaker()
+    sm = _sm
     fmt = _resolve_format(format)
     cfg = _make_config(fmt, max_length=max_length)
-    cfg = __import__("dataclasses").replace(cfg, print_top_x=top)
+    import dataclasses
+    cfg = dataclasses.replace(cfg, print_top_x=top)
     finder = sm.XrefFinder()
     addrs_list = normalize_list_input(addrs)
 
@@ -383,7 +371,7 @@ def scan_signature(
     in IDA, x64dbg, mask, bitmask, or loose hex formats. Returns all match
     addresses. Use this to verify a signature is unique or find all instances
     of a pattern."""
-    sm = _get_sigmaker()
+    sm = _sm
     sigs_list = normalize_list_input(signatures)
 
     results: list[ScanSigResult] = []

--- a/src/ida_pro_mcp/ida_mcp/tests/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/__init__.py
@@ -17,3 +17,4 @@ from . import test_framework_helpers
 from . import test_typed_fixture
 from . import test_utils
 from . import test_api_analysis_internals
+from . import test_api_sigmaker

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
@@ -1,4 +1,13 @@
-"""Tests for api_sigmaker API functions."""
+"""Tests for api_sigmaker API functions.
+
+Tests are structured to validate semantically meaningful behavior:
+- Round-trip: generate a signature then scan it back to verify it finds
+  the original address (proving uniqueness isn't just a boolean flag).
+- Function resolution: make_signature_for_function resolves mid-function
+  addresses to the function start and populates the name field.
+- Batch with mixed input: batching names and hex addresses together tests
+  the name-resolution path that plain hex batches don't exercise.
+"""
 
 from ..framework import (
     test,
@@ -19,6 +28,7 @@ from ..api_sigmaker import (
     make_signature_for_range,
     find_xref_signatures,
 )
+from ..api_analysis import find_bytes
 
 
 # ============================================================================
@@ -27,8 +37,9 @@ from ..api_sigmaker import (
 
 
 @test()
-def test_make_signature_produces_unique_sig():
-    """make_signature returns a unique signature for a valid code address."""
+def test_make_signature_round_trip():
+    """Generate a unique signature, then scan it back with find_bytes to prove
+    it actually matches the original address and only that address."""
     fn_addr = get_any_function()
     if not fn_addr:
         skip_test("binary has no functions")
@@ -36,12 +47,16 @@ def test_make_signature_produces_unique_sig():
     result = make_signature(fn_addr)
     assert_is_list(result, min_length=1)
     entry = result[0]
-    assert entry["query"] == fn_addr
-    assert_valid_address(entry["addr"])
     assert entry["signature"] is not None
     assert_non_empty(entry["signature"])
     assert entry["unique"] is True
-    assert entry["format"] == "ida"
+
+    # Round-trip: scan the generated signature and verify it lands back
+    # on the same address with exactly one match (proving true uniqueness).
+    scan = find_bytes(entry["signature"])
+    assert_is_list(scan, min_length=1)
+    assert scan[0]["n"] == 1, f"expected 1 match (unique), got {scan[0]['n']}"
+    assert scan[0]["matches"][0] == entry["addr"]
 
 
 @test()
@@ -85,18 +100,41 @@ def test_make_signature_by_name():
 
 
 @test()
-def test_make_signature_for_function_valid():
-    """make_signature_for_function returns a signature at the function entry."""
-    fn_addr = get_any_function()
-    if not fn_addr:
-        skip_test("binary has no functions")
+def test_make_signature_for_function_resolves_to_start():
+    """Pass a mid-function address and verify the tool resolves it to the
+    function start.  Also verify the name field matches IDA's own function
+    name — this is the key behaviour that make_signature doesn't provide."""
+    import ida_funcs
+    import idaapi
+    import idautils
 
-    result = make_signature_for_function(fn_addr)
+    # Find a function with at least 2 bytes so we can pick a mid-function addr
+    func_ea = None
+    for ea in idautils.Functions():
+        f = ida_funcs.get_func(ea)
+        if f and f.end_ea - f.start_ea > 2:
+            func_ea = f.start_ea
+            break
+    if func_ea is None:
+        skip_test("no function with size > 2 found")
+
+    func = ida_funcs.get_func(func_ea)
+    mid_addr = hex(func.start_ea + 1)  # one byte into the function
+
+    result = make_signature_for_function(mid_addr)
     assert_is_list(result, min_length=1)
     entry = result[0]
-    assert_valid_address(entry["addr"])
+
+    # Should resolve back to function start, not the mid-function input
+    assert entry["addr"] == hex(func.start_ea), (
+        f"expected addr {hex(func.start_ea)}, got {entry['addr']}"
+    )
+    # Name field should match IDA's function name
+    expected_name = idaapi.get_func_name(func.start_ea)
+    assert entry["name"] == expected_name, (
+        f"expected name '{expected_name}', got '{entry['name']}'"
+    )
     assert entry["signature"] is not None
-    assert entry["name"] is not None
 
 
 @test(binary="crackme03.elf")
@@ -123,18 +161,38 @@ def test_make_signature_for_function_no_func():
 
 
 @test()
-def test_make_signature_for_function_batch():
-    """make_signature_for_function handles multiple inputs."""
+def test_make_signature_for_function_batch_mixed_input():
+    """Batch with a mix of hex addresses and symbolic names — exercises
+    the name-resolution path that a pure-hex batch (make_signature_batch)
+    never touches.  Also verifies each result carries a correct name."""
+    import idaapi
     import idautils
 
-    addrs = [hex(ea) for ea in list(idautils.Functions())[:3]]
-    if len(addrs) < 2:
+    # Build a mixed batch: first function as hex, second as its IDA name
+    funcs = list(idautils.Functions())[:2]
+    if len(funcs) < 2:
         skip_test("binary has fewer than two functions")
 
-    result = make_signature_for_function(addrs)
-    assert_is_list(result, min_length=len(addrs))
-    for entry in result:
-        assert entry["signature"] is not None
+    hex_addr = hex(funcs[0])
+    name_str = idaapi.get_func_name(funcs[1])
+    if not name_str:
+        skip_test("second function has no name")
+
+    result = make_signature_for_function([hex_addr, name_str])
+    assert_is_list(result, min_length=2)
+
+    # First entry: queried by hex address
+    assert result[0]["query"] == hex_addr
+    assert result[0]["signature"] is not None
+    assert result[0]["name"] is not None  # name must be populated even for hex input
+
+    # Second entry: queried by name
+    assert result[1]["query"] == name_str
+    assert result[1]["name"] == name_str
+    assert result[1]["signature"] is not None
+
+    # Both should resolve to different addresses (different functions)
+    assert result[0]["addr"] != result[1]["addr"]
 
 
 # ============================================================================

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
@@ -18,7 +18,6 @@ from ..api_sigmaker import (
     make_signature_for_function,
     make_signature_for_range,
     find_xref_signatures,
-    scan_signature,
 )
 
 
@@ -203,60 +202,6 @@ def test_find_xref_signatures_no_xrefs():
     if "error" not in entry:
         assert entry["signatures"] is not None
         assert entry["total_xrefs"] == 0
-
-
-# ============================================================================
-# scan_signature
-# ============================================================================
-
-
-@test()
-def test_scan_signature_from_generated():
-    """scan_signature finds a match when scanning with a generated signature."""
-    fn_addr = get_any_function()
-    if not fn_addr:
-        skip_test("binary has no functions")
-
-    # Generate a signature first
-    sig_result = make_signature(fn_addr)
-    assert_is_list(sig_result, min_length=1)
-    sig_str = sig_result[0]["signature"]
-    assert sig_str is not None
-
-    # Scan for it — should find exactly 1 match (unique)
-    scan_result = scan_signature(sig_str)
-    assert_is_list(scan_result, min_length=1)
-    entry = scan_result[0]
-    assert entry["n"] >= 1
-    assert entry["unique"] is True
-    assert_valid_address(entry["matches"][0])
-
-
-@test()
-def test_scan_signature_no_match():
-    """scan_signature returns no matches for a bogus pattern."""
-    result = scan_signature("DE AD BE EF CA FE BA BE 13 37 42 42 42 42")
-    assert_is_list(result, min_length=1)
-    entry = result[0]
-    assert entry["n"] == 0
-    assert entry["unique"] is False
-    assert len(entry["matches"]) == 0
-
-
-@test()
-def test_scan_signature_batch():
-    """scan_signature handles multiple patterns in one call."""
-    fn_addr = get_any_function()
-    if not fn_addr:
-        skip_test("binary has no functions")
-
-    sig_result = make_signature(fn_addr)
-    sig_str = sig_result[0]["signature"]
-
-    result = scan_signature([sig_str, "DE AD BE EF CA FE BA BE 13 37"])
-    assert_is_list(result, min_length=2)
-    assert result[0]["n"] >= 1
-    assert result[1]["n"] == 0
 
 
 # ============================================================================

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
@@ -1,0 +1,314 @@
+"""Tests for api_sigmaker API functions."""
+
+from ..framework import (
+    test,
+    skip_test,
+    assert_is_list,
+    assert_ok,
+    assert_error,
+    assert_valid_address,
+    assert_non_empty,
+    optional,
+    get_any_function,
+    get_data_address,
+    get_unmapped_address,
+)
+from ..api_sigmaker import (
+    make_signature,
+    make_signature_for_function,
+    make_signature_for_range,
+    find_xref_signatures,
+    scan_signature,
+)
+
+
+# ============================================================================
+# make_signature
+# ============================================================================
+
+
+@test()
+def test_make_signature_produces_unique_sig():
+    """make_signature returns a unique signature for a valid code address."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = make_signature(fn_addr)
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert entry["query"] == fn_addr
+    assert_valid_address(entry["addr"])
+    assert entry["signature"] is not None
+    assert_non_empty(entry["signature"])
+    assert entry["unique"] is True
+    assert entry["format"] == "ida"
+
+
+@test()
+def test_make_signature_invalid_address():
+    """make_signature reports an error for an unmapped address."""
+    result = make_signature(get_unmapped_address())
+    assert_is_list(result, min_length=1)
+    assert "error" in result[0]
+
+
+@test()
+def test_make_signature_batch():
+    """make_signature handles multiple addresses in one call."""
+    import idautils
+
+    addrs = [hex(ea) for ea in list(idautils.Functions())[:3]]
+    if len(addrs) < 2:
+        skip_test("binary has fewer than two functions")
+
+    result = make_signature(addrs)
+    assert_is_list(result, min_length=len(addrs))
+    for entry, addr in zip(result, addrs):
+        assert entry["query"] == addr
+        assert entry["signature"] is not None
+
+
+@test(binary="crackme03.elf")
+def test_make_signature_by_name():
+    """make_signature accepts a function name and produces a valid signature."""
+    result = make_signature("check_pw")
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert entry["query"] == "check_pw"
+    assert entry["signature"] is not None
+    assert entry["unique"] is True
+
+
+# ============================================================================
+# make_signature_for_function
+# ============================================================================
+
+
+@test()
+def test_make_signature_for_function_valid():
+    """make_signature_for_function returns a signature at the function entry."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    result = make_signature_for_function(fn_addr)
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert_valid_address(entry["addr"])
+    assert entry["signature"] is not None
+    assert entry["name"] is not None
+
+
+@test(binary="crackme03.elf")
+def test_make_signature_for_function_by_name():
+    """make_signature_for_function resolves 'main' and returns its signature."""
+    result = make_signature_for_function("main")
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert entry["query"] == "main"
+    assert entry["name"] == "main"
+    assert entry["signature"] is not None
+
+
+@test()
+def test_make_signature_for_function_no_func():
+    """make_signature_for_function errors for a data address with no function."""
+    data_addr = get_data_address()
+    if not data_addr:
+        skip_test("binary has no data segments")
+
+    result = make_signature_for_function(data_addr)
+    assert_is_list(result, min_length=1)
+    assert "error" in result[0]
+
+
+@test()
+def test_make_signature_for_function_batch():
+    """make_signature_for_function handles multiple inputs."""
+    import idautils
+
+    addrs = [hex(ea) for ea in list(idautils.Functions())[:3]]
+    if len(addrs) < 2:
+        skip_test("binary has fewer than two functions")
+
+    result = make_signature_for_function(addrs)
+    assert_is_list(result, min_length=len(addrs))
+    for entry in result:
+        assert entry["signature"] is not None
+
+
+# ============================================================================
+# make_signature_for_range
+# ============================================================================
+
+
+@test()
+def test_make_signature_for_range_valid():
+    """make_signature_for_range encodes an address range as a signature."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    import ida_funcs
+    func = ida_funcs.get_func(int(fn_addr, 16))
+    if not func:
+        skip_test("cannot get function object")
+
+    start = hex(func.start_ea)
+    # Use a small range: first 16 bytes or function end, whichever is smaller
+    end_ea = min(func.start_ea + 16, func.end_ea)
+    end = hex(end_ea)
+
+    result = make_signature_for_range(start, end)
+    assert result["signature"] is not None
+    assert_non_empty(result["signature"])
+    assert_valid_address(result["addr"])
+
+
+@test(binary="crackme03.elf")
+def test_make_signature_for_range_crackme():
+    """make_signature_for_range works on a known crackme function range."""
+    result = make_signature_for_range("0x11a9", "0x11b9")
+    assert result["signature"] is not None
+    assert "error" not in result
+
+
+# ============================================================================
+# find_xref_signatures
+# ============================================================================
+
+
+@test(binary="crackme03.elf")
+def test_find_xref_signatures_for_string():
+    """find_xref_signatures finds signatures for xrefs to a known string address."""
+    # "Need exactly one argument." string at 0x2004
+    result = find_xref_signatures("0x2004")
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    if entry.get("signatures") and len(entry["signatures"]) > 0:
+        sig = entry["signatures"][0]
+        assert sig["signature"] is not None
+        assert sig["length"] > 0
+        assert_valid_address(sig["xref_addr"])
+
+
+@test()
+def test_find_xref_signatures_no_xrefs():
+    """find_xref_signatures returns empty list for address with no xrefs."""
+    result = find_xref_signatures(get_unmapped_address())
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    # Either error or empty signatures
+    if "error" not in entry:
+        assert entry["signatures"] is not None
+        assert entry["total_xrefs"] == 0
+
+
+# ============================================================================
+# scan_signature
+# ============================================================================
+
+
+@test()
+def test_scan_signature_from_generated():
+    """scan_signature finds a match when scanning with a generated signature."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    # Generate a signature first
+    sig_result = make_signature(fn_addr)
+    assert_is_list(sig_result, min_length=1)
+    sig_str = sig_result[0]["signature"]
+    assert sig_str is not None
+
+    # Scan for it — should find exactly 1 match (unique)
+    scan_result = scan_signature(sig_str)
+    assert_is_list(scan_result, min_length=1)
+    entry = scan_result[0]
+    assert entry["n"] >= 1
+    assert entry["unique"] is True
+    assert_valid_address(entry["matches"][0])
+
+
+@test()
+def test_scan_signature_no_match():
+    """scan_signature returns no matches for a bogus pattern."""
+    result = scan_signature("DE AD BE EF CA FE BA BE 13 37 42 42 42 42")
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert entry["n"] == 0
+    assert entry["unique"] is False
+    assert len(entry["matches"]) == 0
+
+
+@test()
+def test_scan_signature_batch():
+    """scan_signature handles multiple patterns in one call."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    sig_result = make_signature(fn_addr)
+    sig_str = sig_result[0]["signature"]
+
+    result = scan_signature([sig_str, "DE AD BE EF CA FE BA BE 13 37"])
+    assert_is_list(result, min_length=2)
+    assert result[0]["n"] >= 1
+    assert result[1]["n"] == 0
+
+
+# ============================================================================
+# Output formats
+# ============================================================================
+
+
+@test()
+def test_all_output_formats():
+    """make_signature produces valid output in all 4 formats."""
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    for fmt in ("ida", "x64dbg", "mask", "bitmask"):
+        result = make_signature(fn_addr, format=fmt)
+        assert_is_list(result, min_length=1)
+        entry = result[0]
+        assert entry["format"] == fmt
+        assert entry["signature"] is not None, f"format {fmt} returned None"
+        assert_non_empty(entry["signature"])
+
+    # IDA format uses single '?'
+    ida_result = make_signature(fn_addr, format="ida")[0]["signature"]
+    # x64dbg format uses '??'
+    x64_result = make_signature(fn_addr, format="x64dbg")[0]["signature"]
+    # mask format has backslash-x bytes + mask string
+    mask_result = make_signature(fn_addr, format="mask")[0]["signature"]
+    # bitmask format has 0x bytes + 0b bitmask
+    bitmask_result = make_signature(fn_addr, format="bitmask")[0]["signature"]
+
+    # Basic format validation
+    assert "?" not in x64_result or "??" in x64_result  # x64dbg uses ?? not single ?
+    assert "\\x" in mask_result or "x" in mask_result
+    assert "0b" in bitmask_result
+
+
+# ============================================================================
+# Name resolution
+# ============================================================================
+
+
+@test(binary="crackme03.elf")
+def test_name_resolution_across_tools():
+    """All signature tools accept function names alongside hex addresses."""
+    # make_signature
+    r1 = make_signature("check_pw")
+    assert r1[0]["signature"] is not None
+
+    # make_signature_for_function
+    r2 = make_signature_for_function("check_pw")
+    assert r2[0]["signature"] is not None
+
+    # Both should resolve to the same address
+    assert r1[0]["addr"] == r2[0]["addr"]


### PR DESCRIPTION
Vendors the core engine from [sigmaker.py](https://github.com/mahmoudimus/ida-sigmaker) as `_sigmaker.py`
Adds `api_sigmaker.py` with 5 new MCP tools:
- `make_signature` — generate the shortest unique byte signature for an address
- `make_signature_for_function` — generate a unique signature at a function's entry point
- `make_signature_for_range` — encode a specific address range as a signature (e.g. a selection)
- `find_xref_signatures` — find signatures for code that references a target address (ideal for data/strings/vtables)
- `scan_signature` — scan the IDB for all matches of a signature pattern

All tools support batch input, name resolution, and 4 output formats: IDA (`48 8B ? EC`), x64dbg (`48 8B ?? EC`),
mask (`\x48\x8B\x00\xEC xx?x`), bitmask (`0x48, 0x8B, 0x00, 0xEC 0b1101`)
Multi-architecture wildcard policies: x86, ARM, MIPS, PPC