### PR TITLE
feat(trace): store tools/call trace in IDB + idalib dump script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ build-backend = "setuptools.build_meta"
 ida-pro-mcp = "ida_pro_mcp.server:main"
 idalib-mcp = "ida_pro_mcp.idalib_server:main"
 ida-mcp-test = "ida_pro_mcp.test:main"
+ida-mcp-trace-dump = "ida_pro_mcp.trace_dump:main"
 
 [tool.pyright]
 include = ["src/ida_pro_mcp"]

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -37,7 +37,7 @@ from . import api_resources
 from . import api_survey
 from . import api_composite
 from . import api_discovery
-from . import trace as trace  # registers the trace_clear tool; must precede http import
+from . import trace as trace
 
 # Re-export key components for external use
 from .sync import idasync, IDAError, IDASyncError, CancelledError
@@ -46,9 +46,8 @@ from .http import IdaMcpHttpRequestHandler
 from .api_core import init_caches
 from .api_discovery import set_local_instance
 
-# Activate tracing if IDA_MCP_TRACE_FILE is set (env-var opt-in for the
-# in-IDA plugin, which has no CLI).
-trace.configure_from_env()
+# Tracing is always on: every tools/call is recorded into the IDB netnode.
+trace.configure_idb()
 
 __all__ = [
     # Infrastructure modules

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -37,6 +37,7 @@ from . import api_resources
 from . import api_survey
 from . import api_composite
 from . import api_discovery
+from . import trace as trace  # registers the trace_clear tool; must precede http import
 
 # Re-export key components for external use
 from .sync import idasync, IDAError, IDASyncError, CancelledError
@@ -44,7 +45,6 @@ from .rpc import MCP_SERVER, MCP_UNSAFE, tool, unsafe, resource
 from .http import IdaMcpHttpRequestHandler
 from .api_core import init_caches
 from .api_discovery import set_local_instance
-from . import trace as trace
 
 # Activate tracing if IDA_MCP_TRACE_FILE is set (env-var opt-in for the
 # in-IDA plugin, which has no CLI).

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -44,6 +44,11 @@ from .rpc import MCP_SERVER, MCP_UNSAFE, tool, unsafe, resource
 from .http import IdaMcpHttpRequestHandler
 from .api_core import init_caches
 from .api_discovery import set_local_instance
+from . import trace as trace
+
+# Activate tracing if IDA_MCP_TRACE_FILE is set (env-var opt-in for the
+# in-IDA plugin, which has no CLI).
+trace.configure_from_env()
 
 __all__ = [
     # Infrastructure modules

--- a/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
@@ -1,124 +1,75 @@
-"""Tests for the tools/call trace middleware (file backend and IDB backend)."""
+# Tests for the IDB tools/call trace middleware.
 
-import json
-import tempfile
-from pathlib import Path
-
-from ..framework import test, skip_test
+from ..framework import test
 from ..rpc import MCP_SERVER
 from .. import trace
-
-
-def _read_lines(path: Path) -> list[dict]:
-    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
 
 
 def _call_through_registry(name: str, arguments: dict | None = None) -> dict:
     return MCP_SERVER.registry.methods["tools/call"](name, arguments)
 
 
-def _reset_idb_state() -> None:
-    """Kill any residual trace netnode from prior tests."""
-    try:
-        import ida_netnode
-    except Exception:
-        return
+def _kill_trace_node() -> None:
+    """Wipe the trace netnode."""
+    import ida_netnode
     n = ida_netnode.netnode(trace.IDB_NETNODE_NAME, 0, False)
     if n != ida_netnode.BADNODE:
         n.kill()
 
 
-# ============================================================================
-# File backend
-# ============================================================================
+def _reset_trace(*, batch_records: int = 1, batch_bytes: int | None = None) -> None:
+    """Drain the prior backend, wipe the netnode, configure fresh."""
+    # Shutdown before kill so buffered records don't leak into the new netnode.
+    trace.shutdown()
+    _kill_trace_node()
+    if batch_bytes is None:
+        trace.configure_idb(batch_records=batch_records)
+    else:
+        trace.configure_idb(batch_records=batch_records, batch_bytes=batch_bytes)
 
 
-@test()
-def test_trace_writes_one_record_per_tool_call():
-    """configure() + one tools/call should produce one JSONL line."""
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "trace.jsonl"
-        trace.configure(str(path))
-        try:
-            _call_through_registry("server_health", {})
-        finally:
-            trace.shutdown()
-
-        lines = _read_lines(path)
-        assert len(lines) == 1, f"expected 1 record, got {len(lines)}"
-        rec = lines[0]
-        assert rec["tool"] == "server_health"
-        assert rec["arguments"] == {}
-        assert "ts" in rec and "duration_ms" in rec
-        assert "isError" in rec
-        assert "structuredContent" in rec
+def _teardown_trace() -> None:
+    """Drain pending records, then wipe the netnode."""
+    trace.shutdown()
+    _kill_trace_node()
 
 
-@test()
-def test_trace_redacts_unsafe_tool_arguments_by_default():
-    """py_eval arguments should be '<redacted>' when --trace-verbose is off."""
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "trace.jsonl"
-        trace.configure(str(path))
-        try:
-            _call_through_registry("py_eval", {"code": "2+2"})
-        finally:
-            trace.shutdown()
-        rec = _read_lines(path)[0]
-        assert rec["tool"] == "py_eval"
-        assert rec["arguments"] == "<redacted>"
+def _read_stats() -> dict[str, int]:
+    """Read counters directly from the trace netnode."""
+    import ida_netnode
+    node = ida_netnode.netnode(trace.IDB_NETNODE_NAME, 0, False)
+    if node == ida_netnode.BADNODE:
+        return {
+            "version": 0,
+            "segments": 0,
+            "next_chunk_start": 0,
+            "next_segment_id": 0,
+            "total_records": 0,
+        }
+    segments = 0
+    i = node.altfirst(trace._TAG_INDEX)
+    while i != ida_netnode.BADNODE:
+        segments += 1
+        i = node.altnext(i, trace._TAG_INDEX)
+    return {
+        "version": node.altval(trace._META_VERSION, trace._TAG_META),
+        "segments": segments,
+        "next_chunk_start": node.altval(trace._META_NEXT_CHUNK, trace._TAG_META),
+        "next_segment_id": node.altval(trace._META_NEXT_SEG_ID, trace._TAG_META),
+        "total_records": node.altval(trace._META_TOTAL_RECORDS, trace._TAG_META),
+    }
 
 
-@test()
-def test_trace_verbose_keeps_unsafe_tool_arguments():
-    """verbose=True should pass @unsafe arguments through."""
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "trace.jsonl"
-        trace.configure(str(path), verbose=True)
-        try:
-            _call_through_registry("py_eval", {"code": "2+2"})
-        finally:
-            trace.shutdown()
-        rec = _read_lines(path)[0]
-        assert rec["arguments"] == {"code": "2+2"}
-
-
-@test()
-def test_trace_disabled_by_default_writes_nothing():
-    """Without configure(), no tracing should happen."""
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "should-not-exist.jsonl"
-        _call_through_registry("server_health", {})
-        assert not path.exists(), "unexpected trace file created"
-
-
-@test()
-def test_trace_records_duration_and_timestamp_shape():
-    """Each record has a numeric duration_ms and an ISO-8601 UTC timestamp."""
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "trace.jsonl"
-        trace.configure(str(path))
-        try:
-            _call_through_registry("server_health", {})
-        finally:
-            trace.shutdown()
-        rec = _read_lines(path)[0]
-        assert isinstance(rec["duration_ms"], (int, float))
-        assert rec["duration_ms"] >= 0
-        assert rec["ts"].endswith("Z")
-        assert "T" in rec["ts"]
-
-
-# ============================================================================
-# IDB backend
-# ============================================================================
+def _flush() -> None:
+    backend = trace._state["idb_backend"]
+    if backend is not None:
+        backend.flush()
 
 
 @test()
 def test_trace_idb_round_trip():
-    """configure_idb + one call + flush → iter_records yields the record."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
+    """configure_idb + one call + flush -> iter_records yields the record."""
+    _reset_trace(batch_records=1)
     try:
         _call_through_registry("server_health", {})
         records = list(trace.iter_idb_records())
@@ -126,197 +77,190 @@ def test_trace_idb_round_trip():
         assert records[0]["tool"] == "server_health"
         assert records[0]["arguments"] == {}
     finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_multiple_segments_preserve_order():
     """Per-record flushing creates multiple segments; iteration preserves order."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
+    _reset_trace(batch_records=1)
     try:
         for _ in range(5):
             _call_through_registry("server_health", {})
         records = list(trace.iter_idb_records())
         assert len(records) == 5
-        stats = trace.idb_stats()
+        stats = _read_stats()
         assert stats["segments"] == 5
         assert stats["total_records"] == 5
     finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_large_batch_spans_multiple_supvals():
     """A batch whose gzipped size exceeds one supval (>1024 B) round-trips."""
-    _reset_idb_state()
-    # 200 records batched into one segment; gzipped JSONL comfortably exceeds 1 KB.
-    trace.configure_idb(batch_records=200, batch_bytes=10 * 1024 * 1024)
+    _reset_trace(batch_records=200, batch_bytes=10 * 1024 * 1024)
     try:
         for _ in range(200):
             _call_through_registry("server_health", {})
-        trace.flush_idb()
-        stats = trace.idb_stats()
+        _flush()
+        stats = _read_stats()
         assert stats["segments"] == 1, f"expected 1 segment, got {stats['segments']}"
         records = list(trace.iter_idb_records())
         assert len(records) == 200
         for r in records:
             assert r["tool"] == "server_health"
     finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_gap_trick_adjacent_segments_intact():
     """Two segments stored with the +1 gap both decode to their own payloads."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
+    _reset_trace(batch_records=1)
     try:
         _call_through_registry("server_health", {})
         _call_through_registry("server_health", {"arg": "second"})
-        stats = trace.idb_stats()
+        stats = _read_stats()
         assert stats["segments"] == 2
         records = list(trace.iter_idb_records())
         assert len(records) == 2
         assert records[0]["arguments"] == {}
         assert records[1]["arguments"] == {"arg": "second"}
     finally:
-        trace.clear_idb()
-        trace.shutdown()
-
-
-@test()
-def test_trace_idb_clear_wipes_node_and_resets_meta():
-    """clear_idb removes every segment and zeroes meta counters."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
-    try:
-        for _ in range(3):
-            _call_through_registry("server_health", {})
-        assert trace.idb_stats()["total_records"] == 3
-        trace.clear_idb()
-        stats = trace.idb_stats()
-        assert stats["segments"] == 0
-        assert stats["total_records"] == 0
-        assert stats["next_chunk_start"] == 0
-        assert list(trace.iter_idb_records()) == []
-    finally:
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_batching_defers_writes_until_threshold():
     """Appends below threshold stay buffered; crossing it flushes one segment."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=3)
+    _reset_trace(batch_records=3)
     try:
         _call_through_registry("server_health", {})
         _call_through_registry("server_health", {})
-        assert trace.idb_stats()["segments"] == 0
+        assert _read_stats()["segments"] == 0
         _call_through_registry("server_health", {})
-        assert trace.idb_stats()["segments"] == 1
-        assert trace.idb_stats()["total_records"] == 3
+        assert _read_stats()["segments"] == 1
+        assert _read_stats()["total_records"] == 3
         _call_through_registry("server_health", {})
-        assert trace.idb_stats()["segments"] == 1
-        trace.flush_idb()
-        assert trace.idb_stats()["segments"] == 2
-        assert trace.idb_stats()["total_records"] == 4
+        assert _read_stats()["segments"] == 1
+        _flush()
+        assert _read_stats()["segments"] == 2
+        assert _read_stats()["total_records"] == 4
     finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
-def test_trace_idb_redaction_applies():
-    """@unsafe tool arguments are redacted in the IDB backend too."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
+def test_trace_idb_unsafe_arguments_logged_verbatim():
+    """@unsafe tool arguments are stored as-is (no redaction)."""
+    _reset_trace(batch_records=1)
     try:
         _call_through_registry("py_eval", {"code": "2+2"})
         records = list(trace.iter_idb_records())
         assert records[0]["tool"] == "py_eval"
-        assert records[0]["arguments"] == "<redacted>"
+        assert records[0]["arguments"] == {"code": "2+2"}
     finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_meta_version_and_counters():
     """meta exposes version + monotonically increasing counters."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
+    _reset_trace(batch_records=1)
     try:
         _call_through_registry("server_health", {})
         _call_through_registry("server_health", {})
-        stats = trace.idb_stats()
+        stats = _read_stats()
         assert stats["version"] >= 1
         assert stats["segments"] == 2
         assert stats["total_records"] == 2
         assert stats["next_segment_id"] == 2
         assert stats["next_chunk_start"] > 0
     finally:
-        trace.clear_idb()
-        trace.shutdown()
-
-
-@test()
-def test_trace_both_backends_receive_same_records():
-    """File + IDB backends configured together both capture every call."""
-    _reset_idb_state()
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "trace.jsonl"
-        trace.configure(str(path))
-        trace.configure_idb(batch_records=1)
-        try:
-            _call_through_registry("server_health", {"x": 1})
-            _call_through_registry("server_health", {"x": 2})
-            file_records = _read_lines(path)
-            idb_records = list(trace.iter_idb_records())
-            assert len(file_records) == 2
-            assert len(idb_records) == 2
-            assert [r["arguments"] for r in file_records] == [{"x": 1}, {"x": 2}]
-            assert [r["arguments"] for r in idb_records] == [{"x": 1}, {"x": 2}]
-        finally:
-            trace.clear_idb()
-            trace.shutdown()
-
-
-@test()
-def test_trace_clear_tool_wipes_idb_segments():
-    """`trace_clear` wipes the IDB backend. The call itself is traced after
-    the wipe, so exactly one record (the clear call) remains."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=1)
-    try:
-        _call_through_registry("server_health", {})
-        _call_through_registry("server_health", {})
-        assert trace.idb_stats()["total_records"] == 2
-        resp = _call_through_registry("trace_clear", {})
-        sc = resp.get("structuredContent") or {}
-        assert sc.get("ok") is True, f"unexpected response: {resp}"
-        records = list(trace.iter_idb_records())
-        assert len(records) == 1, f"expected 1 residual record, got {len(records)}"
-        assert records[0]["tool"] == "trace_clear"
-    finally:
-        trace.clear_idb()
-        trace.shutdown()
+        _teardown_trace()
 
 
 @test()
 def test_trace_idb_shutdown_flushes_pending_buffer():
     """Shutdown must drain the in-memory buffer to a final segment."""
-    _reset_idb_state()
-    trace.configure_idb(batch_records=100)
+    _reset_trace(batch_records=100)
     try:
         _call_through_registry("server_health", {})
         _call_through_registry("server_health", {})
-        assert trace.idb_stats()["segments"] == 0
+        assert _read_stats()["segments"] == 0
         trace.shutdown()
         records = list(trace.iter_idb_records())
         assert len(records) == 2, f"expected 2 flushed records, got {len(records)}"
     finally:
-        _reset_idb_state()
+        _teardown_trace()
+
+
+@test()
+def test_trace_idb_records_duration_and_timestamp_shape():
+    """Each record has numeric duration_ms and ISO-8601 UTC timestamp."""
+    _reset_trace(batch_records=1)
+    try:
+        _call_through_registry("server_health", {})
+        rec = list(trace.iter_idb_records())[0]
+        assert isinstance(rec["duration_ms"], (int, float))
+        assert rec["duration_ms"] >= 0
+        assert rec["ts"].endswith("Z")
+        assert "T" in rec["ts"]
+    finally:
+        _teardown_trace()
+
+
+@test()
+def test_trace_install_tracer_idempotent():
+    """Calling install_tracer() twice does not double-wrap tools/call."""
+    _reset_trace(batch_records=1)
+    try:
+        from ..rpc import MCP_SERVER
+        first = MCP_SERVER.registry.methods["tools/call"]
+        trace.install_tracer()
+        assert MCP_SERVER.registry.methods["tools/call"] is first
+
+        _call_through_registry("server_health", {})
+        records = list(trace.iter_idb_records())
+        assert len(records) == 1
+    finally:
+        _teardown_trace()
+
+
+@test()
+def test_trace_install_tracer_lifts_to_outermost():
+    """install_tracer() lifts the tracer above a later non-tracer wrapper."""
+    _reset_trace(batch_records=1)
+    try:
+        from ..rpc import MCP_SERVER
+
+        observed: list[str] = []
+        prior_tracer = MCP_SERVER.registry.methods["tools/call"]
+        assert getattr(prior_tracer, "_ida_mcp_tracer", False)
+
+        def outer(name, arguments=None, _meta=None):
+            observed.append(name)
+            return prior_tracer(name, arguments, _meta)
+
+        MCP_SERVER.registry.methods["tools/call"] = outer
+        try:
+            # `outer` is now the outermost layer; the tracer is inner.
+            # install_tracer() should re-wrap so the tracer is outermost
+            # while `outer` remains on the call path between tracer and
+            # the original method.
+            trace.install_tracer()
+            top = MCP_SERVER.registry.methods["tools/call"]
+            assert getattr(top, "_ida_mcp_tracer", False)
+            assert top is not prior_tracer
+
+            _call_through_registry("server_health", {})
+            # `outer` is still in the chain, so it observed the call once.
+            assert observed == ["server_health"]
+            # The new outermost tracer recorded the call.
+            records = list(trace.iter_idb_records())
+            assert any(r["tool"] == "server_health" for r in records)
+        finally:
+            MCP_SERVER.registry.methods["tools/call"] = prior_tracer
+    finally:
+        _teardown_trace()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
@@ -1,10 +1,10 @@
-"""Tests for the tools/call trace middleware (#189)."""
+"""Tests for the tools/call trace middleware (file backend and IDB backend)."""
 
 import json
 import tempfile
 from pathlib import Path
 
-from ..framework import test
+from ..framework import test, skip_test
 from ..rpc import MCP_SERVER
 from .. import trace
 
@@ -15,6 +15,22 @@ def _read_lines(path: Path) -> list[dict]:
 
 def _call_through_registry(name: str, arguments: dict | None = None) -> dict:
     return MCP_SERVER.registry.methods["tools/call"](name, arguments)
+
+
+def _reset_idb_state() -> None:
+    """Kill any residual trace netnode from prior tests."""
+    try:
+        import ida_netnode
+    except Exception:
+        return
+    n = ida_netnode.netnode(trace.IDB_NETNODE_NAME, 0, False)
+    if n != ida_netnode.BADNODE:
+        n.kill()
+
+
+# ============================================================================
+# File backend
+# ============================================================================
 
 
 @test()
@@ -70,9 +86,6 @@ def test_trace_verbose_keeps_unsafe_tool_arguments():
 @test()
 def test_trace_disabled_by_default_writes_nothing():
     """Without configure(), no tracing should happen."""
-    # The middleware only attaches after configure(); a bare call must not
-    # leak to a non-configured sink. We verify by ensuring no file exists
-    # for a path we never registered.
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "should-not-exist.jsonl"
         _call_through_registry("server_health", {})
@@ -94,3 +107,216 @@ def test_trace_records_duration_and_timestamp_shape():
         assert rec["duration_ms"] >= 0
         assert rec["ts"].endswith("Z")
         assert "T" in rec["ts"]
+
+
+# ============================================================================
+# IDB backend
+# ============================================================================
+
+
+@test()
+def test_trace_idb_round_trip():
+    """configure_idb + one call + flush → iter_records yields the record."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        _call_through_registry("server_health", {})
+        records = list(trace.iter_idb_records())
+        assert len(records) == 1, f"expected 1 record, got {len(records)}"
+        assert records[0]["tool"] == "server_health"
+        assert records[0]["arguments"] == {}
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_multiple_segments_preserve_order():
+    """Per-record flushing creates multiple segments; iteration preserves order."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        for _ in range(5):
+            _call_through_registry("server_health", {})
+        records = list(trace.iter_idb_records())
+        assert len(records) == 5
+        stats = trace.idb_stats()
+        assert stats["segments"] == 5
+        assert stats["total_records"] == 5
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_large_batch_spans_multiple_supvals():
+    """A batch whose gzipped size exceeds one supval (>1024 B) round-trips."""
+    _reset_idb_state()
+    # 200 records batched into one segment; gzipped JSONL comfortably exceeds 1 KB.
+    trace.configure_idb(batch_records=200, batch_bytes=10 * 1024 * 1024)
+    try:
+        for _ in range(200):
+            _call_through_registry("server_health", {})
+        trace.flush_idb()
+        stats = trace.idb_stats()
+        assert stats["segments"] == 1, f"expected 1 segment, got {stats['segments']}"
+        records = list(trace.iter_idb_records())
+        assert len(records) == 200
+        for r in records:
+            assert r["tool"] == "server_health"
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_gap_trick_adjacent_segments_intact():
+    """Two segments stored with the +1 gap both decode to their own payloads."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        _call_through_registry("server_health", {})
+        _call_through_registry("server_health", {"arg": "second"})
+        stats = trace.idb_stats()
+        assert stats["segments"] == 2
+        records = list(trace.iter_idb_records())
+        assert len(records) == 2
+        assert records[0]["arguments"] == {}
+        assert records[1]["arguments"] == {"arg": "second"}
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_clear_wipes_node_and_resets_meta():
+    """clear_idb removes every segment and zeroes meta counters."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        for _ in range(3):
+            _call_through_registry("server_health", {})
+        assert trace.idb_stats()["total_records"] == 3
+        trace.clear_idb()
+        stats = trace.idb_stats()
+        assert stats["segments"] == 0
+        assert stats["total_records"] == 0
+        assert stats["next_chunk_start"] == 0
+        assert list(trace.iter_idb_records()) == []
+    finally:
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_batching_defers_writes_until_threshold():
+    """Appends below threshold stay buffered; crossing it flushes one segment."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=3)
+    try:
+        _call_through_registry("server_health", {})
+        _call_through_registry("server_health", {})
+        assert trace.idb_stats()["segments"] == 0
+        _call_through_registry("server_health", {})
+        assert trace.idb_stats()["segments"] == 1
+        assert trace.idb_stats()["total_records"] == 3
+        _call_through_registry("server_health", {})
+        assert trace.idb_stats()["segments"] == 1
+        trace.flush_idb()
+        assert trace.idb_stats()["segments"] == 2
+        assert trace.idb_stats()["total_records"] == 4
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_redaction_applies():
+    """@unsafe tool arguments are redacted in the IDB backend too."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        _call_through_registry("py_eval", {"code": "2+2"})
+        records = list(trace.iter_idb_records())
+        assert records[0]["tool"] == "py_eval"
+        assert records[0]["arguments"] == "<redacted>"
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_meta_version_and_counters():
+    """meta exposes version + monotonically increasing counters."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        _call_through_registry("server_health", {})
+        _call_through_registry("server_health", {})
+        stats = trace.idb_stats()
+        assert stats["version"] >= 1
+        assert stats["segments"] == 2
+        assert stats["total_records"] == 2
+        assert stats["next_segment_id"] == 2
+        assert stats["next_chunk_start"] > 0
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_both_backends_receive_same_records():
+    """File + IDB backends configured together both capture every call."""
+    _reset_idb_state()
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "trace.jsonl"
+        trace.configure(str(path))
+        trace.configure_idb(batch_records=1)
+        try:
+            _call_through_registry("server_health", {"x": 1})
+            _call_through_registry("server_health", {"x": 2})
+            file_records = _read_lines(path)
+            idb_records = list(trace.iter_idb_records())
+            assert len(file_records) == 2
+            assert len(idb_records) == 2
+            assert [r["arguments"] for r in file_records] == [{"x": 1}, {"x": 2}]
+            assert [r["arguments"] for r in idb_records] == [{"x": 1}, {"x": 2}]
+        finally:
+            trace.clear_idb()
+            trace.shutdown()
+
+
+@test()
+def test_trace_clear_tool_wipes_idb_segments():
+    """`trace_clear` wipes the IDB backend. The call itself is traced after
+    the wipe, so exactly one record (the clear call) remains."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=1)
+    try:
+        _call_through_registry("server_health", {})
+        _call_through_registry("server_health", {})
+        assert trace.idb_stats()["total_records"] == 2
+        resp = _call_through_registry("trace_clear", {})
+        sc = resp.get("structuredContent") or {}
+        assert sc.get("ok") is True, f"unexpected response: {resp}"
+        records = list(trace.iter_idb_records())
+        assert len(records) == 1, f"expected 1 residual record, got {len(records)}"
+        assert records[0]["tool"] == "trace_clear"
+    finally:
+        trace.clear_idb()
+        trace.shutdown()
+
+
+@test()
+def test_trace_idb_shutdown_flushes_pending_buffer():
+    """Shutdown must drain the in-memory buffer to a final segment."""
+    _reset_idb_state()
+    trace.configure_idb(batch_records=100)
+    try:
+        _call_through_registry("server_health", {})
+        _call_through_registry("server_health", {})
+        assert trace.idb_stats()["segments"] == 0
+        trace.shutdown()
+        records = list(trace.iter_idb_records())
+        assert len(records) == 2, f"expected 2 flushed records, got {len(records)}"
+    finally:
+        _reset_idb_state()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
@@ -1,0 +1,96 @@
+"""Tests for the tools/call trace middleware (#189)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from ..framework import test
+from ..rpc import MCP_SERVER
+from .. import trace
+
+
+def _read_lines(path: Path) -> list[dict]:
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+def _call_through_registry(name: str, arguments: dict | None = None) -> dict:
+    return MCP_SERVER.registry.methods["tools/call"](name, arguments)
+
+
+@test()
+def test_trace_writes_one_record_per_tool_call():
+    """configure() + one tools/call should produce one JSONL line."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "trace.jsonl"
+        trace.configure(str(path))
+        try:
+            _call_through_registry("server_health", {})
+        finally:
+            trace.shutdown()
+
+        lines = _read_lines(path)
+        assert len(lines) == 1, f"expected 1 record, got {len(lines)}"
+        rec = lines[0]
+        assert rec["tool"] == "server_health"
+        assert rec["arguments"] == {}
+        assert "ts" in rec and "duration_ms" in rec
+        assert "isError" in rec
+        assert "structuredContent" in rec
+
+
+@test()
+def test_trace_redacts_unsafe_tool_arguments_by_default():
+    """py_eval arguments should be '<redacted>' when --trace-verbose is off."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "trace.jsonl"
+        trace.configure(str(path))
+        try:
+            _call_through_registry("py_eval", {"code": "2+2"})
+        finally:
+            trace.shutdown()
+        rec = _read_lines(path)[0]
+        assert rec["tool"] == "py_eval"
+        assert rec["arguments"] == "<redacted>"
+
+
+@test()
+def test_trace_verbose_keeps_unsafe_tool_arguments():
+    """verbose=True should pass @unsafe arguments through."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "trace.jsonl"
+        trace.configure(str(path), verbose=True)
+        try:
+            _call_through_registry("py_eval", {"code": "2+2"})
+        finally:
+            trace.shutdown()
+        rec = _read_lines(path)[0]
+        assert rec["arguments"] == {"code": "2+2"}
+
+
+@test()
+def test_trace_disabled_by_default_writes_nothing():
+    """Without configure(), no tracing should happen."""
+    # The middleware only attaches after configure(); a bare call must not
+    # leak to a non-configured sink. We verify by ensuring no file exists
+    # for a path we never registered.
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "should-not-exist.jsonl"
+        _call_through_registry("server_health", {})
+        assert not path.exists(), "unexpected trace file created"
+
+
+@test()
+def test_trace_records_duration_and_timestamp_shape():
+    """Each record has a numeric duration_ms and an ISO-8601 UTC timestamp."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "trace.jsonl"
+        trace.configure(str(path))
+        try:
+            _call_through_registry("server_health", {})
+        finally:
+            trace.shutdown()
+        rec = _read_lines(path)[0]
+        assert isinstance(rec["duration_ms"], (int, float))
+        assert rec["duration_ms"] >= 0
+        assert rec["ts"].endswith("Z")
+        assert "T" in rec["ts"]

--- a/src/ida_pro_mcp/ida_mcp/trace.py
+++ b/src/ida_pro_mcp/ida_mcp/trace.py
@@ -1,0 +1,128 @@
+"""Tool call tracing (#189).
+
+Appends one JSON record per tools/call to a file. Opt-in via CLI flag
+(--trace-file PATH) or env var IDA_MCP_TRACE_FILE. Arguments for
+@unsafe tools (py_eval, py_exec_file, ...) are redacted unless
+--trace-verbose / IDA_MCP_TRACE_VERBOSE=1.
+"""
+
+import atexit
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .rpc import MCP_SERVER, MCP_UNSAFE
+
+
+_state: dict[str, Any] = {
+    "enabled": False,
+    "verbose": False,
+    "path": None,
+    "file": None,
+    "lock": threading.Lock(),
+}
+
+
+def configure(path: str, *, verbose: bool = False) -> None:
+    """Enable tracing; opens `path` in append mode and installs middleware."""
+    resolved = Path(path).expanduser().resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with _state["lock"]:
+        if _state["file"] is not None:
+            _state["file"].close()
+        _state["file"] = open(resolved, "a", encoding="utf-8")
+        _state["path"] = resolved
+        _state["verbose"] = verbose
+        already = _state["enabled"]
+        _state["enabled"] = True
+    if not already:
+        _install_trace_patch()
+        atexit.register(shutdown)
+
+
+def configure_from_env() -> None:
+    path = os.environ.get("IDA_MCP_TRACE_FILE", "").strip()
+    if not path:
+        return
+    verbose = os.environ.get("IDA_MCP_TRACE_VERBOSE", "").strip() not in ("", "0", "false", "no")
+    configure(path, verbose=verbose)
+
+
+def shutdown() -> None:
+    with _state["lock"]:
+        f = _state["file"]
+        if f is not None:
+            try:
+                f.flush()
+                f.close()
+            except Exception:
+                pass
+        _state["file"] = None
+
+
+def _redact_args(tool_name: str, arguments: Any) -> Any:
+    if _state["verbose"]:
+        return arguments
+    if tool_name in MCP_UNSAFE:
+        return "<redacted>"
+    return arguments
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _emit(record: dict) -> None:
+    line = json.dumps(record, separators=(",", ":"), default=str)
+    with _state["lock"]:
+        f = _state["file"]
+        if f is None:
+            return
+        f.write(line)
+        f.write("\n")
+        f.flush()
+
+
+def _install_trace_patch() -> None:
+    original = MCP_SERVER.registry.methods["tools/call"]
+
+    def traced(name, arguments=None, _meta=None):
+        start = time.monotonic()
+        record: dict[str, Any] = {
+            "ts": _now_iso(),
+            "tool": name,
+            "arguments": _redact_args(name, arguments or {}),
+        }
+        try:
+            response = original(name, arguments, _meta)
+        except Exception as e:
+            record["duration_ms"] = round((time.monotonic() - start) * 1000, 2)
+            record["error"] = f"{type(e).__name__}: {e}"
+            _emit(record)
+            raise
+
+        record["duration_ms"] = round((time.monotonic() - start) * 1000, 2)
+        record["isError"] = bool(response.get("isError"))
+        record["structuredContent"] = response.get("structuredContent")
+
+        meta = (response.get("_meta") or {}).get("ida_mcp") or {}
+        if meta.get("output_truncated"):
+            record["full_result_size"] = meta.get("total_chars")
+            record["truncated"] = True
+            record["output_id"] = meta.get("output_id")
+
+        _emit(record)
+        return response
+
+    MCP_SERVER.registry.methods["tools/call"] = traced
+
+
+__all__ = ["configure", "configure_from_env", "shutdown"]

--- a/src/ida_pro_mcp/ida_mcp/trace.py
+++ b/src/ida_pro_mcp/ida_mcp/trace.py
@@ -1,35 +1,27 @@
 """Tool-call tracing.
 
-Two opt-in backends:
+Always-on. The trace lives in the IDB under netnode `$ ida_mcp.trace` as
+append-only gzipped batches. Tags:
+  META  (version, next_chunk, next_seg_id, total_records),
+  INDEX (seg_id -> start),
+  DATA  (blobs).
+One empty supval sits between blobs so getblob() self-terminates. All netnode
+writes run on the IDA main thread via @idasync.
 
-  File backend:  one JSON record per tools/call to a JSONL file.
-                 trace.configure(path) or IDA_MCP_TRACE_FILE=<path>.
-
-  IDB backend:   append-only gzipped batches in netnode `$ ida_mcp.trace`.
-                 trace.configure_idb() or IDA_MCP_TRACE_IDB=1.
-                 Tags: META (version, next_chunk, next_seg_id, total_records),
-                 INDEX (seg_id -> start), DATA (blobs). One empty supval sits
-                 between blobs so getblob() self-terminates. All netnode ops
-                 run on the IDA main thread via @idasync.
+Use the `ida-mcp-trace-dump` script to export an IDB's trace as JSONL.
 """
 
 import atexit
 import gzip
 import json
-import os
 import threading
 import time
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Iterator
 
-from .rpc import MCP_SERVER, MCP_UNSAFE, tool
+from .rpc import MCP_SERVER
 from .sync import idasync
 
-
-# ----------------------------------------------------------------------------
-# Constants
-# ----------------------------------------------------------------------------
 
 IDB_NETNODE_NAME = "$ ida_mcp.trace"
 _TAG_META = ord("M")
@@ -47,69 +39,17 @@ _DEFAULT_BATCH_RECORDS = 256
 _DEFAULT_BATCH_BYTES = 64 * 1024
 
 
-# ----------------------------------------------------------------------------
-# Shared state
-# ----------------------------------------------------------------------------
-
 _state_lock = threading.Lock()
 _state: dict[str, Any] = {
-    "verbose": False,
-    "patched": False,
-    "file_backend": None,
     "idb_backend": None,
     "atexit_registered": False,
+    "idb_hook": None,
 }
-
-
-# ----------------------------------------------------------------------------
-# File backend
-# ----------------------------------------------------------------------------
-
-
-class FileBackend:
-    """One JSON line per call, flushed after every write."""
-
-    def __init__(self, path: Path):
-        self.path = path
-        self._lock = threading.Lock()
-        self._file = open(path, "a", encoding="utf-8")
-
-    def append(self, record: dict) -> None:
-        line = json.dumps(record, separators=(",", ":"), default=str)
-        with self._lock:
-            if self._file is None:
-                return
-            self._file.write(line)
-            self._file.write("\n")
-            self._file.flush()
-
-    def flush(self) -> None:
-        with self._lock:
-            if self._file is not None:
-                self._file.flush()
-
-    def close(self) -> None:
-        with self._lock:
-            if self._file is not None:
-                try:
-                    self._file.flush()
-                    self._file.close()
-                finally:
-                    self._file = None
-
-
-# ----------------------------------------------------------------------------
-# Netnode backend
-# ----------------------------------------------------------------------------
 
 
 @idasync
 def _netnode_flush_segment(payload: bytes, record_count: int) -> None:
-    """Write one segment and advance all meta counters in a single main-thread hop.
-
-    Keeping data + index + meta writes inside one @idasync job prevents a
-    concurrent kill from slipping between partial updates.
-    """
+    """Write one segment and bump meta counters atomically on the IDA main thread."""
     import ida_netnode
 
     node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, True)
@@ -121,7 +61,6 @@ def _netnode_flush_segment(payload: bytes, record_count: int) -> None:
     seg_id = node.altval(_META_NEXT_SEG_ID, _TAG_META)
 
     if not node.setblob(payload, start, _TAG_DATA):
-        # Leave meta untouched so the caller keeps the buffered batch for retry.
         raise RuntimeError(f"setblob failed at index {start}")
 
     node.altset(seg_id, start, _TAG_INDEX)
@@ -135,32 +74,6 @@ def _netnode_flush_segment(payload: bytes, record_count: int) -> None:
 
     cur_total = node.altval(_META_TOTAL_RECORDS, _TAG_META)
     node.altset(_META_TOTAL_RECORDS, cur_total + record_count, _TAG_META)
-
-
-@idasync
-def _netnode_read_stats() -> dict[str, int]:
-    import ida_netnode
-    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
-    if node == ida_netnode.BADNODE:
-        return {
-            "version": 0,
-            "segments": 0,
-            "next_chunk_start": 0,
-            "next_segment_id": 0,
-            "total_records": 0,
-        }
-    segments = 0
-    i = node.altfirst(_TAG_INDEX)
-    while i != ida_netnode.BADNODE:
-        segments += 1
-        i = node.altnext(i, _TAG_INDEX)
-    return {
-        "version": node.altval(_META_VERSION, _TAG_META),
-        "segments": segments,
-        "next_chunk_start": node.altval(_META_NEXT_CHUNK, _TAG_META),
-        "next_segment_id": node.altval(_META_NEXT_SEG_ID, _TAG_META),
-        "total_records": node.altval(_META_TOTAL_RECORDS, _TAG_META),
-    }
 
 
 @idasync
@@ -186,22 +99,14 @@ def _netnode_iter_blobs() -> list[bytes]:
     return blobs
 
 
-@idasync
-def _netnode_kill() -> None:
-    import ida_netnode
-    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
-    if node != ida_netnode.BADNODE:
-        node.kill()
-
-
 class NetnodeBackend:
     """Append-only compressed-segment log in an IDA netnode."""
 
     def __init__(self, *, batch_records: int, batch_bytes: int):
         self.batch_records = max(1, batch_records)
         self.batch_bytes = max(1024, batch_bytes)
-        self._lock = threading.Lock()        # buffer + closed flag
-        self._flush_lock = threading.Lock()  # serializes flushes and clears
+        self._lock = threading.Lock()
+        self._flush_lock = threading.Lock()
         self._buffer: list[bytes] = []
         self._buffered_bytes = 0
         self._closed = False
@@ -241,25 +146,10 @@ class NetnodeBackend:
                     self._buffered_bytes = sum(len(l) + 1 for l in self._buffer)
                 return
 
-    def clear(self) -> dict:
-        # Flush lock drains any in-flight write before we kill the node, so a
-        # pending @idasync meta-bump cannot resurrect the node after kill().
-        with self._flush_lock:
-            with self._lock:
-                self._buffer.clear()
-                self._buffered_bytes = 0
-            _netnode_kill()
-        return {"ok": True}
-
     def close(self) -> None:
-        # Set closed before draining so concurrent appends drop instead of
-        # racing into a buffer we're about to flush.
         with self._lock:
             self._closed = True
         self.flush()
-
-    def stats(self) -> dict[str, int]:
-        return _netnode_read_stats()
 
     def iter_records(self) -> Iterator[dict]:
         self.flush()
@@ -267,7 +157,7 @@ class NetnodeBackend:
             try:
                 raw = gzip.decompress(blob)
             except OSError:
-                continue  # tolerate a truncated tail segment
+                continue
             for line in raw.splitlines():
                 if not line:
                     continue
@@ -277,120 +167,91 @@ class NetnodeBackend:
                     continue
 
 
-# ----------------------------------------------------------------------------
-# Public configure / shutdown
-# ----------------------------------------------------------------------------
-
-
-def _ensure_patched() -> None:
+def _ensure_atexit() -> None:
     with _state_lock:
-        if _state["patched"]:
+        if _state["atexit_registered"]:
             return
-        _state["patched"] = True
-    _install_trace_patch()
-    with _state_lock:
-        if not _state["atexit_registered"]:
-            atexit.register(shutdown)
-            _state["atexit_registered"] = True
+        _state["atexit_registered"] = True
+    atexit.register(shutdown)
 
 
-def configure(path: str, *, verbose: bool = False) -> None:
-    """Enable the file backend. Appends to `path` (creates parents)."""
-    resolved = Path(path).expanduser().resolve()
-    resolved.parent.mkdir(parents=True, exist_ok=True)
-    new_backend = FileBackend(resolved)
+def _install_idb_hook() -> None:
+    """Flush pending records when the IDB is saved or closed."""
     with _state_lock:
-        old = _state["file_backend"]
-        _state["file_backend"] = new_backend
-        if verbose:
-            _state["verbose"] = True
-    if old is not None:
-        old.close()
-    _ensure_patched()
+        if _state["idb_hook"] is not None:
+            return
+    try:
+        import ida_idp
+    except Exception:
+        return
+
+    backend_ref = _state
+
+    class _TraceFlushHook(ida_idp.IDB_Hooks):
+        def savebase(self, *args):
+            b = backend_ref.get("idb_backend")
+            if b is not None:
+                try:
+                    b.flush()
+                except Exception:
+                    pass
+            return 0
+
+        def closebase(self, *args):
+            b = backend_ref.get("idb_backend")
+            if b is not None:
+                try:
+                    b.flush()
+                except Exception:
+                    pass
+            return 0
+
+    hook = _TraceFlushHook()
+    if hook.hook():
+        with _state_lock:
+            _state["idb_hook"] = hook
 
 
 def configure_idb(
     *,
-    verbose: bool = False,
     batch_records: int = _DEFAULT_BATCH_RECORDS,
     batch_bytes: int = _DEFAULT_BATCH_BYTES,
 ) -> None:
-    """Enable the IDB backend. Batches writes before committing to the netnode."""
+    """Enable IDB tracing. Batches writes before committing to the netnode."""
     new_backend = NetnodeBackend(
         batch_records=batch_records, batch_bytes=batch_bytes
     )
     with _state_lock:
         old = _state["idb_backend"]
         _state["idb_backend"] = new_backend
-        if verbose:
-            _state["verbose"] = True
     if old is not None:
         old.close()
-    _ensure_patched()
-
-
-def configure_from_env() -> None:
-    path = os.environ.get("IDA_MCP_TRACE_FILE", "").strip()
-    verbose = os.environ.get("IDA_MCP_TRACE_VERBOSE", "").strip() not in ("", "0", "false", "no")
-    idb = os.environ.get("IDA_MCP_TRACE_IDB", "").strip() not in ("", "0", "false", "no")
-    if path:
-        configure(path, verbose=verbose)
-    if idb:
-        configure_idb(verbose=verbose)
+    install_tracer()
+    _ensure_atexit()
+    _install_idb_hook()
 
 
 def shutdown() -> None:
-    """Close both backends (flushing any pending IDB segment)."""
+    """Flush and close the backend, unhook the IDB listener."""
     with _state_lock:
-        file_b = _state["file_backend"]
         idb_b = _state["idb_backend"]
-        _state["file_backend"] = None
+        hook = _state["idb_hook"]
         _state["idb_backend"] = None
+        _state["idb_hook"] = None
+    if hook is not None:
+        try:
+            hook.unhook()
+        except Exception:
+            pass
     if idb_b is not None:
         try:
             idb_b.close()
         except Exception:
             pass
-    if file_b is not None:
-        try:
-            file_b.close()
-        except Exception:
-            pass
-
-
-# ----------------------------------------------------------------------------
-# Introspection helpers used by the test suite and future tooling
-# ----------------------------------------------------------------------------
-
-
-def flush_idb() -> None:
-    """Force the IDB backend to flush any buffered records."""
-    with _state_lock:
-        backend = _state["idb_backend"]
-    if backend is not None:
-        backend.flush()
-
-
-def clear_idb() -> dict:
-    """Wipe every segment from the IDB trace netnode (preserves configuration)."""
-    with _state_lock:
-        backend = _state["idb_backend"]
-    if backend is None:
-        try:
-            _netnode_kill()
-            return {"ok": True, "note": "no backend active; wiped node directly"}
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
-    return backend.clear()
-
-
-def idb_stats() -> dict[str, int]:
-    """Return counters from the IDB trace netnode (zero dict if none exists)."""
-    return _netnode_read_stats()
 
 
 def iter_idb_records() -> Iterator[dict]:
-    """Iterate every trace record stored in the IDB (flushes pending first)."""
+    """Iterate every trace record stored in the IDB. Flushes pending writes first."""
     with _state_lock:
         backend = _state["idb_backend"]
     if backend is None:
@@ -409,19 +270,6 @@ def iter_idb_records() -> Iterator[dict]:
     yield from backend.iter_records()
 
 
-# ----------------------------------------------------------------------------
-# Middleware
-# ----------------------------------------------------------------------------
-
-
-def _redact_args(tool_name: str, arguments: Any) -> Any:
-    if _state["verbose"]:
-        return arguments
-    if tool_name in MCP_UNSAFE:
-        return "<redacted>"
-    return arguments
-
-
 def _now_iso() -> str:
     return (
         datetime.now(timezone.utc)
@@ -432,13 +280,7 @@ def _now_iso() -> str:
 
 def _dispatch(record: dict) -> None:
     with _state_lock:
-        file_b = _state["file_backend"]
         idb_b = _state["idb_backend"]
-    if file_b is not None:
-        try:
-            file_b.append(record)
-        except Exception:
-            pass
     if idb_b is not None:
         try:
             idb_b.append(record)
@@ -446,15 +288,19 @@ def _dispatch(record: dict) -> None:
             pass
 
 
-def _install_trace_patch() -> None:
-    original = MCP_SERVER.registry.methods["tools/call"]
+def install_tracer() -> None:
+    """Wrap tools/call. Idempotent; lifts the tracer to outermost if already wrapped."""
+    inner = MCP_SERVER.registry.methods["tools/call"]
+    if getattr(inner, "_ida_mcp_tracer", False):
+        return
+    original = inner
 
     def traced(name, arguments=None, _meta=None):
         start = time.monotonic()
         record: dict[str, Any] = {
             "ts": _now_iso(),
             "tool": name,
-            "arguments": _redact_args(name, arguments or {}),
+            "arguments": arguments or {},
         }
         try:
             response = original(name, arguments, _meta)
@@ -477,29 +323,14 @@ def _install_trace_patch() -> None:
         _dispatch(record)
         return response
 
+    traced._ida_mcp_tracer = True
     MCP_SERVER.registry.methods["tools/call"] = traced
 
 
-# ----------------------------------------------------------------------------
-# MCP tool
-# ----------------------------------------------------------------------------
-
-
-@tool
-def trace_clear() -> dict:
-    """Wipe the IDB trace log (netnode `$ ida_mcp.trace`). File backend unaffected."""
-    return clear_idb()
-
-
 __all__ = [
-    "configure",
     "configure_idb",
-    "configure_from_env",
+    "install_tracer",
     "shutdown",
-    "flush_idb",
-    "clear_idb",
-    "idb_stats",
     "iter_idb_records",
-    "trace_clear",
     "IDB_NETNODE_NAME",
 ]

--- a/src/ida_pro_mcp/ida_mcp/trace.py
+++ b/src/ida_pro_mcp/ida_mcp/trace.py
@@ -1,67 +1,417 @@
-"""Tool call tracing (#189).
+"""Tool-call tracing.
 
-Appends one JSON record per tools/call to a file. Opt-in via CLI flag
-(--trace-file PATH) or env var IDA_MCP_TRACE_FILE. Arguments for
-@unsafe tools (py_eval, py_exec_file, ...) are redacted unless
---trace-verbose / IDA_MCP_TRACE_VERBOSE=1.
+Two opt-in backends:
+
+  File backend:  one JSON record per tools/call to a JSONL file.
+                 trace.configure(path) or IDA_MCP_TRACE_FILE=<path>.
+
+  IDB backend:   append-only gzipped batches in netnode `$ ida_mcp.trace`.
+                 trace.configure_idb() or IDA_MCP_TRACE_IDB=1.
+                 Tags: META (version, next_chunk, next_seg_id, total_records),
+                 INDEX (seg_id -> start), DATA (blobs). One empty supval sits
+                 between blobs so getblob() self-terminates. All netnode ops
+                 run on the IDA main thread via @idasync.
 """
 
 import atexit
+import gzip
 import json
 import os
 import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
-from .rpc import MCP_SERVER, MCP_UNSAFE
+from .rpc import MCP_SERVER, MCP_UNSAFE, tool
+from .sync import idasync
 
 
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+IDB_NETNODE_NAME = "$ ida_mcp.trace"
+_TAG_META = ord("M")
+_TAG_INDEX = ord("I")
+_TAG_DATA = ord("D")
+_CHUNK = 1024  # MAXSPECSIZE: one netnode supval
+_FORMAT_VERSION = 1
+
+_META_VERSION = 0
+_META_NEXT_CHUNK = 1
+_META_NEXT_SEG_ID = 2
+_META_TOTAL_RECORDS = 3
+
+_DEFAULT_BATCH_RECORDS = 256
+_DEFAULT_BATCH_BYTES = 64 * 1024
+
+
+# ----------------------------------------------------------------------------
+# Shared state
+# ----------------------------------------------------------------------------
+
+_state_lock = threading.Lock()
 _state: dict[str, Any] = {
-    "enabled": False,
     "verbose": False,
-    "path": None,
-    "file": None,
-    "lock": threading.Lock(),
+    "patched": False,
+    "file_backend": None,
+    "idb_backend": None,
+    "atexit_registered": False,
 }
 
 
+# ----------------------------------------------------------------------------
+# File backend
+# ----------------------------------------------------------------------------
+
+
+class FileBackend:
+    """One JSON line per call, flushed after every write."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._lock = threading.Lock()
+        self._file = open(path, "a", encoding="utf-8")
+
+    def append(self, record: dict) -> None:
+        line = json.dumps(record, separators=(",", ":"), default=str)
+        with self._lock:
+            if self._file is None:
+                return
+            self._file.write(line)
+            self._file.write("\n")
+            self._file.flush()
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._file is not None:
+                self._file.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._file is not None:
+                try:
+                    self._file.flush()
+                    self._file.close()
+                finally:
+                    self._file = None
+
+
+# ----------------------------------------------------------------------------
+# Netnode backend
+# ----------------------------------------------------------------------------
+
+
+@idasync
+def _netnode_flush_segment(payload: bytes, record_count: int) -> None:
+    """Write one segment and advance all meta counters in a single main-thread hop.
+
+    Keeping data + index + meta writes inside one @idasync job prevents a
+    concurrent kill from slipping between partial updates.
+    """
+    import ida_netnode
+
+    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, True)
+
+    if node.altval(_META_VERSION, _TAG_META) == 0:
+        node.altset(_META_VERSION, _FORMAT_VERSION, _TAG_META)
+
+    start = node.altval(_META_NEXT_CHUNK, _TAG_META)
+    seg_id = node.altval(_META_NEXT_SEG_ID, _TAG_META)
+
+    if not node.setblob(payload, start, _TAG_DATA):
+        # Leave meta untouched so the caller keeps the buffered batch for retry.
+        raise RuntimeError(f"setblob failed at index {start}")
+
+    node.altset(seg_id, start, _TAG_INDEX)
+
+    used_chunks = (len(payload) + _CHUNK - 1) // _CHUNK
+    new_start = start + used_chunks + 1  # +1: empty supval that terminates getblob
+    new_seg_id = seg_id + 1
+
+    node.altset(_META_NEXT_CHUNK, new_start, _TAG_META)
+    node.altset(_META_NEXT_SEG_ID, new_seg_id, _TAG_META)
+
+    cur_total = node.altval(_META_TOTAL_RECORDS, _TAG_META)
+    node.altset(_META_TOTAL_RECORDS, cur_total + record_count, _TAG_META)
+
+
+@idasync
+def _netnode_read_stats() -> dict[str, int]:
+    import ida_netnode
+    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
+    if node == ida_netnode.BADNODE:
+        return {
+            "version": 0,
+            "segments": 0,
+            "next_chunk_start": 0,
+            "next_segment_id": 0,
+            "total_records": 0,
+        }
+    segments = 0
+    i = node.altfirst(_TAG_INDEX)
+    while i != ida_netnode.BADNODE:
+        segments += 1
+        i = node.altnext(i, _TAG_INDEX)
+    return {
+        "version": node.altval(_META_VERSION, _TAG_META),
+        "segments": segments,
+        "next_chunk_start": node.altval(_META_NEXT_CHUNK, _TAG_META),
+        "next_segment_id": node.altval(_META_NEXT_SEG_ID, _TAG_META),
+        "total_records": node.altval(_META_TOTAL_RECORDS, _TAG_META),
+    }
+
+
+@idasync
+def _netnode_iter_blobs() -> list[bytes]:
+    """Return every segment's compressed blob in segment-id order."""
+    import ida_netnode
+    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
+    if node == ida_netnode.BADNODE:
+        return []
+    pairs: list[tuple[int, int]] = []
+    i = node.altfirst(_TAG_INDEX)
+    while i != ida_netnode.BADNODE:
+        pairs.append((i, node.altval(i, _TAG_INDEX)))
+        i = node.altnext(i, _TAG_INDEX)
+    pairs.sort()
+    blobs: list[bytes] = []
+    for _, start in pairs:
+        blob = node.getblob(start, _TAG_DATA)
+        if isinstance(blob, tuple):
+            blob = blob[0]
+        if blob:
+            blobs.append(bytes(blob))
+    return blobs
+
+
+@idasync
+def _netnode_kill() -> None:
+    import ida_netnode
+    node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
+    if node != ida_netnode.BADNODE:
+        node.kill()
+
+
+class NetnodeBackend:
+    """Append-only compressed-segment log in an IDA netnode."""
+
+    def __init__(self, *, batch_records: int, batch_bytes: int):
+        self.batch_records = max(1, batch_records)
+        self.batch_bytes = max(1024, batch_bytes)
+        self._lock = threading.Lock()        # buffer + closed flag
+        self._flush_lock = threading.Lock()  # serializes flushes and clears
+        self._buffer: list[bytes] = []
+        self._buffered_bytes = 0
+        self._closed = False
+
+    def append(self, record: dict) -> None:
+        line = json.dumps(record, separators=(",", ":"), default=str).encode("utf-8")
+        flush_now = False
+        with self._lock:
+            if self._closed:
+                return
+            self._buffer.append(line)
+            self._buffered_bytes += len(line) + 1
+            if (
+                len(self._buffer) >= self.batch_records
+                or self._buffered_bytes >= self.batch_bytes
+            ):
+                flush_now = True
+        if flush_now:
+            self.flush()
+
+    def flush(self) -> None:
+        with self._flush_lock:
+            with self._lock:
+                if not self._buffer:
+                    return
+                to_flush = self._buffer
+                self._buffer = []
+                self._buffered_bytes = 0
+            payload = b"\n".join(to_flush) + b"\n"
+            compressed = gzip.compress(payload, mtime=0)
+            try:
+                _netnode_flush_segment(compressed, len(to_flush))
+            except Exception:
+                # Re-prepend the failed batch so retries keep wall-clock order.
+                with self._lock:
+                    self._buffer[:0] = to_flush
+                    self._buffered_bytes = sum(len(l) + 1 for l in self._buffer)
+                return
+
+    def clear(self) -> dict:
+        # Flush lock drains any in-flight write before we kill the node, so a
+        # pending @idasync meta-bump cannot resurrect the node after kill().
+        with self._flush_lock:
+            with self._lock:
+                self._buffer.clear()
+                self._buffered_bytes = 0
+            _netnode_kill()
+        return {"ok": True}
+
+    def close(self) -> None:
+        # Set closed before draining so concurrent appends drop instead of
+        # racing into a buffer we're about to flush.
+        with self._lock:
+            self._closed = True
+        self.flush()
+
+    def stats(self) -> dict[str, int]:
+        return _netnode_read_stats()
+
+    def iter_records(self) -> Iterator[dict]:
+        self.flush()
+        for blob in _netnode_iter_blobs():
+            try:
+                raw = gzip.decompress(blob)
+            except OSError:
+                continue  # tolerate a truncated tail segment
+            for line in raw.splitlines():
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+
+# ----------------------------------------------------------------------------
+# Public configure / shutdown
+# ----------------------------------------------------------------------------
+
+
+def _ensure_patched() -> None:
+    with _state_lock:
+        if _state["patched"]:
+            return
+        _state["patched"] = True
+    _install_trace_patch()
+    with _state_lock:
+        if not _state["atexit_registered"]:
+            atexit.register(shutdown)
+            _state["atexit_registered"] = True
+
+
 def configure(path: str, *, verbose: bool = False) -> None:
-    """Enable tracing; opens `path` in append mode and installs middleware."""
+    """Enable the file backend. Appends to `path` (creates parents)."""
     resolved = Path(path).expanduser().resolve()
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    with _state["lock"]:
-        if _state["file"] is not None:
-            _state["file"].close()
-        _state["file"] = open(resolved, "a", encoding="utf-8")
-        _state["path"] = resolved
-        _state["verbose"] = verbose
-        already = _state["enabled"]
-        _state["enabled"] = True
-    if not already:
-        _install_trace_patch()
-        atexit.register(shutdown)
+    new_backend = FileBackend(resolved)
+    with _state_lock:
+        old = _state["file_backend"]
+        _state["file_backend"] = new_backend
+        if verbose:
+            _state["verbose"] = True
+    if old is not None:
+        old.close()
+    _ensure_patched()
+
+
+def configure_idb(
+    *,
+    verbose: bool = False,
+    batch_records: int = _DEFAULT_BATCH_RECORDS,
+    batch_bytes: int = _DEFAULT_BATCH_BYTES,
+) -> None:
+    """Enable the IDB backend. Batches writes before committing to the netnode."""
+    new_backend = NetnodeBackend(
+        batch_records=batch_records, batch_bytes=batch_bytes
+    )
+    with _state_lock:
+        old = _state["idb_backend"]
+        _state["idb_backend"] = new_backend
+        if verbose:
+            _state["verbose"] = True
+    if old is not None:
+        old.close()
+    _ensure_patched()
 
 
 def configure_from_env() -> None:
     path = os.environ.get("IDA_MCP_TRACE_FILE", "").strip()
-    if not path:
-        return
     verbose = os.environ.get("IDA_MCP_TRACE_VERBOSE", "").strip() not in ("", "0", "false", "no")
-    configure(path, verbose=verbose)
+    idb = os.environ.get("IDA_MCP_TRACE_IDB", "").strip() not in ("", "0", "false", "no")
+    if path:
+        configure(path, verbose=verbose)
+    if idb:
+        configure_idb(verbose=verbose)
 
 
 def shutdown() -> None:
-    with _state["lock"]:
-        f = _state["file"]
-        if f is not None:
+    """Close both backends (flushing any pending IDB segment)."""
+    with _state_lock:
+        file_b = _state["file_backend"]
+        idb_b = _state["idb_backend"]
+        _state["file_backend"] = None
+        _state["idb_backend"] = None
+    if idb_b is not None:
+        try:
+            idb_b.close()
+        except Exception:
+            pass
+    if file_b is not None:
+        try:
+            file_b.close()
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------------------
+# Introspection helpers used by the test suite and future tooling
+# ----------------------------------------------------------------------------
+
+
+def flush_idb() -> None:
+    """Force the IDB backend to flush any buffered records."""
+    with _state_lock:
+        backend = _state["idb_backend"]
+    if backend is not None:
+        backend.flush()
+
+
+def clear_idb() -> dict:
+    """Wipe every segment from the IDB trace netnode (preserves configuration)."""
+    with _state_lock:
+        backend = _state["idb_backend"]
+    if backend is None:
+        try:
+            _netnode_kill()
+            return {"ok": True, "note": "no backend active; wiped node directly"}
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+    return backend.clear()
+
+
+def idb_stats() -> dict[str, int]:
+    """Return counters from the IDB trace netnode (zero dict if none exists)."""
+    return _netnode_read_stats()
+
+
+def iter_idb_records() -> Iterator[dict]:
+    """Iterate every trace record stored in the IDB (flushes pending first)."""
+    with _state_lock:
+        backend = _state["idb_backend"]
+    if backend is None:
+        for blob in _netnode_iter_blobs():
             try:
-                f.flush()
-                f.close()
-            except Exception:
-                pass
-        _state["file"] = None
+                raw = gzip.decompress(blob)
+            except OSError:
+                continue
+            for line in raw.splitlines():
+                if line:
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+        return
+    yield from backend.iter_records()
+
+
+# ----------------------------------------------------------------------------
+# Middleware
+# ----------------------------------------------------------------------------
 
 
 def _redact_args(tool_name: str, arguments: Any) -> Any:
@@ -80,15 +430,20 @@ def _now_iso() -> str:
     )
 
 
-def _emit(record: dict) -> None:
-    line = json.dumps(record, separators=(",", ":"), default=str)
-    with _state["lock"]:
-        f = _state["file"]
-        if f is None:
-            return
-        f.write(line)
-        f.write("\n")
-        f.flush()
+def _dispatch(record: dict) -> None:
+    with _state_lock:
+        file_b = _state["file_backend"]
+        idb_b = _state["idb_backend"]
+    if file_b is not None:
+        try:
+            file_b.append(record)
+        except Exception:
+            pass
+    if idb_b is not None:
+        try:
+            idb_b.append(record)
+        except Exception:
+            pass
 
 
 def _install_trace_patch() -> None:
@@ -106,7 +461,7 @@ def _install_trace_patch() -> None:
         except Exception as e:
             record["duration_ms"] = round((time.monotonic() - start) * 1000, 2)
             record["error"] = f"{type(e).__name__}: {e}"
-            _emit(record)
+            _dispatch(record)
             raise
 
         record["duration_ms"] = round((time.monotonic() - start) * 1000, 2)
@@ -119,10 +474,32 @@ def _install_trace_patch() -> None:
             record["truncated"] = True
             record["output_id"] = meta.get("output_id")
 
-        _emit(record)
+        _dispatch(record)
         return response
 
     MCP_SERVER.registry.methods["tools/call"] = traced
 
 
-__all__ = ["configure", "configure_from_env", "shutdown"]
+# ----------------------------------------------------------------------------
+# MCP tool
+# ----------------------------------------------------------------------------
+
+
+@tool
+def trace_clear() -> dict:
+    """Wipe the IDB trace log (netnode `$ ida_mcp.trace`). File backend unaffected."""
+    return clear_idb()
+
+
+__all__ = [
+    "configure",
+    "configure_idb",
+    "configure_from_env",
+    "shutdown",
+    "flush_idb",
+    "clear_idb",
+    "idb_stats",
+    "iter_idb_records",
+    "trace_clear",
+    "IDB_NETNODE_NAME",
+]

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -494,27 +494,6 @@ def main():
         "--unsafe", action="store_true", help="Enable unsafe functions (DANGEROUS)"
     )
     parser.add_argument(
-        "--trace-file",
-        type=Path,
-        default=None,
-        metavar="PATH",
-        help="Append one JSONL record per tools/call to PATH (diagnostic trace).",
-    )
-    parser.add_argument(
-        "--trace-verbose",
-        action="store_true",
-        help="Include @unsafe tool arguments verbatim in trace (default: redacted).",
-    )
-    parser.add_argument(
-        "--trace-idb",
-        action="store_true",
-        help=(
-            "Store tools/call trace inside the IDB using a dedicated netnode "
-            "(append-only, gzip-compressed segments). Can be combined with "
-            "--trace-file."
-        ),
-    )
-    parser.add_argument(
         "--profile",
         type=Path,
         default=None,
@@ -619,17 +598,9 @@ def main():
 
     _install_context_activation_hooks()
 
-    if args.trace_file is not None or args.trace_idb:
-        from ida_pro_mcp.ida_mcp import trace
-
-        if args.trace_file is not None:
-            trace.configure(str(args.trace_file), verbose=args.trace_verbose)
-            logger.info("Tracing tools/call to %s", args.trace_file)
-        if args.trace_idb:
-            trace.configure_idb(verbose=args.trace_verbose)
-            logger.info(
-                "Tracing tools/call to IDB netnode %s", trace.IDB_NETNODE_NAME
-            )
+    from ida_pro_mcp.ida_mcp import trace
+    trace.install_tracer()
+    logger.info("Tracing tools/call to IDB netnode %s", trace.IDB_NETNODE_NAME)
 
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -494,6 +494,18 @@ def main():
         "--unsafe", action="store_true", help="Enable unsafe functions (DANGEROUS)"
     )
     parser.add_argument(
+        "--trace-file",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Append one JSONL record per tools/call to PATH (diagnostic trace).",
+    )
+    parser.add_argument(
+        "--trace-verbose",
+        action="store_true",
+        help="Include @unsafe tool arguments verbatim in trace (default: redacted).",
+    )
+    parser.add_argument(
         "--profile",
         type=Path,
         default=None,
@@ -597,6 +609,12 @@ def main():
         )
 
     _install_context_activation_hooks()
+
+    if args.trace_file is not None:
+        from ida_pro_mcp.ida_mcp import trace
+
+        trace.configure(str(args.trace_file), verbose=args.trace_verbose)
+        logger.info("Tracing tools/call to %s", args.trace_file)
 
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -506,6 +506,15 @@ def main():
         help="Include @unsafe tool arguments verbatim in trace (default: redacted).",
     )
     parser.add_argument(
+        "--trace-idb",
+        action="store_true",
+        help=(
+            "Store tools/call trace inside the IDB using a dedicated netnode "
+            "(append-only, gzip-compressed segments). Can be combined with "
+            "--trace-file."
+        ),
+    )
+    parser.add_argument(
         "--profile",
         type=Path,
         default=None,
@@ -610,11 +619,17 @@ def main():
 
     _install_context_activation_hooks()
 
-    if args.trace_file is not None:
+    if args.trace_file is not None or args.trace_idb:
         from ida_pro_mcp.ida_mcp import trace
 
-        trace.configure(str(args.trace_file), verbose=args.trace_verbose)
-        logger.info("Tracing tools/call to %s", args.trace_file)
+        if args.trace_file is not None:
+            trace.configure(str(args.trace_file), verbose=args.trace_verbose)
+            logger.info("Tracing tools/call to %s", args.trace_file)
+        if args.trace_idb:
+            trace.configure_idb(verbose=args.trace_verbose)
+            logger.info(
+                "Tracing tools/call to IDB netnode %s", trace.IDB_NETNODE_NAME
+            )
 
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any

--- a/src/ida_pro_mcp/trace_dump.py
+++ b/src/ida_pro_mcp/trace_dump.py
@@ -1,0 +1,55 @@
+# Dump the tools/call trace stored inside an IDB to JSONL.
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# idapro must come first to initialize idalib.
+import idapro
+from ida_pro_mcp.ida_mcp.trace import iter_idb_records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Export the tools/call trace from an IDB as JSONL."
+    )
+    parser.add_argument("idb", type=Path, help="Path to the .idb / .i64 to read.")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Write JSONL to PATH (default: stdout).",
+    )
+    args = parser.parse_args()
+
+    if not args.idb.exists():
+        parser.error(f"IDB not found: {args.idb}")
+
+    if idapro.open_database(str(args.idb), run_auto_analysis=False) != 0:
+        print(f"failed to open IDB: {args.idb}", file=sys.stderr)
+        return 1
+
+    try:
+        out = open(args.output, "w", encoding="utf-8") if args.output else sys.stdout
+        try:
+            count = 0
+            for rec in iter_idb_records():
+                out.write(json.dumps(rec, separators=(",", ":"), default=str))
+                out.write("\n")
+                count += 1
+            out.flush()
+        finally:
+            if out is not sys.stdout:
+                out.close()
+    finally:
+        idapro.close_database(False)
+
+    print(f"exported {count} record(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #189.

Appends one JSON line per `tools/call` to a file.

Each record: `{ts, tool, arguments, structuredContent, isError, duration_ms, truncated?, full_result_size?}`. `@unsafe` tool arguments (`py_eval`, `py_exec_file`) are redacted by default. Pass `--trace-verbose` to keep them as-is.

## Enable

```sh
# CLI
idalib-mcp --trace-file /tmp/trace.jsonl [--trace-verbose]

# Plugin (no CLI)
IDA_MCP_TRACE_FILE=/tmp/trace.jsonl ida ...
```

## Read

```sh
cat /tmp/trace.jsonl | jq .
```

The issue mentions "IDB/to a file". I went with the file path since it's simpler and covers the stated use case. An IDB netnode backend would be a natural follow-up so the trace travels with the database, maybe with `trace_list` / `trace_clear` tools on top. I can do that if you prefer.