### PR TITLE
Fix schema-invalid truncation in large tool outputs

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -48,17 +48,14 @@ def _truncate_value(value: Any, depth: int = 0) -> Any:
         return value[:OUTPUT_LIMIT_PREVIEW_STR_LEN] + f"... [{len(value)} chars total]"
 
     if isinstance(value, list):
-        truncated_list = [
+        # IMPORTANT: Do not inject sentinel objects like {"_truncated": "..."} into lists.
+        # Many tool schemas constrain list item shapes (additionalProperties: false),
+        # so sentinels can break structured output validation. Truncation is reported
+        # via _meta.ida_mcp and the download_hint content.
+        return [
             _truncate_value(item, depth + 1)
             for item in value[:OUTPUT_LIMIT_PREVIEW_ITEMS]
         ]
-        if len(value) > OUTPUT_LIMIT_PREVIEW_ITEMS:
-            truncated_list.append(
-                {
-                    "_truncated": f"... and {len(value) - OUTPUT_LIMIT_PREVIEW_ITEMS} more items"
-                }
-            )
-        return truncated_list
 
     if isinstance(value, dict):
         return {k: _truncate_value(v, depth + 1) for k, v in value.items()}


### PR DESCRIPTION
This fixes a failure where large structuredContent responses (e.g. `disasm`) were preview-truncated by appending a `{"_truncated": "..."}` sentinel into lists. For tools with strict JSON schemas (`additionalProperties: false` on list item objects), that sentinel makes the response invalid and the client rejects it.

The output limiter now truncates lists by slicing only and relies on the existing `_meta.ida_mcp` truncation metadata + `download_hint text` to indicate that full output is available via download, without breaking schema validation.