### PR TITLE
Tighten tool parameter schemas and fix BSS-resident memory reads

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -91,7 +91,7 @@ class FuncProfileItem(TypedDict, total=False):
 
 
 class FuncProfileResult(TypedDict, total=False):
-    query: str
+    target: str
     data: list[FuncProfileItem]
     next_offset: int | None
     error: str | None
@@ -141,7 +141,7 @@ class AnalyzeBatchDetails(TypedDict, total=False):
 
 
 class AnalyzeBatchResult(TypedDict, total=False):
-    query: str
+    target: str
     addr: str | None
     name: str | None
     analysis: AnalyzeBatchDetails | None
@@ -170,7 +170,7 @@ XrefQueryRow = TypedDict(
 
 
 class XrefQueryResult(TypedDict, total=False):
-    query: str
+    target: str
     resolved_addr: str | None
     direction: str
     xref_type: str
@@ -803,28 +803,16 @@ def disasm(
 @tool_timeout(120.0)
 def func_profile(
     queries: Annotated[
-        list[FuncProfileQuery] | FuncProfileQuery | str,
+        list[FuncProfileQuery] | FuncProfileQuery,
         "Function profiling query (supports name/address filters + pagination)",
     ],
 ) -> list[FuncProfileResult]:
     """Profile functions with summary metrics and optional sampled details."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "query": s,
-            "offset": 0,
-            "count": 50,
-            "sort_by": "addr",
-            "descending": False,
-            "include_lists": False,
-            "max_items": 25,
-            "include_prototype": False,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     results: list[dict] = []
     for query in queries:
-        q = str(query.get("query", "*") or "*").strip()
+        q = str(query.get("addr", "*") or "*").strip()
         filter_pattern = str(query.get("filter", "") or "")
         offset = _clamp_int(query.get("offset", 0), 0, 0, 2_000_000_000)
         count = _clamp_int(query.get("count", 50), 50, 0, 1000)
@@ -841,7 +829,7 @@ def func_profile(
             if err is not None or start_ea is None:
                 results.append(
                     {
-                        "query": q,
+                        "target": q,
                         "data": [],
                         "next_offset": None,
                         "error": err or "Failed to resolve function",
@@ -901,7 +889,7 @@ def func_profile(
 
         results.append(
             {
-                "query": q,
+                "target": q,
                 "data": profiled,
                 "next_offset": page["next_offset"],
                 "error": None,
@@ -916,44 +904,24 @@ def func_profile(
 @tool_timeout(120.0)
 def analyze_batch(
     queries: Annotated[
-        list[AnalyzeBatchQuery] | AnalyzeBatchQuery | str,
+        list[AnalyzeBatchQuery] | AnalyzeBatchQuery,
         "Comprehensive per-function analysis with selectable sections",
     ],
 ) -> list[AnalyzeBatchResult]:
     """Run comprehensive analysis over one or more target functions."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "query": s,
-            "include_decompile": True,
-            "include_disasm": False,
-            "include_xrefs": True,
-            "include_callers": True,
-            "include_callees": True,
-            "include_strings": True,
-            "include_constants": True,
-            "include_basic_blocks": True,
-            "include_proto": True,
-            "max_disasm_insns": 300,
-            "max_callers": 100,
-            "max_callees": 100,
-            "max_strings": 100,
-            "max_constants": 200,
-            "max_blocks": 500,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     results: list[dict] = []
     for query in queries:
-        q = str(query.get("query", "") or query.get("addr", "") or "").strip()
+        q = str(query.get("addr", "") or "").strip()
         if not q:
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "addr": None,
                     "name": None,
                     "analysis": None,
-                    "error": "Function query is required",
+                    "error": "addr is required",
                 }
             )
             continue
