### PR TITLE
fix: sync truncated-output download URL to actual bound port

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -202,8 +202,10 @@ class MCP(idaapi.plugin_t):
         unload_package("ida_mcp")
         if TYPE_CHECKING:
             from .ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, set_local_instance
+            from .ida_mcp.rpc import set_download_base_url
         else:
             from ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, set_local_instance
+            from ida_mcp.rpc import set_download_base_url
 
         port = self.port
         max_port = port + 100
@@ -215,6 +217,7 @@ class MCP(idaapi.plugin_t):
                 print(f"  Config: http://{self.host}:{port}/config.html")
                 self.mcp = MCP_SERVER
                 set_local_instance(self.host, port)
+                set_download_base_url(f"http://{self.host}:{port}")
                 self._register_instance(port)
                 return
             except OSError as e:

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -18,7 +18,7 @@ from ida_pro_mcp.ida_mcp.api_core import (
     server_warmup,
 )
 from ida_pro_mcp.ida_mcp.profile import apply_profile, load_profile
-from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, tool
+from ida_pro_mcp.ida_mcp.rpc import get_current_transport_session_id, set_download_base_url, tool
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 
 class IdalibContextFields(TypedDict):
@@ -601,6 +601,7 @@ def main():
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any
     # work from @idasync, so we deadlock.
+    set_download_base_url(f"http://{args.host}:{args.port}")
     MCP_SERVER.serve(host=args.host, port=args.port, background=False)
 
 


### PR DESCRIPTION
## Problem

When MCP tool output exceeds `OUTPUT_LIMIT_MAX_CHARS` (50 000 chars), the server emits a truncated preview and a `download_hint` like:

```
Output truncated. Run: curl -o .ida-mcp/<id>.json http://127.0.0.1:13337/output/<id>.json
```

The port in this URL is **always 13337** (the hard-coded default), even when the server is actually bound to a different port.

### Two affected code paths

1. **IDA Plugin mode** (`ida_mcp.py`): `run()` scans for a free port starting at `DEFAULT_PORT` (13337) and may land on 13338, 13339, etc. The actual port was never written back to `_download_base_url`.

2. **idalib mode** (`idalib_server.py`): the default CLI port is **8745**, but `_download_base_url` still defaulted to 13337, so the curl hint was always wrong.

`set_download_base_url()` existed in `rpc.py` but was never called.

## Fix

Call `set_download_base_url(f"http://{host}:{port}")` at the point where each server path knows the real port:

- **`ida_mcp.py`** – immediately after `MCP_SERVER.serve()` succeeds (inside the port-scan loop).
- **`idalib_server.py`** – just before `MCP_SERVER.serve()` in `main()`.

No API changes; `set_download_base_url` was already exported in `__all__`.