### PR TITLE
FIX PR #357 regression

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -989,6 +989,11 @@ class McpServer:
                     "properties": {"result": return_schema},
                     "required": ["result"],
                 }
+            elif return_schema.get("type") != "object":
+                # anyOf-of-objects: MCP spec requires outputSchema root to be
+                # type:"object". Hoist it so validators (e.g. MCP Inspector)
+                # accept the schema while anyOf still constrains the variants.
+                return_schema = {"type": "object", **return_schema}
 
             schema["outputSchema"] = return_schema
 


### PR DESCRIPTION
Fixes regression from #357 and closes #368.

Union-of-TypedDicts return types produced an outputSchema like {"anyOf": [...]} with no root "type" key, violating the MCP spec (outputSchema root must be type: "object") and causing strict validators (MCP Inspector >=0.21) to reject tools/list entirely.

Hoist type: "object" to the root alongside anyOf so the schema stays spec-compliant while anyOf still constrains variants.