### PR TITLE
fix: validate Host and Origin on MCP HTTP endpoints

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -138,6 +138,8 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         # Handle output download requests
         output_match = re.match(r"^/output/([a-f0-9-]+)\.(\w+)$", path)
         if output_match:
+            if not self._check_api_request():
+                return
             self._handle_output_download(output_match.group(1), output_match.group(2))
             return
 

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -7,6 +7,7 @@ import uuid
 import json
 import gzip
 import zlib
+import ipaddress
 import inspect
 import threading
 import traceback
@@ -63,6 +64,61 @@ class _McpSseConnection:
             self.alive = False
             return False
 
+
+def _origin_allowed_by_policy(
+    allowed: Callable[[str], bool] | list[str] | str | None,
+    origin: str,
+) -> bool:
+    if not origin or allowed is None:
+        return False
+    if callable(allowed):
+        return allowed(origin)
+    if isinstance(allowed, str):
+        allowed = [allowed]
+    return "*" in allowed or origin in allowed
+
+
+def _parse_host_header(host_header: str | None) -> str | None:
+    if not host_header:
+        return None
+
+    host_header = host_header.strip()
+    if not host_header:
+        return None
+
+    if host_header.startswith("["):
+        end = host_header.find("]")
+        if end == -1:
+            return None
+        return host_header[1:end]
+
+    if host_header.count(":") == 1:
+        return host_header.rsplit(":", 1)[0]
+
+    return host_header
+
+
+def _is_loopback_host(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
+
+
+def _host_header_allowed_for_bind(bound_host: str, host_header: str | None) -> bool:
+    """Reject DNS-rebinding style Host headers when the server is loopback-bound."""
+    if host_header is None:
+        return True
+
+    host_name = _parse_host_header(host_header)
+    if host_name is None:
+        return False
+
+    if not _is_loopback_host(bound_host):
+        return True
+
+    return _is_loopback_host(host_name)
+
 class McpHttpRequestHandler(BaseHTTPRequestHandler):
     server_version = "zeromcp/1.3.0"
     error_message_format = "%(code)d - %(message)s"
@@ -86,19 +142,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
 
     def send_cors_headers(self, *, preflight = False):
         origin = self.headers.get("Origin", "")
-        if not origin:
-            return
-        def is_allowed():
-            allowed = self.mcp_server.cors_allowed_origins
-            if allowed is None:
-                return False
-            if callable(allowed):
-                return allowed(origin)
-            if isinstance(allowed, str):
-                allowed = [allowed]
-            assert isinstance(allowed, list)
-            return "*" in allowed or origin in allowed
-        if not is_allowed():
+        if not _origin_allowed_by_policy(self.mcp_server.cors_allowed_origins, origin):
             return
         self.send_header("Access-Control-Allow-Origin", origin)
         if preflight:
@@ -122,7 +166,30 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             # Client disconnected - normal, suppress traceback
             pass
 
+    def _check_api_request(self) -> bool:
+        """Block browser traffic that violates the configured origin policy.
+
+        Browsers can bypass passive CORS-only defenses during DNS rebinding
+        because same-origin requests do not need CORS. Rejecting unexpected Host
+        and Origin headers closes that gap while keeping direct clients working.
+        """
+        bound_host = self.server.server_address[0]
+        if not _host_header_allowed_for_bind(bound_host, self.headers.get("Host")):
+            self.send_error(403, "Invalid Host")
+            return False
+
+        origin = self.headers.get("Origin", "")
+        if origin and not _origin_allowed_by_policy(
+            self.mcp_server.cors_allowed_origins, origin
+        ):
+            self.send_error(403, "Invalid Origin")
+            return False
+
+        return True
+
     def do_GET(self):
+        if not self._check_api_request():
+            return
         match urlparse(self.path).path:
             case "/sse":
                 self._handle_sse_get()
@@ -132,6 +199,8 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
                 self.send_error(404, "Not Found")
 
     def do_POST(self):
+        if not self._check_api_request():
+            return
         body = self._read_body()
         if body is None:
             return
@@ -146,6 +215,8 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
         """Handle CORS preflight requests"""
+        if not self._check_api_request():
+            return
         self.send_response(200)
         self.send_cors_headers(preflight=True)
         self.end_headers()

--- a/tests/test_browser_transport_guards.py
+++ b/tests/test_browser_transport_guards.py
@@ -1,0 +1,121 @@
+import pathlib
+import sys
+import unittest
+import http.server  # Preload stdlib http before adding local ida_mcp paths.
+
+
+_ZEROMCP_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "ida_pro_mcp" / "ida_mcp"
+sys.path.insert(0, str(_ZEROMCP_SRC))
+try:
+    from zeromcp.mcp import (
+        McpHttpRequestHandler,
+        McpServer,
+        _host_header_allowed_for_bind,
+        _origin_allowed_by_policy,
+    )
+finally:
+    sys.path.remove(str(_ZEROMCP_SRC))
+
+
+class _DummyHandler(McpHttpRequestHandler):
+    def __init__(self):
+        pass
+
+
+def _make_handler(
+    *,
+    host: str | None,
+    origin: str | None,
+    bound_host: str = "127.0.0.1",
+    allowed=None,
+):
+    mcp_server = McpServer("test")
+    if allowed is not None:
+        mcp_server.cors_allowed_origins = allowed
+
+    server = type(
+        "_FakeServer",
+        (),
+        {
+            "server_address": (bound_host, 13337),
+            "server_port": 13337,
+            "mcp_server": mcp_server,
+        },
+    )()
+    handler = _DummyHandler.__new__(_DummyHandler)
+    handler.server = server
+    handler.mcp_server = mcp_server
+    headers = {}
+    if host is not None:
+        headers["Host"] = host
+    if origin is not None:
+        headers["Origin"] = origin
+    handler.headers = headers
+    errors = []
+    handler.send_error = lambda code, message=None, explain=None: errors.append(
+        (code, message)
+    )
+    return handler, errors
+
+
+class BrowserTransportGuardTests(unittest.TestCase):
+    def test_loopback_host_helper_rejects_rebinding_domain(self):
+        self.assertFalse(
+            _host_header_allowed_for_bind("127.0.0.1", "evil.example:13337")
+        )
+        self.assertTrue(
+            _host_header_allowed_for_bind("127.0.0.1", "localhost:13337")
+        )
+        self.assertTrue(
+            _host_header_allowed_for_bind("127.0.0.1", "127.0.0.1:13337")
+        )
+        self.assertTrue(_host_header_allowed_for_bind("::1", "[::1]:13337"))
+
+    def test_origin_policy_helper_matches_cors_behavior(self):
+        self.assertTrue(
+            _origin_allowed_by_policy(
+                ["http://127.0.0.1:3000"], "http://127.0.0.1:3000"
+            )
+        )
+        self.assertFalse(
+            _origin_allowed_by_policy(None, "http://127.0.0.1:3000")
+        )
+
+    def test_check_api_request_rejects_rebinding_host(self):
+        handler, errors = _make_handler(
+            host="evil.example:13337",
+            origin="http://evil.example:13337",
+        )
+        self.assertFalse(handler._check_api_request())
+        self.assertEqual(errors, [(403, "Invalid Host")])
+
+    def test_check_api_request_rejects_browser_origin_in_direct_mode(self):
+        handler, errors = _make_handler(
+            host="127.0.0.1:13337",
+            origin="http://127.0.0.1:3000",
+            allowed=None,
+        )
+        handler.mcp_server.cors_allowed_origins = None
+        self.assertFalse(handler._check_api_request())
+        self.assertEqual(errors, [(403, "Invalid Origin")])
+
+    def test_check_api_request_allows_direct_clients_without_origin(self):
+        handler, errors = _make_handler(
+            host="127.0.0.1:13337",
+            origin=None,
+        )
+        handler.mcp_server.cors_allowed_origins = None
+        self.assertTrue(handler._check_api_request())
+        self.assertEqual(errors, [])
+
+    def test_check_api_request_allows_local_browser_origin(self):
+        handler, errors = _make_handler(
+            host="localhost:13337",
+            origin="http://127.0.0.1:3000",
+        )
+        self.assertTrue(handler._check_api_request())
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `Host` on loopback-bound MCP HTTP endpoints instead of relying on CORS alone
- reject browser requests with disallowed `Origin` values while still allowing direct clients with no `Origin`
- apply the same guard to `/output/*` downloads and add regression coverage for the transport boundary

## Rationale
The config UI already validates browser-facing requests, but the shared MCP HTTP transport still accepted browser requests as long as they reached the loopback listener. Same-origin DNS rebinding can bypass passive CORS handling, so the request handler should actively reject unexpected `Host` and `Origin` headers on `/mcp`, `/sse`, and `/output/*`.

## Testing
- `python -m unittest discover -s tests -p 'test_browser_transport_guards.py'`
- `PYTHONPATH=src python tests/test_server_transport.py`
- `python -m py_compile src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py src/ida_pro_mcp/ida_mcp/http.py`
