### PR TITLE
Enrich disasm/decompile output with labels, comments, and refs

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -36,6 +36,7 @@ from .utils import (
     extract_function_constants,
     Argument,
     DisassemblyFunction,
+    Ref,
     Xref,
     BasicBlock,
     StructFieldQuery,
@@ -50,6 +51,7 @@ from . import compat
 class DecompileResult(TypedDict):
     addr: str
     code: str | None
+    refs: NotRequired[list[Ref]]
     error: NotRequired[str]
 
 
@@ -494,6 +496,108 @@ def _resolve_function_start(query: object) -> tuple[int | None, str | None]:
     return func.start_ea, None
 
 
+def _collect_line_comments(ea: int) -> list[str]:
+    out: list[str] = []
+    i = 0
+    while True:
+        line = ida_lines.get_extra_cmt(ea, ida_lines.E_PREV + i)
+        if line is None:
+            break
+        out.append(ida_lines.tag_remove(line))
+        i += 1
+    cmt = ida_bytes.get_cmt(ea, False)
+    if cmt:
+        out.append(cmt)
+    rcmt = ida_bytes.get_cmt(ea, True)
+    if rcmt and rcmt != cmt:
+        out.append(rcmt)
+    i = 0
+    while True:
+        line = ida_lines.get_extra_cmt(ea, ida_lines.E_NEXT + i)
+        if line is None:
+            break
+        out.append(ida_lines.tag_remove(line))
+        i += 1
+    return out
+
+
+def _resolve_ref_name(ea: int) -> str:
+    name = ida_name.get_ea_name(ea)
+    if name:
+        return name
+    func = idaapi.get_func(ea)
+    if func and func.start_ea == ea:
+        return ida_funcs.get_func_name(ea) or ""
+    return ""
+
+
+_STR_CODECS = {0: "utf-8", 1: "utf-16-le", 2: "utf-32-le"}
+
+
+def _resolve_ref(ea: int) -> dict | None:
+    name = _resolve_ref_name(ea)
+    if not name:
+        return None
+    info: dict = {"addr": hex(ea), "name": name}
+    flags = ida_bytes.get_flags(ea)
+    if ida_bytes.is_strlit(flags):
+        strtype = ida_nalt.get_str_type(ea)
+        if strtype is None or strtype < 0:
+            strtype = ida_nalt.STRTYPE_C
+        raw = ida_bytes.get_strlit_contents(ea, -1, strtype)
+        if raw:
+            codec = _STR_CODECS.get(strtype & 3, "utf-8")
+            try:
+                info["string"] = raw.decode(codec, errors="replace")
+            except Exception:
+                pass
+    return info
+
+
+def _collect_decompile_refs(cfunc) -> list[dict]:
+    import ida_hexrays
+
+    seen: set[int] = set()
+    refs: list[dict] = []
+
+    class _Visitor(ida_hexrays.ctree_visitor_t):
+        def __init__(self):
+            ida_hexrays.ctree_visitor_t.__init__(self, ida_hexrays.CV_FAST)
+
+        def visit_expr(self, e):
+            if e.op == ida_hexrays.cot_obj:
+                ea = e.obj_ea
+                if ea != idaapi.BADADDR and ea not in seen:
+                    seen.add(ea)
+                    info = _resolve_ref(ea)
+                    if info:
+                        refs.append(info)
+            return 0
+
+    _Visitor().apply_to(cfunc.body, None)
+    return refs
+
+
+def _collect_line_refs(ea: int) -> list[dict]:
+    seen: set[int] = set()
+    refs: list[dict] = []
+    for ref_ea in idautils.CodeRefsFrom(ea, False):
+        if ref_ea == idaapi.BADADDR or ref_ea in seen:
+            continue
+        seen.add(ref_ea)
+        info = _resolve_ref(ref_ea)
+        if info:
+            refs.append(info)
+    for ref_ea in idautils.DataRefsFrom(ea):
+        if ref_ea == idaapi.BADADDR or ref_ea in seen:
+            continue
+        seen.add(ref_ea)
+        info = _resolve_ref(ref_ea)
+        if info:
+            refs.append(info)
+    return refs
+
+
 def _limit_items(items: list, limit: int) -> tuple[list, bool]:
     if limit < 0:
         limit = 0
@@ -651,7 +755,19 @@ def decompile(
         code = decompile_function_safe(start)
         if code is None:
             return {"addr": addr, "code": None, "error": "Decompilation failed"}
-        return {"addr": addr, "code": code}
+        result: DecompileResult = {"addr": addr, "code": code}
+        try:
+            import ida_hexrays
+
+            if ida_hexrays.init_hexrays_plugin():
+                cfunc = ida_hexrays.decompile(start)
+                if cfunc:
+                    refs = _collect_decompile_refs(cfunc)
+                    if refs:
+                        result["refs"] = refs
+        except Exception:
+            pass
+        return result
     except Exception as e:
         return {"addr": addr, "code": None, "error": str(e)}
 
@@ -717,7 +833,20 @@ def disasm(
             if len(lines) < max_instructions:
                 line = ida_lines.generate_disasm_line(ea, 0)
                 instruction = ida_lines.tag_remove(line) if line else ""
-                lines.append({"addr": f"{ea:x}", "instruction": compact_whitespace(instruction)})
+                entry: dict = {
+                    "addr": f"{ea:x}",
+                    "instruction": compact_whitespace(instruction),
+                }
+                name = ida_name.get_ea_name(ea)
+                if name:
+                    entry["label"] = name
+                comments = _collect_line_comments(ea)
+                if comments:
+                    entry["comments"] = comments
+                refs = _collect_line_refs(ea)
+                if refs:
+                    entry["refs"] = refs
+                lines.append(entry)
                 seen += 1
                 return True
             more = True

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
@@ -224,6 +224,170 @@ def test_disasm_interior_address_preserves_cursor():
 
 
 @test(binary="crackme03.elf")
+def test_decompile_refs_include_check_pw():
+    """decompile surfaces cot_obj refs, including the check_pw call target."""
+    result = decompile(CRACKME_MAIN)
+    assert_ok(result, "code")
+    refs = result.get("refs", [])
+    hit = next((r for r in refs if r["name"] == "check_pw"), None)
+    assert hit is not None, f"check_pw not in decompile refs: {refs}"
+    assert hit["addr"] == CRACKME_CHECK_PW
+
+
+@test(binary="crackme03.elf")
+def test_decompile_refs_decode_usage_string():
+    """decompile refs carry decoded bytes for string-literal data targets."""
+    result = decompile(CRACKME_MAIN)
+    assert_ok(result, "code")
+    refs = result.get("refs", [])
+    hit = next((r for r in refs if r["addr"] == CRACKME_USAGE_STRING), None)
+    assert hit is not None, f"usage-string ref missing: {refs}"
+    assert "string" in hit, f"decoded string missing on ref: {hit}"
+    assert "Need exactly" in hit["string"]
+
+
+@test(binary="crackme03.elf")
+def test_disasm_labels_populated():
+    """disasm populates `label` on the function head and on branch targets."""
+    result = disasm(CRACKME_MAIN, max_instructions=200)
+    assert_ok(result, "asm")
+    lines = result["asm"]["lines"]
+    first = lines[0]
+    assert first["addr"] == CRACKME_MAIN.removeprefix("0x")
+    assert first.get("label") == "main"
+    # At least one interior branch-target label should be present
+    interior_labels = [ln["label"] for ln in lines[1:] if "label" in ln]
+    assert interior_labels, "expected at least one interior label (e.g. loc_...)"
+
+
+@test(binary="crackme03.elf")
+def test_disasm_resolves_call_target():
+    """disasm resolves `call check_pw` to a ref pointing at CRACKME_CHECK_PW."""
+    result = disasm(CRACKME_MAIN, max_instructions=200)
+    assert_ok(result, "asm")
+    call_line = next(
+        (ln for ln in result["asm"]["lines"] if ln["addr"] == CRACKME_CALL_TO_CHECK_PW.removeprefix("0x")),
+        None,
+    )
+    assert call_line is not None, "missing expected call-to-check_pw line"
+    refs = call_line.get("refs", [])
+    hit = next((r for r in refs if r["name"] == "check_pw"), None)
+    assert hit is not None, f"check_pw not in refs: {refs}"
+    assert hit["addr"] == CRACKME_CHECK_PW
+
+
+@test(binary="crackme03.elf")
+def test_disasm_branch_ref_uses_local_label():
+    """A branch to an in-function label must resolve to the label, not `main`."""
+    result = disasm(CRACKME_MAIN, max_instructions=200)
+    assert_ok(result, "asm")
+    branch_refs = [
+        r
+        for ln in result["asm"]["lines"]
+        for r in ln.get("refs", [])
+        if r["name"].startswith("loc_")
+    ]
+    assert branch_refs, "expected at least one loc_* branch ref inside main"
+    for ref in branch_refs:
+        assert ref["name"] != "main", f"containing function leaked into ref: {ref}"
+
+
+@test(binary="crackme03.elf")
+def test_disasm_resolves_data_ref():
+    """disasm resolves a load of the usage string to a data ref with its symbol."""
+    result = disasm(CRACKME_MAIN, max_instructions=200)
+    assert_ok(result, "asm")
+    hits = [
+        r
+        for ln in result["asm"]["lines"]
+        for r in ln.get("refs", [])
+        if r["addr"] == CRACKME_USAGE_STRING
+    ]
+    assert hits, "expected a data ref to the usage string"
+
+
+@test(binary="crackme03.elf")
+def test_disasm_captures_comments():
+    """disasm surfaces a user-set comment on an instruction line."""
+    import ida_bytes
+
+    ea = int(CRACKME_CALL_TO_CHECK_PW, 16)
+    marker = "mcp-test-comment"
+    prev = ida_bytes.get_cmt(ea, False)
+    try:
+        ida_bytes.set_cmt(ea, marker, False)
+        result = disasm(CRACKME_MAIN, max_instructions=200)
+        assert_ok(result, "asm")
+        line = next(
+            (ln for ln in result["asm"]["lines"] if ln["addr"] == CRACKME_CALL_TO_CHECK_PW.removeprefix("0x")),
+            None,
+        )
+        assert line is not None
+        assert marker in line.get("comments", []), f"comment missing: {line}"
+    finally:
+        ida_bytes.set_cmt(ea, prev or "", False)
+
+
+@test(binary="crackme03.elf")
+def test_disasm_captures_repeatable_and_extra_comments():
+    """disasm surfaces repeatable comments and anterior/posterior extra comments."""
+    import ida_bytes
+    import ida_lines
+
+    ea = int(CRACKME_CALL_TO_CHECK_PW, 16)
+    prev_rep = ida_bytes.get_cmt(ea, True)
+    try:
+        ida_bytes.set_cmt(ea, "rep-marker", True)
+        ida_lines.update_extra_cmt(ea, ida_lines.E_PREV, "ante-marker-0")
+        ida_lines.update_extra_cmt(ea, ida_lines.E_PREV + 1, "ante-marker-1")
+        ida_lines.update_extra_cmt(ea, ida_lines.E_NEXT, "post-marker")
+
+        result = disasm(CRACKME_MAIN, max_instructions=200)
+        assert_ok(result, "asm")
+        line = next(
+            (
+                ln
+                for ln in result["asm"]["lines"]
+                if ln["addr"] == CRACKME_CALL_TO_CHECK_PW.removeprefix("0x")
+            ),
+            None,
+        )
+        assert line is not None
+        comments = line.get("comments", [])
+        for marker in ("rep-marker", "ante-marker-0", "ante-marker-1", "post-marker"):
+            assert marker in comments, f"{marker} missing: {comments}"
+        # Ordering contract: anterior (multi-line, in order) -> inline -> posterior
+        assert (
+            comments.index("ante-marker-0")
+            < comments.index("ante-marker-1")
+            < comments.index("rep-marker")
+            < comments.index("post-marker")
+        )
+    finally:
+        ida_bytes.set_cmt(ea, prev_rep or "", True)
+        ida_lines.del_extra_cmt(ea, ida_lines.E_PREV)
+        ida_lines.del_extra_cmt(ea, ida_lines.E_PREV + 1)
+        ida_lines.del_extra_cmt(ea, ida_lines.E_NEXT)
+
+
+@test(binary="crackme03.elf")
+def test_disasm_ref_decodes_string_literal():
+    """A data ref targeting a string literal carries the decoded bytes."""
+    result = disasm(CRACKME_MAIN, max_instructions=200)
+    assert_ok(result, "asm")
+    usage_refs = [
+        r
+        for ln in result["asm"]["lines"]
+        for r in ln.get("refs", [])
+        if r["addr"] == CRACKME_USAGE_STRING
+    ]
+    assert usage_refs, "expected a ref to the usage string"
+    with_string = [r for r in usage_refs if "string" in r]
+    assert with_string, f"no ref carried a decoded string: {usage_refs}"
+    assert "Need exactly" in with_string[0]["string"]
+
+
+@test(binary="crackme03.elf")
 def test_xrefs_to_check_pw_from_main():
     """xrefs_to(check_pw) includes the known call from main."""
     result = xrefs_to(CRACKME_CHECK_PW)

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -453,12 +453,19 @@ class Segment(TypedDict):
     permissions: str
 
 
+class Ref(TypedDict):
+    addr: str
+    name: str
+    string: NotRequired[str]
+
+
 class DisassemblyLine(TypedDict):
     segment: NotRequired[str]
     addr: str
     label: NotRequired[str]
     instruction: str
     comments: NotRequired[list[str]]
+    refs: NotRequired[list[Ref]]
 
 
 class Argument(TypedDict):


### PR DESCRIPTION
Closes #35. I can take a look at #34 in a follow-up if this is relevant.

`disasm()` was returning per-line `{addr, instruction}` and `decompile()` just rendered text. `DisassemblyLine` already had `label` and `comments` as `NotRequired`, nothing populated them. So the model sees `jz short loc_127F` and has to round-trip through `xrefs_to`/`get_name`.

Each disasm line now gets:
- `label` from `ida_name.get_ea_name(ea)`.
- `comments` from regular + repeatable inline and multi-line anterior/posterior extras, ordered anterior => inline => posterior.
- `refs` walking `CodeRefsFrom`/`DataRefsFrom`, each as `{addr, name}`.
Gotcha: `ida_funcs.get_func_name` returns the *containing* function, so a naive impl resolves `jz short loc_127F` inside `main` as `main`.

`DecompileResult` gets a function-level `refs` list from a `ctree_visitor_t` walking `cot_obj` nodes, deduped by ea. The visitor runs inside an isolated `try` so a Hex-Rays hiccup can't wipe out good pseudocode.

When a ref's target is `is_strlit`, decoded contents are attached as `string`. The codec comes from the low two bits of `strtype` so UTF-16/32 literals don't come back as mojibake.

All new fields are `NotRequired` and only emitted when non-empty. The `instruction` text and the `code` field are untouched, so existing substring assertions keep passing.

I didn't do per-pseudocode-line ref mapping walking `strvec_t` yet (function-level is enough for the model, per-line is bigger, but I can do that if you want). I also skipped the multi-base immediate comments from #34 because `generate_disasm_line` already respects operand display.

I also added 9 new tests in `test_api_analysis.py` on `crackme03.elf` to cover labels, call-target resolution, the containing-function-leak regression guard, data refs, string decoding, regular vs repeatable comments, multi-line anterior extras with ordering pinned, and two decompile-side assertions.