### PR TITLE
fix: wire IdaMcpHttpRequestHandler and set_download_base_url into idalib server

### DIFF
--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -18,7 +18,8 @@ from ida_pro_mcp.ida_mcp.api_core import (
     server_warmup,
 )
 from ida_pro_mcp.ida_mcp.profile import apply_profile, load_profile
-from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, tool
+from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, set_download_base_url, tool
+from ida_pro_mcp.ida_mcp.http import IdaMcpHttpRequestHandler
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 
 class IdalibContextFields(TypedDict):
@@ -601,7 +602,9 @@ def main():
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any
     # work from @idasync, so we deadlock.
-    MCP_SERVER.serve(host=args.host, port=args.port, background=False)
+    set_download_base_url(f"http://{args.host}:{args.port}")
+    MCP_SERVER.serve(host=args.host, port=args.port, background=False,
+                     request_handler=IdaMcpHttpRequestHandler)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Commit 216f276 (`feat(rpc): add generic output size limiting middleware`) added a middleware in `rpc.py` that truncates tool responses exceeding 50K chars and provides a download URL for the full data. The download endpoint (`/output/{id}.json`) is served by `IdaMcpHttpRequestHandler` in `http.py`.

The IDA plugin server (`ida_mcp.py`) already passes `IdaMcpHttpRequestHandler` to `serve()`, so truncation + download works there. However, the idalib headless server (`idalib_server.py`) was never updated:

1. **Wrong HTTP handler** — `MCP_SERVER.serve()` still uses the base `McpHttpRequestHandler`, which has no `/output/` route → download returns 404.

2. **Wrong download URL** — `_download_base_url` defaults to `http://127.0.0.1:13337` (the plugin's default port), but idalib runs on a user-specified port → download URL points to wrong port.

The result: when a tool response exceeds 50K chars on idalib, the truncated output includes an unrecoverable download URL — wrong port, and endpoint doesn't exist.

## Fix

- Import `set_download_base_url` and `IdaMcpHttpRequestHandler` into `idalib_server.py`
- Call `set_download_base_url()` with the actual `host:port` before `serve()`
- Pass `request_handler=IdaMcpHttpRequestHandler` to `MCP_SERVER.serve()`

## Testing

Reproduced on `main`: forced truncation, confirmed download URL → `:13337` (wrong), download → `Connection refused`, `/output/` → 404.

Verified on fix branch: download URL → correct port, download → 200 OK with full data.