### PR TITLE
fix: truncation metadata violates output schema (#361)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -66,28 +66,15 @@ def _truncate_value(value: Any, depth: int = 0) -> Any:
     return value
 
 
-def _add_download_info(result: Any, output_id: str, total_chars: int) -> Any:
+def _build_download_meta(output_id: str, total_chars: int) -> dict:
     download_url = f"{_download_base_url}/output/{output_id}.json"
-    info = {
-        "_output_truncated": True,
-        "_total_chars": total_chars,
-        "_output_id": output_id,
-        "_download_url": download_url,
-        "_download_hint": f"Output truncated. Run: curl -o .ida-mcp/{output_id}.json {download_url}",
+    return {
+        "output_truncated": True,
+        "total_chars": total_chars,
+        "output_id": output_id,
+        "download_url": download_url,
+        "download_hint": f"Output truncated. Run: curl -o .ida-mcp/{output_id}.json {download_url}",
     }
-
-    if isinstance(result, dict):
-        return {**result, **info}
-
-    if isinstance(result, list) and result:
-        result = list(result)
-        if isinstance(result[0], dict):
-            result[0] = {**result[0], **info}
-        else:
-            result.insert(0, info)
-        return result
-
-    return {"_preview": result, **info}
 
 
 def get_cached_output(output_id: str) -> Optional[Any]:
@@ -124,12 +111,21 @@ def _install_tools_call_patch() -> None:
         _cache_output(output_id, structured)
 
         preview = _truncate_value(structured)
-        preview = _add_download_info(preview, output_id, len(serialized))
+        download_meta = _build_download_meta(output_id, len(serialized))
+
+        content = [{
+            "type": "text",
+            "text": json.dumps(preview, separators=(",", ":")),
+        }, {
+            "type": "text",
+            "text": download_meta["download_hint"],
+        }]
 
         return {
             "structuredContent": preview,
-            "content": response.get("content", []),
+            "content": content,
             "isError": False,
+            "_meta": {"ida_mcp": download_meta},
         }
 
     MCP_SERVER.registry.methods["tools/call"] = patched


### PR DESCRIPTION
Closes #361.

When structuredContent goes over 50 KB, the server truncates it and was merging `_output_truncated`, `_total_chars`, `_output_id`, `_download_url` and `_download_hint` straight into the dict. Output schemas are auto-generated with `additionalProperties: False`, so strict MCP clients reject the whole response.

This PR keeps structuredContent schema-clean and puts the metadata where it belongs.

    The five fields go under _meta.ida_mcp on the tool result. _meta is
    the MCP-reserved slot and isn't validated against the output schema.
    The curl hint also lands in content[] as a second text block so the
    model still sees "output truncated, run: curl ..." without digging
    into _meta.
    _add_download_info had list/scalar branches that were dead code
    (structuredContent is always a dict per zeromcp/mcp.py:678). Gone.

Verified by replaying an oversize decompile response, didn't add tests yet.

