### PR TITLE
Add --profile flag to idalib-mcp

### DIFF
--- a/profiles/readonly.txt
+++ b/profiles/readonly.txt
@@ -1,0 +1,53 @@
+# Read-only profile for ida-pro-mcp
+#
+# Exposes analysis tools that never mutate the IDB: decompilation, disassembly,
+# xrefs, queries, reads. No renaming, commenting, typing, or patching.
+#
+# Use with: idalib-mcp --profile profiles/readonly.txt <binary>
+
+# --- Core metadata & listings ---
+server_health
+server_warmup
+list_funcs
+list_globals
+imports
+imports_query
+lookup_funcs
+func_query
+entity_query
+int_convert
+find_regex
+
+# --- Analysis (decomp / disasm / xrefs) ---
+decompile
+disasm
+func_profile
+analyze_batch
+xrefs_to
+xref_query
+xrefs_to_field
+callees
+basic_blocks
+find_bytes
+find
+insn_query
+export_funcs
+callgraph
+
+# --- Composite analyses ---
+analyze_function
+analyze_component
+trace_data_flow
+
+# --- Types (read-only) ---
+read_struct
+type_query
+
+# --- Memory reads ---
+get_bytes
+get_int
+get_string
+get_global_value
+
+# --- Stack (read-only) ---
+stack_frame

--- a/profiles/triage.txt
+++ b/profiles/triage.txt
@@ -1,0 +1,20 @@
+# Minimal triage profile for ida-pro-mcp
+#
+# A focused starter set for first-pass binary assessment:
+# enumerate, decompile, trace xrefs.
+# Small enough to keep small models on-task.
+#
+# Use with: idalib-mcp --profile profiles/triage.txt <binary>
+
+list_funcs
+list_globals
+imports
+lookup_funcs
+
+decompile
+disasm
+
+xrefs_to
+callees
+
+get_string

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, parse_qs
 from typing import TypeVar, cast
 from http.server import HTTPServer
 
