### PR TITLE
Use environment variables for MCP host and port

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -4,6 +4,7 @@ This file serves as the entry point for IDA Pro's plugin system.
 It loads the actual implementation from the ida_mcp package.
 """
 
+import os
 import sys
 import idaapi
 import ida_kernwin
@@ -152,8 +153,10 @@ class MCP(idaapi.plugin_t):
             hotkey = hotkey.replace("Alt", "Option")
 
         self.mcp: "ida_mcp.rpc.McpServer | None" = None
-        self.host = self.DEFAULT_HOST
-        self.port = self.DEFAULT_PORT
+        # self.host = self.DEFAULT_HOST
+        # self.port = self.DEFAULT_PORT
+        self.host = os.environ.get("IDAMCP_HOST", self.DEFAULT_HOST)
+        self.port = int(os.environ.get("IDAMCP_PORT", str(self.DEFAULT_PORT)))
         self.autostart = _get_autostart()
 
         if self.autostart and ida_kernwin.is_idaq():


### PR DESCRIPTION
Updated host and port initialization to use environment variables. use IDAMCP_HOST and IDAMCP_PORT to set host/port for server.