### PR TITLE
feat(decompile): add include_addresses flag to strip per-line markers…

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -748,11 +748,14 @@ def _profile_function(
 @tool_timeout(90.0)
 def decompile(
     addr: Annotated[str, "Function address or name to decompile"],
+    include_addresses: Annotated[
+        bool, "Append /*0xNNNN*/ markers per line (default: true). Set false to save tokens."
+    ] = True,
 ) -> DecompileResult:
     """Decompile function(s) at address(es); returns pseudocode and per-item errors."""
     try:
         start = parse_address(addr)
-        code = decompile_function_safe(start)
+        code = decompile_function_safe(start, include_addresses=include_addresses)
         if code is None:
             return {"addr": addr, "code": None, "error": "Decompilation failed"}
         result: DecompileResult = {"addr": addr, "code": code}

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
@@ -104,6 +104,22 @@ def test_decompile_unknown_name():
     assert_error(result, contains="Not found")
 
 
+@test(binary="crackme03.elf")
+def test_decompile_default_includes_address_markers():
+    """Default output carries /*0xNNNN*/ markers on at least one line."""
+    result = decompile("main")
+    assert_ok(result, "code")
+    assert "/*0x" in result["code"]
+
+
+@test(binary="crackme03.elf")
+def test_decompile_include_addresses_false_strips_markers():
+    """include_addresses=False drops all /*0xNNNN*/ markers."""
+    result = decompile("main", include_addresses=False)
+    assert_ok(result, "code")
+    assert "/*0x" not in result["code"]
+
+
 @test()
 def test_disasm_valid_function():
     """disasm returns non-empty assembly for a valid function."""

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -1103,7 +1103,7 @@ def decompile_checked(addr: int):
     return cfunc
 
 
-def decompile_function_safe(ea: int) -> Optional[str]:
+def decompile_function_safe(ea: int, include_addresses: bool = True) -> Optional[str]:
     """Safely decompile a function, returning None on failure (uses cache)"""
     import ida_lines
     import ida_kernwin
@@ -1122,7 +1122,7 @@ def decompile_function_safe(ea: int) -> Optional[str]:
             item = ida_hexrays.ctree_item_t()
             _tail = ida_hexrays.ctree_item_t()
             line_ea = None
-            if cfunc.get_line_item(sl.line, 0, False, _head, item, _tail):
+            if include_addresses and cfunc.get_line_item(sl.line, 0, False, _head, item, _tail):
                 dstr: str | None = item.dstr()
                 if dstr:
                     ds = dstr.split(": ")


### PR DESCRIPTION
Closes #169.

Adds an opt-in flag to strip the `/*0xNNNN*/` per-line markers from `decompile` output for callers that want cleaner pseudocode and don't need address correlation.

## API

```python
decompile(
    addr,
    include_addresses=True,  # default preserves existing output
) -> DecompileResult
```

Set `include_addresses=False` to save tokens when the LLM just needs the pseudocode.