+from .profile import dump_profile, parse_profile
 from .sync import idasync
 from .rpc import (
     McpRpcRegistry,
@@ -135,6 +136,12 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
             self._handle_config_get()
             return
 
+        if path == "/profile.txt":
+            if not self._check_host():
+                return
+            self._handle_profile_export()
+            return
+
         # Handle output download requests
         output_match = re.match(r"^/output/([a-f0-9-]+)\.(\w+)$", path)
         if output_match:
@@ -144,6 +151,22 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
             return
 
         super().do_GET()
+
+    def _handle_profile_export(self):
+        """Return the currently enabled tools as a profile file."""
+        enabled = sorted(self.mcp_server.tools.methods.keys())
+        body = dump_profile(
+            enabled,
+            header="ida-pro-mcp profile exported from /config.html",
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header(
+            "Content-Disposition", 'attachment; filename="ida-mcp-profile.txt"'
+        )
+        self.end_headers()
+        self.wfile.write(body)
 
     def _handle_output_download(self, output_id: str, extension: str):
         """Handle download of cached output data."""
@@ -367,6 +390,11 @@ input[type="submit"]:hover {
 </p>"""
 
         body += "<h2>Enabled Tools</h2>"
+        body += (
+            '<p style="font-size: 0.9rem; margin: 0.5rem 0;">'
+            '<a href="/profile.txt" download>Export as --profile file</a>'
+            "</p>"
+        )
         body += quick_select
         for name, func in ORIGINAL_TOOLS.items():
             description = (
@@ -378,6 +406,20 @@ input[type="submit"]:hover {
             body += f"<label><input type='checkbox' name='{html.escape(name)}' value='{html.escape(name)}'{checked}{unsafe_attr} data-tool>{unsafe_prefix}{html.escape(name)}: {html.escape(description)}</label>"
         body += quick_select
         body += "<br><input type='submit' value='Save'>"
+
+        body += "<h2>Import Profile</h2>"
+        body += (
+            "<p style='font-size: 0.9rem; margin: 0.5rem 0;'>"
+            "Paste profile contents (one tool name per line, <code>#</code> for comments) "
+            "to replace the current Enabled Tools selection."
+            "</p>"
+        )
+        body += (
+            "<textarea name='profile_text' rows='6' "
+            "style='width:100%;font-family:monospace;' "
+            "placeholder='# paste profile here'></textarea>"
+        )
+        body += "<br><input type='submit' name='apply_profile' value='Apply profile'>"
         body += "</form></body></html>"
         self._send_html(200, body)
 
@@ -400,7 +442,12 @@ input[type="submit"]:hover {
 
         # Update the server's tools (discovery tools cannot be disabled)
         from .api_discovery import _LOCAL_TOOL_NAMES as PROTECTED_TOOLS
-        enabled_tools = {name: name in postvars for name in ORIGINAL_TOOLS.keys()}
+
+        if "apply_profile" in postvars:
+            whitelist = parse_profile(postvars.get("profile_text", [""])[0])
+            enabled_tools = {name: name in whitelist for name in ORIGINAL_TOOLS.keys()}
+        else:
+            enabled_tools = {name: name in postvars for name in ORIGINAL_TOOLS.keys()}
         for name in PROTECTED_TOOLS:
             enabled_tools[name] = True
         self.mcp_server.tools.methods = {

--- a/src/ida_pro_mcp/ida_mcp/profile.py
+++ b/src/ida_pro_mcp/ida_mcp/profile.py
@@ -1,0 +1,53 @@
+"""Profile files whitelist MCP tools by name.
+
+Format: one tool name per line; ``#`` starts a comment; blank lines are ignored.
+Passed to ``idalib-mcp --profile PATH`` or exported from ``/config.html``.
+"""
+
+from pathlib import Path
+from typing import Iterable
+
+
+def parse_profile(text: str) -> set[str]:
+    """Parse profile text into a set of tool names."""
+    names: set[str] = set()
+    for line in text.splitlines():
+        name = line.split("#", 1)[0].strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def load_profile(path: str | Path) -> set[str]:
+    """Read a profile file and return its whitelisted tool names."""
+    return parse_profile(Path(path).read_text(encoding="utf-8"))
+
+
+def dump_profile(names: Iterable[str], *, header: str | None = None) -> str:
+    """Serialize tool names into profile file format (deterministic order)."""
+    lines = []
+    if header:
+        lines.extend(f"# {line}" for line in header.splitlines())
+        lines.append("")
+    lines.extend(sorted(names))
+    return "\n".join(lines) + "\n"
+
+
+def apply_profile(
+    tools: dict,
+    whitelist: set[str],
+    *,
+    protected: Iterable[str] = (),
+) -> tuple[list[str], list[str]]:
+    """Filter ``tools`` in place to ``whitelist`` plus ``protected`` names.
+
+    Returns ``(kept, unknown)``: tools from the whitelist that survived, and
+    whitelist entries that did not match any registered tool.
+    """
+    keep = whitelist | set(protected)
+    unknown = sorted(whitelist - set(tools))
+    for name in list(tools):
+        if name not in keep:
+            tools.pop(name)
+    kept = sorted(set(tools) & whitelist)
+    return kept, unknown

--- a/src/ida_pro_mcp/ida_mcp/tests/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/__init__.py
@@ -17,3 +17,4 @@ from . import test_framework_helpers
 from . import test_typed_fixture
 from . import test_utils
 from . import test_api_analysis_internals
+from . import test_profile

--- a/src/ida_pro_mcp/ida_mcp/tests/test_profile.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_profile.py
@@ -1,0 +1,161 @@
+"""Tests for profile-file parsing and registry filtering."""
+
+import contextlib
+from pathlib import Path
+
+from ..framework import test
+from ..profile import apply_profile, dump_profile, load_profile, parse_profile
+from ..rpc import MCP_SERVER
+
+
+@contextlib.contextmanager
+def _saved_tools():
+    """Restore MCP_SERVER.tools.methods so registry tests are non-destructive."""
+    original = MCP_SERVER.tools.methods.copy()
+    try:
+        yield
+    finally:
+        MCP_SERVER.tools.methods = original
+
+
+@test()
+def test_parse_profile_strips_comments_and_blanks():
+    """Comments, inline comments, blank lines, and whitespace are stripped."""
+    text = "\n".join(
+        [
+            "# header comment",
+            "",
+            "  decompile_function  ",
+            "list_functions # trailing comment",
+            "# full-line comment",
+            "\t",
+            "get_function",
+        ]
+    )
+    assert parse_profile(text) == {"decompile_function", "list_functions", "get_function"}
+
+
+@test()
+def test_parse_profile_empty_returns_empty_set():
+    """Empty or comment-only text yields an empty whitelist."""
+    assert parse_profile("") == set()
+    assert parse_profile("# only comments\n\n#another") == set()
+
+
+@test()
+def test_load_profile_round_trip():
+    """load_profile + dump_profile round-trip through the filesystem."""
+    import tempfile
+
+    names = {"decompile_function", "list_functions", "get_xrefs"}
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(dump_profile(names, header="test header"))
+        path = Path(f.name)
+    try:
+        assert load_profile(path) == names
+    finally:
+        path.unlink()
+
+
+@test()
+def test_dump_profile_is_deterministic():
+    """dump_profile sorts names so output is stable across runs."""
+    a = dump_profile({"b_tool", "a_tool", "c_tool"})
+    b = dump_profile(["c_tool", "a_tool", "b_tool"])
+    assert a == b
+    assert a.splitlines() == ["a_tool", "b_tool", "c_tool"]
+
+
+@test()
+def test_dump_profile_header_is_commented():
+    """Header lines are emitted as ``#`` comments followed by a blank line."""
+    out = dump_profile({"x"}, header="line1\nline2")
+    assert out.startswith("# line1\n# line2\n\nx\n")
+
+
+@test()
+def test_apply_profile_keeps_whitelist_and_protected():
+    """apply_profile retains whitelisted + protected names, drops the rest."""
+    tools = {"a": 1, "b": 2, "c": 3, "mgmt": 4}
+    kept, unknown = apply_profile(
+        tools, whitelist={"a", "c"}, protected={"mgmt"}
+    )
+    assert set(tools) == {"a", "c", "mgmt"}
+    assert kept == ["a", "c"]
+    assert unknown == []
+
+
+@test()
+def test_apply_profile_reports_unknown_entries():
+    """Whitelist entries not in the registry are returned as unknown."""
+    tools = {"real_tool": 1}
+    kept, unknown = apply_profile(tools, whitelist={"real_tool", "typo_tool"})
+    assert kept == ["real_tool"]
+    assert unknown == ["typo_tool"]
+    assert set(tools) == {"real_tool"}
+
+
+@test()
+def test_apply_profile_empty_whitelist_keeps_only_protected():
+    """An empty whitelist still preserves protected tools."""
+    tools = {"a": 1, "mgmt": 2}
+    kept, unknown = apply_profile(tools, whitelist=set(), protected={"mgmt"})
+    assert set(tools) == {"mgmt"}
+    assert kept == []
+    assert unknown == []
+
+
+@test()
+def test_apply_profile_survives_missing_protected():
+    """Protected names that aren't registered don't crash or re-appear."""
+    tools = {"a": 1}
+    kept, unknown = apply_profile(
+        tools, whitelist={"a"}, protected={"ghost_mgmt"}
+    )
+    assert set(tools) == {"a"}
+    assert kept == ["a"]
+    assert unknown == []
+
+
+@test()
+def test_apply_profile_against_real_registry():
+    """Filtering the live MCP_SERVER registry keeps only the whitelist."""
+    with _saved_tools():
+        registered = set(MCP_SERVER.tools.methods)
+        # Pick a couple of real tool names to whitelist.
+        sample = sorted(registered)[:2]
+        assert len(sample) == 2, "Expected ≥2 registered tools for this test"
+        kept, unknown = apply_profile(
+            MCP_SERVER.tools.methods, whitelist=set(sample)
+        )
+        assert set(MCP_SERVER.tools.methods) == set(sample)
+        assert kept == sorted(sample)
+        assert unknown == []
+
+
+@test()
+def test_export_round_trips_through_parse_profile():
+    """Dumping the live registry and re-parsing yields the same names."""
+    names = sorted(MCP_SERVER.tools.methods.keys())
+    text = dump_profile(names, header="ida-pro-mcp profile export")
+    assert parse_profile(text) == set(names)
+
+
+@test()
+def test_bundled_profiles_reference_known_tools():
+    """Shipped profile files list only tools that exist in the registry."""
+    import os
+
+    registered = set(MCP_SERVER.tools.methods)
+    # repo-root/profiles relative to src/ida_pro_mcp/ida_mcp/tests/test_profile.py
+    here = Path(__file__).resolve()
+    root = here.parents[4]
+    for name in ("readonly.txt", "triage.txt"):
+        path = root / "profiles" / name
+        if not path.exists():
+            continue  # running from installed package without repo layout
+        whitelist = load_profile(path)
+        unknown = whitelist - registered
+        assert not unknown, f"{name}: unknown tools {sorted(unknown)}"

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -17,6 +17,7 @@ from ida_pro_mcp.ida_mcp.api_core import (
     server_health,
     server_warmup,
 )
+from ida_pro_mcp.ida_mcp.profile import apply_profile, load_profile
 from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, tool
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 
@@ -493,6 +494,17 @@ def main():
         "--unsafe", action="store_true", help="Enable unsafe functions (DANGEROUS)"
     )
     parser.add_argument(
+        "--profile",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Restrict exposed tools to those listed in a profile file "
+            "(one name per line, # for comments). idalib_* management tools "
+            "are always kept."
+        ),
+    )
+    parser.add_argument(
         "input_path",
         type=Path,
         nargs="?",
@@ -563,6 +575,26 @@ def main():
             MCP_SERVER.tools.methods.pop(name, None)
         if MCP_UNSAFE:
             logger.info("Unsafe tools disabled (start with --unsafe to enable)")
+
+    if args.profile is not None:
+        try:
+            whitelist = load_profile(args.profile)
+        except (OSError, UnicodeDecodeError) as e:
+            raise SystemExit(f"Failed to read profile '{args.profile}': {e}")
+        kept, unknown = apply_profile(
+            MCP_SERVER.tools.methods,
+            whitelist,
+            protected=IDALIB_MANAGEMENT_TOOLS,
+        )
+        if unknown:
+            logger.warning(
+                "Profile references unknown tool(s) (ignored): %s", ", ".join(unknown)
+            )
+        logger.info(
+            "Profile applied: %d whitelisted + %d management tool(s) active",
+            len(kept),
+            len(IDALIB_MANAGEMENT_TOOLS),
+        )
 
     _install_context_activation_hooks()
 


### PR DESCRIPTION
Closes #49.

`config.html` covers tool selection already, but only inside the plugin.
It stores the selection in a per-IDB netnode and needs the GUI to edit.
`idalib-mcp` has neither, and a netnode isn't something you can commit to
a repo or send to a teammate.

This PR adds a whitelist, same format on both sides.

- `idalib-mcp --profile my_profile.txt` filters the registry at startup.
  Management tools (`idalib_open`, etc...) are kept so you can't lock
  yourself out and unknown names log a warning.
- `config.html` gets an Export link and an Import Profile textarea, so
  you can pull your current selection out as a file, or paste one in.
- I added two examples presets: `profiles/readonly.txt` (35 non-mutating tools)
  and `profiles/triage.txt` (9 tools for a first-pass look).

Why bother when the UI already works? Every registered tool ships its
schema into the model prompt every turn. A 9-tool surface uses roughly
10x fewer tokens than the full set, and small models stop picking the
fancy tool when it isn't on the list. A file is also something you can
commit and share; a netnode isn't.

I also added 12 new tests in `test_profile.py`. And ran the full testsuite on IDA 9.3 still passes.