@@ -962,7 +930,7 @@ def analyze_batch(
         if err is not None or start_ea is None:
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "addr": None,
                     "name": None,
                     "analysis": None,
@@ -1095,7 +1063,7 @@ def analyze_batch(
 
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "addr": hex(fn.start_ea),
                     "name": fn_name,
                     "analysis": analysis,
@@ -1105,7 +1073,7 @@ def analyze_batch(
         except Exception as e:
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "addr": hex(start_ea),
                     "name": None,
                     "analysis": None,
@@ -1161,29 +1129,16 @@ def xrefs_to(
 @idasync
 def xref_query(
     queries: Annotated[
-        list[XrefQuery] | XrefQuery | str,
+        list[XrefQuery] | XrefQuery,
         "Generic xref query with direction/type filters and pagination",
     ],
 ) -> list[XrefQueryResult]:
     """Query xrefs with direction/type filters and pagination."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "query": s,
-            "direction": "both",
-            "xref_type": "any",
-            "offset": 0,
-            "count": 200,
-            "include_fn": True,
-            "dedup": True,
-            "sort_by": "addr",
-            "descending": False,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     results: list[dict] = []
     for query in queries:
-        q = str(query.get("query", "")).strip()
+        q = str(query.get("addr", "")).strip()
         direction = str(query.get("direction", "both") or "both").lower()
         xref_type = str(query.get("xref_type", "any") or "any").lower()
         offset = _clamp_int(query.get("offset", 0), 0, 0, 2_000_000_000)
@@ -1200,7 +1155,7 @@ def xref_query(
 
         try:
             if not q:
-                raise ValueError("query is required")
+                raise ValueError("addr is required")
             try:
                 target = parse_address(q)
             except Exception:
@@ -1263,7 +1218,7 @@ def xref_query(
             page = paginate(rows, offset, count)
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "resolved_addr": hex(target),
                     "direction": direction,
                     "xref_type": xref_type,
@@ -1276,7 +1231,7 @@ def xref_query(
         except Exception as e:
             results.append(
                 {
-                    "query": q,
+                    "target": q,
                     "resolved_addr": None,
                     "direction": direction,
                     "xref_type": xref_type,
@@ -2017,23 +1972,12 @@ def _scan_insn_ranges(
 @idasync
 def insn_query(
     queries: Annotated[
-        list[InsnPattern] | InsnPattern | str,
+        list[InsnPattern] | InsnPattern,
         "Instruction query with mnemonic/operand filters and scoped scan",
     ],
 ) -> list[InsnQueryResult]:
     """Query instructions with mnemonic/operand filters and scoped scans."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "mnem": s,
-            "offset": 0,
-            "count": 100,
-            "max_scan_insns": 200000,
-            "allow_broad": False,
-            "include_fn": False,
-            "include_disasm": False,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     results: list[dict] = []
     for pattern in queries:

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -518,14 +518,12 @@ def int_convert(
 @idasync
 def list_funcs(
     queries: Annotated[
-        list[ListQuery] | ListQuery | str,
+        list[ListQuery] | ListQuery,
         "List functions with optional filtering and pagination",
     ],
 ) -> list[Page[Function]]:
     """List functions with optional filtering and offset/count pagination."""
-    queries = normalize_dict_list(
-        queries, lambda s: {"offset": 0, "count": 50, "filter": s}
-    )
+    queries = normalize_dict_list(queries)
     all_functions = [get_function(addr) for addr in idautils.Functions()]
 
     results = []
@@ -548,21 +546,12 @@ def list_funcs(
 @idasync
 def func_query(
     queries: Annotated[
-        list[FunctionQuery] | FunctionQuery | str,
+        list[FunctionQuery] | FunctionQuery,
         "Richer function query (size/type/name filters + pagination)",
     ],
 ) -> list[FunctionQueryPage]:
     """Query functions with richer filtering than list_funcs."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "filter": s,
-            "offset": 0,
-            "count": 50,
-            "sort_by": "addr",
-            "descending": False,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     all_functions: list[dict] = []
     for addr in idautils.Functions():
@@ -639,14 +628,12 @@ def func_query(
 @idasync
 def list_globals(
     queries: Annotated[
-        list[ListQuery] | ListQuery | str,
+        list[ListQuery] | ListQuery,
         "List global variables with optional filtering and pagination",
     ],
 ) -> list[Page[Global]]:
     """List globals with optional filtering and offset/count pagination."""
-    queries = normalize_dict_list(
-        queries, lambda s: {"offset": 0, "count": 50, "filter": s}
-    )
+    queries = normalize_dict_list(queries)
     all_globals: list[Global] = []
     for addr, name in idautils.Names():
         if not idaapi.get_func(addr) and name is not None:
@@ -672,15 +659,12 @@ def list_globals(
 @idasync
 def entity_query(
     queries: Annotated[
-        list[EntityQuery] | EntityQuery | str,
+        list[EntityQuery] | EntityQuery,
         "Generic entity query with filtering, projection, and pagination",
     ],
 ) -> list[EntityQueryPage]:
     """Query IDB entities with typed filters, projection, and pagination."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {"kind": s, "offset": 0, "count": 100, "sort_by": "addr"},
-    )
+    queries = normalize_dict_list(queries)
     results: list[dict] = []
 
     for query in queries:
@@ -790,14 +774,12 @@ def imports(
 @idasync
 def imports_query(
     queries: Annotated[
-        list[ImportQuery] | ImportQuery | str,
+        list[ImportQuery] | ImportQuery,
         "Import query with import/module filters and pagination",
     ],
 ) -> list[ImportsQueryPage]:
     """Query imports with richer filtering than imports(offset,count)."""
-    queries = normalize_dict_list(
-        queries, lambda s: {"filter": s, "offset": 0, "count": 100}
-    )
+    queries = normalize_dict_list(queries)
     all_imports = _collect_imports()
     results = []
 

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -19,6 +19,8 @@ from .utils import (
     MemoryRead,
     normalize_list_input,
     parse_address,
+    read_bytes_bss_safe,
+    read_int_bss_safe,
 )
 
 
@@ -79,7 +81,8 @@ def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[BytesReadResult]:
 
         try:
             ea = parse_address(addr)
-            data = " ".join(f"{x:#02x}" for x in ida_bytes.get_bytes(ea, size))
+            raw = read_bytes_bss_safe(ea, size)
+            data = " ".join(f"{x:#02x}" for x in raw)
             results.append({"addr": addr, "data": data})
         except Exception as e:
             results.append({"addr": addr, "data": None, "error": str(e)})
@@ -144,8 +147,8 @@ def get_int(
             bits, signed, byte_order, normalized = _parse_int_class(ty)
             ea = parse_address(addr)
             size = bits // 8
-            data = ida_bytes.get_bytes(ea, size)
-            if not data or len(data) != size:
+            data = read_bytes_bss_safe(ea, size)
+            if len(data) != size:
                 raise ValueError(f"Failed to read {size} bytes at {addr}")
 
             value = int.from_bytes(data, byte_order, signed=signed)
@@ -207,16 +210,10 @@ def get_global_variable_value_internal(ea: int) -> str:
             return '""'
         return_string = raw.decode("utf-8", errors="replace").strip()
         return f'"{return_string}"'
-    elif size == 1:
-        return hex(ida_bytes.get_byte(ea))
-    elif size == 2:
-        return hex(ida_bytes.get_word(ea))
-    elif size == 4:
-        return hex(ida_bytes.get_dword(ea))
-    elif size == 8:
-        return hex(ida_bytes.get_qword(ea))
-    else:
-        return " ".join(hex(x) for x in ida_bytes.get_bytes(ea, size))
+
+    if size in (1, 2, 4, 8):
+        return hex(read_int_bss_safe(ea, size))
+    return " ".join(hex(b) for b in read_bytes_bss_safe(ea, size))
 
 
 @tool

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -1,4 +1,4 @@
-from typing import Any, NotRequired, TypedDict
+from typing import Annotated, Any, NotRequired, TypedDict
 
 import idaapi
 import idautils
@@ -301,11 +301,13 @@ def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[PatchAsmResult]:
 
 @tool
 @idasync
-def rename(batch: RenameBatch | dict) -> RenameResult:
+def rename(
+    batch: Annotated[
+        RenameBatch,
+        "Rename batch with func/data/local/stack fields (at least one required)",
+    ],
+) -> RenameResult:
     """Batch-rename funcs/globals/locals/stack vars with dry-run options."""
-
-    if not isinstance(batch, dict):
-        return {"error": "batch must be a dict"}
 
     stop_on_error = bool(batch.get("stop_on_error", False))
     dry_run = bool(batch.get("dry_run", False))

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -19,6 +19,8 @@ from .utils import (
     get_type_by_name,
     parse_decls_ctypes,
     my_modifier_t,
+    read_bytes_bss_safe,
+    read_int_bss_safe,
     StructRead,
     TypeEdit,
     TypeInspectQuery,
@@ -420,38 +422,21 @@ def read_struct(
                 member_name = member.name
                 member_size = member.type.get_size()
 
-                # Read memory value at member address
+                # Read memory value at member address (BSS-aware: unloaded
+                # bytes resolve to zero, matching runtime zero-init).
                 member_addr = addr + offset
                 try:
                     if member.type.is_ptr():
-                        is_64bit = compat.inf_is_64bit()
-                        if is_64bit:
-                            value = idaapi.get_qword(member_addr)
-                            value_str = f"0x{value:016X}"
-                        else:
-                            value = idaapi.get_dword(member_addr)
-                            value_str = f"0x{value:08X}"
-                    elif member_size == 1:
-                        value = idaapi.get_byte(member_addr)
-                        value_str = f"0x{value:02X} ({value})"
-                    elif member_size == 2:
-                        value = idaapi.get_word(member_addr)
-                        value_str = f"0x{value:04X} ({value})"
-                    elif member_size == 4:
-                        value = idaapi.get_dword(member_addr)
-                        value_str = f"0x{value:08X} ({value})"
-                    elif member_size == 8:
-                        value = idaapi.get_qword(member_addr)
-                        value_str = f"0x{value:016X} ({value})"
+                        ptr_size = 8 if compat.inf_is_64bit() else 4
+                        value = read_int_bss_safe(member_addr, ptr_size)
+                        value_str = f"0x{value:0{ptr_size * 2}X}"
+                    elif member_size in (1, 2, 4, 8):
+                        value = read_int_bss_safe(member_addr, member_size)
+                        value_str = f"0x{value:0{member_size * 2}X} ({value})"
                     else:
-                        bytes_data = []
-                        for i in range(min(member_size, 16)):
-                            try:
-                                bytes_data.append(
-                                    f"{idaapi.get_byte(member_addr + i):02X}"
-                                )
-                            except Exception:
-                                break
+                        capped = min(member_size, 16)
+                        raw = read_bytes_bss_safe(member_addr, capped)
+                        bytes_data = [f"{b:02X}" for b in raw]
                         value_str = f"[{' '.join(bytes_data)}{'...' if member_size > 16 else ''}]"
                 except Exception:
                     value_str = "<failed to read>"

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -575,26 +575,12 @@ def _type_matches_kind(kind: str, tif: ida_typeinf.tinfo_t) -> bool:
 @idasync
 def type_query(
     queries: Annotated[
-        list[TypeQuery] | TypeQuery | str,
+        list[TypeQuery] | TypeQuery,
         "Type catalog query with filtering, pagination, and optional relationships",
     ],
 ) -> list[TypeQueryResult]:
     """Query local types with structured filters/projection-friendly output."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {
-            "filter": s,
-            "kind": "any",
-            "offset": 0,
-            "count": 100,
-            "sort_by": "name",
-            "descending": False,
-            "include_decl": True,
-            "include_members": False,
-            "max_members": 64,
-            "include_relationships": False,
-        },
-    )
+    queries = normalize_dict_list(queries)
 
     # Build one local catalog and page/filter it per query.
     catalog: list[dict] = []
@@ -736,15 +722,12 @@ def type_query(
 @idasync
 def type_inspect(
     queries: Annotated[
-        list[TypeInspectQuery] | TypeInspectQuery | str,
+        list[TypeInspectQuery] | TypeInspectQuery,
         "Inspect named types and optionally include member layout",
     ],
 ) -> list[TypeInspectResult]:
     """Inspect named types (size/kind/declaration/members)."""
-    queries = normalize_dict_list(
-        queries,
-        lambda s: {"name": s, "include_members": False, "max_members": 128},
-    )
+    queries = normalize_dict_list(queries)
     results = []
 
     for query in queries:
@@ -1048,19 +1031,15 @@ def set_type(edits: list[TypeEdit] | TypeEdit) -> list[SetTypeResult]:
 @idasync
 def type_apply_batch(
     batch: Annotated[
-        TypeApplyBatch | list[TypeEdit] | TypeEdit,
+        TypeApplyBatch,
         "Batch type edits with optional stop_on_error behavior",
     ],
 ) -> TypeApplyBatchResult:
     """Apply multiple type edits and return aggregate status."""
-    if isinstance(batch, dict) and "edits" in batch:
-        normalized_edits = normalize_dict_list(
-            batch.get("edits", []), _parse_addr_type_shorthand
-        )
-        stop_on_error = bool(batch.get("stop_on_error", False))
-    else:
-        normalized_edits = normalize_dict_list(batch, _parse_addr_type_shorthand)
-        stop_on_error = False
+    normalized_edits = normalize_dict_list(
+        batch.get("edits", []), _parse_addr_type_shorthand
+    )
+    stop_on_error = bool(batch.get("stop_on_error", False))
 
     results: list[dict] = []
     for edit in normalized_edits:

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
@@ -274,7 +274,7 @@ def test_xref_query():
 
     result = xref_query(
         {
-            "query": fn_addr,
+            "addr": fn_addr,
             "direction": "both",
             "xref_type": "any",
             "offset": 0,
@@ -284,7 +284,7 @@ def test_xref_query():
     )
     assert_is_list(result, min_length=1)
     page = result[0]
-    assert_has_keys(page, "query", "resolved_addr", "data", "next_offset", "total", "error")
+    assert_has_keys(page, "target", "resolved_addr", "data", "next_offset", "total", "error")
     if page["data"]:
         assert_has_keys(page["data"][0], "direction", "addr", "from", "to", "type")
 
@@ -565,7 +565,7 @@ def test_func_profile():
     if not fn_addr:
         skip_test("binary has no functions")
 
-    result = func_profile({"query": fn_addr, "include_lists": False})
+    result = func_profile({"addr": fn_addr, "include_lists": False})
     assert_is_list(result, min_length=1)
     page = result[0]
     assert_has_keys(page, "data", "next_offset", "error")
@@ -594,7 +594,7 @@ def test_analyze_batch():
 
     result = analyze_batch(
         {
-            "query": fn_addr,
+            "addr": fn_addr,
             "include_disasm": True,
             "max_disasm_insns": 16,
             "include_strings": True,
@@ -607,7 +607,7 @@ def test_analyze_batch():
     )
     assert_is_list(result, min_length=1)
     r = result[0]
-    assert_has_keys(r, "query", "addr", "name", "analysis", "error")
+    assert_has_keys(r, "target", "addr", "name", "analysis", "error")
     if r["analysis"] is not None:
         a = r["analysis"]
         assert_has_keys(

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_memory.py
@@ -22,6 +22,7 @@ from ..api_memory import (
     patch,
     put_int,
 )
+from ..utils import read_bytes_bss_safe, read_int_bss_safe
 
 
 CRACKME_FORMAT = "0x201f"
@@ -230,3 +231,140 @@ def test_get_global_value_not_found():
     result = get_global_value("definitely_not_a_global_symbol")
     assert_is_list(result, min_length=1)
     assert_error(result[0], contains="Not found")
+
+
+# ============================================================================
+# BSS / unloaded-byte handling
+# ============================================================================
+
+
+def _find_unloaded_addr() -> int | None:
+    """Find an address whose byte is not loaded in the IDB.
+
+    Prefers SEG_BSS segments (most portable signal), falls back to any segment
+    whose starting byte reports is_loaded=False. Returns None if the binary
+    has no unloaded region - in which case BSS tests should skip.
+    """
+    import ida_bytes
+    import idaapi
+    import idautils
+
+    for seg_ea in idautils.Segments():
+        seg = idaapi.getseg(seg_ea)
+        if seg is None:
+            continue
+        if seg.type == idaapi.SEG_BSS:
+            return seg.start_ea
+
+    for seg_ea in idautils.Segments():
+        seg = idaapi.getseg(seg_ea)
+        if seg is None:
+            continue
+        if not ida_bytes.is_loaded(seg.start_ea):
+            return seg.start_ea
+
+    return None
+
+
+def _find_named_bss_symbol() -> str | None:
+    """Find a named global whose starting byte is not loaded (BSS-like)."""
+    import ida_bytes
+    import idaapi
+    import idautils
+
+    for addr, name in idautils.Names():
+        if not name:
+            continue
+        if idaapi.get_func(addr):
+            continue
+        if not ida_bytes.is_loaded(addr):
+            return name
+
+    return None
+
+
+@test()
+def test_read_bytes_bss_safe_returns_zeros_for_unloaded():
+    """read_bytes_bss_safe substitutes 0 for unloaded (BSS) bytes."""
+    ea = _find_unloaded_addr()
+    if ea is None:
+        skip_test("binary has no unloaded/BSS region")
+
+    raw = read_bytes_bss_safe(ea, 16)
+    assert isinstance(raw, bytes)
+    assert len(raw) == 16
+    assert raw == b"\x00" * 16, f"expected all zeros, got {raw.hex()}"
+
+
+@test()
+def test_read_int_bss_safe_returns_zero_for_unloaded():
+    """read_int_bss_safe returns 0 for every int width on unloaded bytes."""
+    ea = _find_unloaded_addr()
+    if ea is None:
+        skip_test("binary has no unloaded/BSS region")
+
+    for size in (1, 2, 4, 8):
+        assert read_int_bss_safe(ea, size) == 0, (
+            f"expected 0 for size {size}, got {read_int_bss_safe(ea, size):#x}"
+        )
+
+
+@test()
+def test_get_int_reads_bss_region_as_zero():
+    """get_int returns 0, not the 0xff sentinel, for unloaded (BSS) bytes."""
+    ea = _find_unloaded_addr()
+    if ea is None:
+        skip_test("binary has no unloaded/BSS region")
+
+    for ty in ("u8", "u16", "u32", "u64", "i32", "i64"):
+        result = get_int({"addr": hex(ea), "ty": ty})
+        assert_is_list(result, min_length=1)
+        entry = result[0]
+        assert "error" not in entry, (
+            f"get_int({ty}) at BSS errored: {entry.get('error')!r}"
+        )
+        assert entry["value"] == 0, (
+            f"expected 0 for {ty} at BSS, got {entry['value']!r}"
+        )
+
+
+@test()
+def test_get_bytes_reads_bss_region_as_zero():
+    """get_bytes returns zeroed bytes for an unloaded (BSS) region."""
+    ea = _find_unloaded_addr()
+    if ea is None:
+        skip_test("binary has no unloaded/BSS region")
+
+    result = get_bytes({"addr": hex(ea), "size": 8})
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert_ok(entry, "data")
+    parts = entry["data"].split()
+    assert len(parts) == 8
+    assert all(int(p, 16) == 0 for p in parts), (
+        f"expected all zeros for BSS, got {entry['data']!r}"
+    )
+
+
+@test()
+def test_get_global_value_bss_symbol_is_zero():
+    """get_global_value on a BSS-resident named global returns 0, not 0xff."""
+    import ida_bytes
+
+    name = _find_named_bss_symbol()
+    if name is None:
+        skip_test("binary has no named BSS global")
+
+    result = get_global_value(name)
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert_ok(entry, "value")
+    value_str = entry["value"]
+
+    # Integer-sized globals return a single "0x0". Larger shapes return a
+    # space-separated run of per-byte hex values.
+    parts = value_str.split()
+    assert parts, f"unexpected empty value for BSS global {name}"
+    assert all(int(p, 16) == 0 for p in parts), (
+        f"expected all zeros for BSS global {name}, got {value_str!r}"
+    )

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
@@ -181,6 +181,72 @@ def test_read_struct_without_type_info_fails_cleanly():
     assert_error(result[0], contains="could not auto-detect")
 
 
+def _find_bss_addr() -> int | None:
+    """Locate an address whose byte is not loaded (BSS or similar)."""
+    import ida_bytes
+    import idaapi
+    import idautils
+
+    for seg_ea in idautils.Segments():
+        seg = idaapi.getseg(seg_ea)
+        if seg is None:
+            continue
+        if seg.type == idaapi.SEG_BSS:
+            return seg.start_ea
+
+    for seg_ea in idautils.Segments():
+        seg = idaapi.getseg(seg_ea)
+        if seg is None:
+            continue
+        if not ida_bytes.is_loaded(seg.start_ea):
+            return seg.start_ea
+
+    return None
+
+
+@test()
+def test_read_struct_bss_members_are_zero():
+    """read_struct reports zero for every member when the struct lives in BSS.
+
+    BSS bytes are unloaded in the IDB but zero-initialized at runtime. Before
+    the BSS-aware read, members would come back as 0xff-filled garbage.
+    """
+    bss_ea = _find_bss_addr()
+    if bss_ea is None:
+        skip_test("binary has no BSS / unloaded region")
+
+    if not create_test_struct(TEST_STRUCT_NAME):
+        skip_test("failed to declare test struct")
+
+    result = read_struct({"addr": hex(bss_ea), "struct": TEST_STRUCT_NAME})
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert_ok(entry, "members")
+
+    failures = []
+    for member in entry["members"]:
+        value_str = member["value"]
+        # Integer members render as "0xNN (N)"; pointer as "0xNN...";
+        # longer shapes render as "[NN NN ...]".
+        if "(" in value_str:
+            hex_part = value_str.split()[0]
+            numeric = int(hex_part, 16)
+        elif value_str.startswith("0x"):
+            numeric = int(value_str, 16)
+        elif value_str.startswith("["):
+            inner = value_str.strip("[]").replace("...", "").split()
+            numeric = sum(int(b, 16) for b in inner)
+        else:
+            failures.append(f"{member['name']}: unparseable value {value_str!r}")
+            continue
+        if numeric != 0:
+            failures.append(
+                f"{member['name']}: expected 0 at BSS, got {value_str!r}"
+            )
+
+    assert not failures, "\n".join(failures)
+
+
 @test()
 def test_search_structs_finds_declared_structs():
     """search_structs returns the previously declared deterministic struct."""

--- a/src/ida_pro_mcp/ida_mcp/tests/test_tool_metadata.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_tool_metadata.py
@@ -97,3 +97,214 @@ def test_tool_param_descriptions_specific():
                 )
 
     assert not failures, "\n".join(failures)
+
+
+# Stdlib/primitive type names that are OK to appear in a union alongside a
+# TypedDict-like name only when the union is a simple single-or-list shortcut.
+_PRIMITIVE_TYPE_NAMES = {"str", "int", "float", "bool", "bytes", "dict"}
+
+# Parameter names whose annotations are allowed to include a bare `str` because
+# the string carries no ambiguity - they're simple scalar inputs, not TypedDict
+# shortcuts. Example: `addr: str`, `addrs: list[str] | str`.
+_PLAIN_STRING_PARAMS = {
+    "addr",
+    "addrs",
+    "name",
+    "target",
+    "targets",
+    "patterns",
+    "decls",
+    "roots",
+    "path",
+    "type",
+    "format",
+}
+
+
+def _union_elements(node: ast.expr) -> list[ast.expr]:
+    """Flatten `A | B | C` into [A, B, C]. Non-union returns [node]."""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _union_elements(node.left) + _union_elements(node.right)
+    return [node]
+
+
+def _is_typed_dict_like(name: str) -> bool:
+    """Heuristic: CamelCase name that ends with a wrapper-ish suffix."""
+    if not name or not name[0].isupper():
+        return False
+    suffixes = (
+        "Query",
+        "Op",
+        "Pattern",
+        "Edit",
+        "Batch",
+        "Rename",
+        "Read",
+        "Write",
+        "Inspect",
+        "Decl",
+        "Delete",
+        "Conversion",
+        "Upsert",
+    )
+    return any(name.endswith(s) for s in suffixes)
+
+
+def _contains_name(node: ast.expr, names: set[str]) -> bool:
+    for elt in ast.walk(node):
+        if isinstance(elt, ast.Name) and elt.id in names:
+            return True
+    return False
+
+
+def _iter_tool_arg_annotations(node: ast.FunctionDef):
+    for arg in [*node.args.args, *node.args.kwonlyargs]:
+        ann = arg.annotation
+        if ann is None:
+            continue
+        if (
+            isinstance(ann, ast.Subscript)
+            and isinstance(ann.value, ast.Name)
+            and ann.value.id == "Annotated"
+            and isinstance(ann.slice, ast.Tuple)
+            and ann.slice.elts
+        ):
+            yield arg.arg, ann.slice.elts[0]
+        else:
+            yield arg.arg, ann
+
+
+@test()
+def test_tool_params_no_bare_string_or_dict_fallback():
+    """Tool parameters must not pair a TypedDict-like name with bare str/dict.
+
+    Catches schemas like `list[FooQuery] | FooQuery | str` where the bare-string
+    branch collapses the typed shape in the emitted JSONSchema, leaving the
+    model with no way to know what the string actually means.
+    """
+    failures: list[str] = []
+    for path, node in _iter_tool_functions():
+        for arg_name, ann in _iter_tool_arg_annotations(node):
+            elements = _union_elements(ann)
+            if len(elements) < 2:
+                continue
+            has_typed_dict_like = any(
+                _contains_name(e, set())
+                or any(
+                    isinstance(n, ast.Name) and _is_typed_dict_like(n.id)
+                    for n in ast.walk(e)
+                )
+                for e in elements
+            )
+            if not has_typed_dict_like:
+                continue
+            has_bare_string = any(
+                isinstance(e, ast.Name) and e.id == "str" for e in elements
+            )
+            has_bare_dict = any(
+                isinstance(e, ast.Name) and e.id == "dict" for e in elements
+            )
+            if has_bare_string and arg_name not in _PLAIN_STRING_PARAMS:
+                failures.append(
+                    f"{path.name}:{node.lineno} {node.name}({arg_name}) "
+                    f"has a typed shape unioned with bare `str` - "
+                    f"the string branch erases the typed schema"
+                )
+            if has_bare_dict:
+                failures.append(
+                    f"{path.name}:{node.lineno} {node.name}({arg_name}) "
+                    f"has a typed shape unioned with bare `dict` - "
+                    f"the dict branch erases the typed schema"
+                )
+
+    assert not failures, "\n".join(failures)
+
+
+@test()
+def test_tool_param_typed_dicts_have_required_core():
+    """TypedDicts used as tool param shapes must declare a required core.
+
+    A `total=False` TypedDict emits `required: []` in the schema, leaving the
+    model no signal about what it must supply. At least one field should be
+    marked required (via default `total=True` + `NotRequired` for the rest),
+    unless the shape is a pure filter/pagination wrapper where every field is
+    genuinely optional.
+    """
+    # Pure-filter wrappers where every field really is optional.
+    ALLOW_EMPTY_REQUIRED = {
+        "RenameBatch",  # at least one of func/local/stack/data (enforced in body)
+        "FunctionQuery",
+        "ListQuery",
+        "ImportQuery",
+        "TypeQuery",
+        "InsnPattern",
+        "FuncProfileQuery",
+        "StructRead",
+        "DefineOp",
+        "UndefineOp",
+        "NumberConversion",
+        "EnumUpsert",
+        "EnumMemberUpsert",
+    }
+
+    utils_path = Path(__file__).resolve().parents[1] / "utils.py"
+    tree = ast.parse(utils_path.read_text(encoding="utf-8"))
+
+    failures: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        bases = [ast.unparse(b) for b in node.bases]
+        if not any("TypedDict" in b for b in bases):
+            continue
+        if node.name in ALLOW_EMPTY_REQUIRED:
+            continue
+
+        # Is the class declared total=False?
+        total_false = any(
+            isinstance(kw, ast.keyword)
+            and kw.arg == "total"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is False
+            for kw in node.keywords
+        )
+
+        fields: list[tuple[str, ast.expr]] = []
+        for stmt in node.body:
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                fields.append((stmt.target.id, stmt.annotation))
+
+        if not fields:
+            continue
+
+        required_count = 0
+        for _, ann in fields:
+            # Unwrap Annotated[...] to inspect the inner type
+            inner = ann
+            if (
+                isinstance(inner, ast.Subscript)
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id == "Annotated"
+                and isinstance(inner.slice, ast.Tuple)
+                and inner.slice.elts
+            ):
+                inner = inner.slice.elts[0]
+
+            is_not_required = (
+                isinstance(inner, ast.Subscript)
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id == "NotRequired"
+            )
+            # total=False + no NotRequired wrapper = optional
+            # total=True (default) + no NotRequired wrapper = required
+            if not total_false and not is_not_required:
+                required_count += 1
+
+        if required_count == 0:
+            failures.append(
+                f"utils.py:{node.lineno} {node.name} has no required fields - "
+                f"emits `required: []` in the schema; either add a required "
+                f"field or allow-list it as a pure-filter wrapper"
+            )
+
+    assert not failures, "\n".join(failures)

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -18,6 +18,7 @@ from typing import (
     overload,
 )
 
+import ida_bytes
 import ida_funcs
 import ida_hexrays
 import ida_kernwin
@@ -598,6 +599,41 @@ def parse_address(addr: str | int) -> int:
             if ch not in "0123456789abcdefABCDEF":
                 raise IDAError(f"Not found: {addr!r}")
         raise IDAError(f"Failed to parse address (missing 0x prefix): {addr}")
+
+
+def read_bytes_bss_safe(ea: int, size: int) -> bytes:
+    """Read `size` bytes starting at `ea`, substituting 0 for unloaded bytes.
+
+    Unloaded bytes in BSS-like sections are zero at runtime by every mainstream
+    loader, but ida_bytes.get_byte() returns 0xFF as a sentinel for them. Patch
+    that here so reads of globals in .bss return the real zero-initialized
+    value instead of 0xff garbage.
+    """
+    out = bytearray(size)
+    for i in range(size):
+        if ida_bytes.is_loaded(ea + i):
+            out[i] = ida_bytes.get_byte(ea + i)
+    return bytes(out)
+
+
+def read_int_bss_safe(ea: int, size: int) -> int:
+    """Read an integer of `size` bytes at `ea`, honoring IDB endianness.
+
+    Returns 0 if the byte at `ea` is not loaded (BSS / zero-initialized region).
+    Uses IDA's native sized readers (get_byte/word/dword/qword) for loaded
+    bytes so the result respects the database endianness.
+    """
+    if not ida_bytes.is_loaded(ea):
+        return 0
+    if size == 1:
+        return ida_bytes.get_byte(ea)
+    if size == 2:
+        return ida_bytes.get_word(ea)
+    if size == 4:
+        return ida_bytes.get_dword(ea)
+    if size == 8:
+        return ida_bytes.get_qword(ea)
+    raise ValueError(f"unsupported integer size: {size}")
 
 
 def normalize_list_input(value: list | str) -> list:

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -85,13 +85,15 @@ class CommentOp(TypedDict):
     comment: Annotated[str, "Comment text"]
 
 
-class CommentAppendOp(TypedDict, total=False):
+class CommentAppendOp(TypedDict):
     """Comment append operation"""
 
     addr: Annotated[str, "Address (hex or decimal)"]
     comment: Annotated[str, "Comment text to append"]
-    scope: Annotated[str, "auto|func|line (default: auto)"]
-    dedupe: Annotated[bool, "Skip if exact text already exists (default: true)"]
+    scope: NotRequired[Annotated[str, "auto|func|line (default: auto)"]]
+    dedupe: NotRequired[
+        Annotated[bool, "Skip if exact text already exists (default: true)"]
+    ]
 
 
 class AsmPatchOp(TypedDict):
@@ -132,20 +134,22 @@ class StackRename(TypedDict):
 
 
 class RenameBatch(TypedDict, total=False):
-    """Batch rename operations across all entity types"""
+    """Batch rename operations across all entity types.
+
+    At least one of func/data/local/stack should be present.
+    """
 
     func: Annotated[
-        list[FunctionRename] | FunctionRename | None, "Function rename operations"
+        list[FunctionRename] | FunctionRename, "Function rename operations"
     ]
     data: Annotated[
-        list[GlobalRename] | GlobalRename | None,
-        "Global/data variable rename operations",
+        list[GlobalRename] | GlobalRename, "Global/data variable rename operations"
     ]
     local: Annotated[
-        list[LocalRename] | LocalRename | None, "Local variable rename operations"
+        list[LocalRename] | LocalRename, "Local variable rename operations"
     ]
     stack: Annotated[
-        list[StackRename] | StackRename | None, "Stack variable rename operations"
+        list[StackRename] | StackRename, "Stack variable rename operations"
     ]
     stop_on_error: Annotated[bool, "Stop on first failure"]
     dry_run: Annotated[bool, "Validate only, no changes"]
@@ -159,18 +163,18 @@ class StructFieldQuery(TypedDict):
     field: Annotated[str, "Field name"]
 
 
-class XrefQuery(TypedDict, total=False):
+class XrefQuery(TypedDict):
     """Generic cross-reference query"""
 
-    query: Annotated[str, "Address or name"]
-    direction: Annotated[str, "to|from|both"]
-    xref_type: Annotated[str, "any|code|data"]
-    offset: Annotated[int, "Start index"]
-    count: Annotated[int, "Max results (max: 5000)"]
-    include_fn: Annotated[bool, "Include function metadata"]
-    dedup: Annotated[bool, "Deduplicate by addr/type"]
-    sort_by: Annotated[str, "Sort: addr|type"]
-    descending: Annotated[bool, "Descending"]
+    addr: Annotated[str, "Address or name"]
+    direction: NotRequired[Annotated[str, "to|from|both (default: both)"]]
+    xref_type: NotRequired[Annotated[str, "any|code|data (default: any)"]]
+    offset: NotRequired[Annotated[int, "Start index (default: 0)"]]
+    count: NotRequired[Annotated[int, "Max results (default: 200, max: 5000)"]]
+    include_fn: NotRequired[Annotated[bool, "Include function metadata"]]
+    dedup: NotRequired[Annotated[bool, "Deduplicate by addr/type"]]
+    sort_by: NotRequired[Annotated[str, "Sort: addr|type"]]
+    descending: NotRequired[Annotated[bool, "Descending"]]
 
 
 class ListQuery(TypedDict, total=False):
@@ -195,27 +199,30 @@ class FunctionQuery(TypedDict, total=False):
     descending: Annotated[bool, "Descending"]
 
 
-class EntityQuery(TypedDict, total=False):
+class EntityQuery(TypedDict):
     """Generic IDB entity query with filtering, projection, and pagination"""
 
     kind: Annotated[str, "functions|globals|imports|strings|names"]
-    filter: Annotated[str, "Glob/regex filter"]
-    regex: Annotated[str, "Regex on primary text field"]
-    min_addr: Annotated[str, "Min address bound"]
-    max_addr: Annotated[str, "Max address bound"]
-    segment: Annotated[str, "Segment filter"]
-    module: Annotated[str, "Import module filter"]
-    offset: Annotated[int, "Start index"]
-    count: Annotated[int, "Max results (0=all)"]
-    sort_by: Annotated[str, "Sort: addr|name|size|length"]
-    descending: Annotated[bool, "Descending"]
-    fields: Annotated[list[str] | str, "Projection field list"]
+    filter: NotRequired[Annotated[str, "Glob/regex filter"]]
+    regex: NotRequired[Annotated[str, "Regex on primary text field"]]
+    min_addr: NotRequired[Annotated[str, "Min address bound"]]
+    max_addr: NotRequired[Annotated[str, "Max address bound"]]
+    segment: NotRequired[Annotated[str, "Segment filter"]]
+    module: NotRequired[Annotated[str, "Import module filter"]]
+    offset: NotRequired[Annotated[int, "Start index"]]
+    count: NotRequired[Annotated[int, "Max results (0=all)"]]
+    sort_by: NotRequired[Annotated[str, "Sort: addr|name|size|length"]]
+    descending: NotRequired[Annotated[bool, "Descending"]]
+    fields: NotRequired[Annotated[list[str], "Projection field list"]]
 
 
 class FuncProfileQuery(TypedDict, total=False):
-    """Function profiling query with pagination and optional detail lists"""
+    """Function profiling query with pagination and optional detail lists.
 
-    query: Annotated[str, "Address/name or '*'"]
+    All fields are optional - omit addr to profile all functions.
+    """
+
+    addr: Annotated[str, "Function address or name (omit or '*' for all)"]
     filter: Annotated[str, "Name glob/regex"]
     offset: Annotated[int, "Start index"]
     count: Annotated[int, "Max results (0=all)"]
@@ -226,25 +233,25 @@ class FuncProfileQuery(TypedDict, total=False):
     include_prototype: Annotated[bool, "Include prototype"]
 
 
-class AnalyzeBatchQuery(TypedDict, total=False):
+class AnalyzeBatchQuery(TypedDict):
     """Comprehensive function analysis request"""
 
-    query: Annotated[str, "Function address or name"]
-    include_decompile: Annotated[bool, "Include decompiler output"]
-    include_disasm: Annotated[bool, "Include disassembly"]
-    include_xrefs: Annotated[bool, "Include xrefs-to/from"]
-    include_callers: Annotated[bool, "Include callers"]
-    include_callees: Annotated[bool, "Include callees"]
-    include_strings: Annotated[bool, "Include strings"]
-    include_constants: Annotated[bool, "Include constants"]
-    include_basic_blocks: Annotated[bool, "Include basic blocks"]
-    include_proto: Annotated[bool, "Include prototype"]
-    max_disasm_insns: Annotated[int, "Max disasm instructions"]
-    max_callers: Annotated[int, "Max callers"]
-    max_callees: Annotated[int, "Max callees"]
-    max_strings: Annotated[int, "Max strings"]
-    max_constants: Annotated[int, "Max constants"]
-    max_blocks: Annotated[int, "Max blocks"]
+    addr: Annotated[str, "Function address or name"]
+    include_decompile: NotRequired[Annotated[bool, "Include decompiler output"]]
+    include_disasm: NotRequired[Annotated[bool, "Include disassembly"]]
+    include_xrefs: NotRequired[Annotated[bool, "Include xrefs-to/from"]]
+    include_callers: NotRequired[Annotated[bool, "Include callers"]]
+    include_callees: NotRequired[Annotated[bool, "Include callees"]]
+    include_strings: NotRequired[Annotated[bool, "Include strings"]]
+    include_constants: NotRequired[Annotated[bool, "Include constants"]]
+    include_basic_blocks: NotRequired[Annotated[bool, "Include basic blocks"]]
+    include_proto: NotRequired[Annotated[bool, "Include prototype"]]
+    max_disasm_insns: NotRequired[Annotated[int, "Max disasm instructions"]]
+    max_callers: NotRequired[Annotated[int, "Max callers"]]
+    max_callees: NotRequired[Annotated[int, "Max callees"]]
+    max_strings: NotRequired[Annotated[int, "Max strings"]]
+    max_constants: NotRequired[Annotated[int, "Max constants"]]
+    max_blocks: NotRequired[Annotated[int, "Max blocks"]]
 
 
 class ImportQuery(TypedDict, total=False):
@@ -256,12 +263,12 @@ class ImportQuery(TypedDict, total=False):
     count: Annotated[int, "Max results (0=all)"]
 
 
-class TypeInspectQuery(TypedDict, total=False):
+class TypeInspectQuery(TypedDict):
     """Type inspection request"""
 
     name: Annotated[str, "Type name"]
-    include_members: Annotated[bool, "Include UDT member details"]
-    max_members: Annotated[int, "Max members"]
+    include_members: NotRequired[Annotated[bool, "Include UDT member details"]]
+    max_members: NotRequired[Annotated[int, "Max members"]]
 
 
 class TypeQuery(TypedDict, total=False):
@@ -324,15 +331,15 @@ class StructRead(TypedDict, total=False):
     struct: Annotated[NotRequired[str], "Struct name (auto-detect if omitted)"]
 
 
-class TypeEdit(TypedDict, total=False):
+class TypeEdit(TypedDict):
     """Type application operation"""
 
-    addr: Annotated[str, "Address"]
-    name: Annotated[str, "Variable/function name"]
-    ty: Annotated[str, "Type name or declaration"]
-    kind: Annotated[str, "Entity kind (auto-detected)"]
-    signature: Annotated[str, "Function signature"]
-    variable: Annotated[str, "Local variable name"]
+    addr: Annotated[str, "Address (function, global, or stack frame)"]
+    ty: NotRequired[Annotated[str, "Type name or declaration"]]
+    name: NotRequired[Annotated[str, "Variable/function name"]]
+    kind: NotRequired[Annotated[str, "Entity kind (auto-detected)"]]
+    signature: NotRequired[Annotated[str, "Function signature"]]
+    variable: NotRequired[Annotated[str, "Local variable name"]]
 
 
 class EnumMemberUpsert(TypedDict, total=False):
@@ -350,11 +357,11 @@ class EnumUpsert(TypedDict, total=False):
     bitfield: Annotated[bool, "Bitfield enum"]
 
 
-class TypeApplyBatch(TypedDict, total=False):
+class TypeApplyBatch(TypedDict):
     """Batch type application configuration"""
 
     edits: Annotated[list[TypeEdit] | TypeEdit, "Type edits to apply"]
-    stop_on_error: Annotated[bool, "Stop on first failure"]
+    stop_on_error: NotRequired[Annotated[bool, "Stop on first failure"]]
 
 
 class StackVarDecl(TypedDict):


### PR DESCRIPTION
To get the tool calls more consistent, here is what changed:

- Input TypedDicts now declare a required core and mark the rest `NotRequired[...]`:
  - `CommentAppendOp`: `addr` + `comment` required (matches `CommentOp`)
  - `XrefQuery`, `AnalyzeBatchQuery`: `addr` required (renamed from `query`)
  - `EntityQuery`: `kind` required
  - `TypeEdit`: `addr` required
  - `TypeApplyBatch`: `edits` required
  - `TypeInspectQuery`: `name` required
  - `RenameBatch`: dropped stray `| None` field branches
  - `FuncProfileQuery`: renamed `query` -> `addr`
- Tool signatures dropped degenerate fallbacks:
  - `rename(batch: RenameBatch)` - no more `| dict`
  - `type_apply_batch(batch: TypeApplyBatch)` - wrapper only
  - `analyze_batch` / `xref_query` / `func_profile` / `insn_query` / `entity_query` / `func_query` / `list_funcs` / `list_globals` / `imports_query` / `type_query` / `type_inspect` - dropped the bare `| str` branch
- Result echo field renamed `query` : `target` in `AnalyzeBatchResult` / `FuncProfileResult` / `XrefQueryResult` to stop colliding with the resolved `addr` field on the same object.
- Two new schema-consistency tests added to `test_tool_metadata.py`:
  - `test_tool_params_no_bare_string_or_dict_fallback` - flags any tool parameter that unions a TypedDict-like shape with bare `str`/`dict`.
  - `test_tool_param_typed_dicts_have_required_core` - flags TypedDicts used as tool inputs that emit `required: []`; pure-filter wrappers (`ListQuery`, `FunctionQuery`, `InsnPattern`, etc.) are allow-listed.

On top of that I also discovered a rather annoying bug/behavior that I did not notice in the very beginning of a project which did cost me quite a few headaches before I figured out that the bytes dumped did not match. Reading bytes from virtual memory / bss should result 0 bytes where it previously gave back FF bytes, majority of systems that zero init those regions in the sections. Now it uses `is_loaded` to see if the bytes actually exist and if not return zero byte data.