### PR TITLE
fix: make caller graph detection architecture agnostic

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -16,6 +16,8 @@ import ida_name
 from .rpc import tool
 from .sync import idasync, tool_timeout, IDAError
 from .utils import (
+    _direct_call_targets,
+    _is_call_instruction,
     parse_address,
     normalize_list_input,
     normalize_dict_list,
@@ -670,7 +672,7 @@ def _collect_callers_for_function(func: ida_funcs.func_t) -> list[dict]:
 
         insn = idaapi.insn_t()
         idaapi.decode_insn(insn, caller_site)
-        if insn.itype not in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]:
+        if not _is_call_instruction(insn):
             continue
 
         callers[caller_start] = {
@@ -1506,15 +1508,8 @@ def callees(
                         break
                     current_ea = next_ea
                     continue
-                if insn.itype in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]:
-                    op0 = insn.ops[0]
-                    if op0.type in (ida_ua.o_mem, ida_ua.o_near, ida_ua.o_far):
-                        target = op0.addr
-                    elif op0.type == ida_ua.o_imm:
-                        target = op0.value
-                    else:
-                        target = None
-                    if target is not None and target not in callees_dict:
+                for target in _direct_call_targets(current_ea, insn):
+                    if target not in callees_dict:
                         func_type = (
                             "internal"
                             if idaapi.get_func(target) is not None

--- a/src/ida_pro_mcp/ida_mcp/tests/test_utils.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_utils.py
@@ -143,6 +143,8 @@ def test_utils_callees_callers_and_xrefs_from_helpers():
 
     callers = get_callers("0x1013dc0")
     assert isinstance(callers, list)
+    assert callers
+    assert all("addr" in caller and "name" in caller for caller in callers)
 
     xrefs_from = get_xrefs_from_internal(0x1013F1B)
     assert any(x["addr"] == "0x1013dc0" for x in xrefs_from)

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -1202,6 +1202,42 @@ def get_all_comments(ea: int) -> dict:
     return comments
 
 
+def _decode_insn_at(ea: int):
+    """Decode the instruction at ea, returning None when decode fails."""
+    insn = idaapi.insn_t()
+    if idaapi.decode_insn(insn, ea) == 0:
+        return None
+    return insn
+
+
+def _is_call_instruction(insn: idaapi.insn_t) -> bool:
+    """Architecture-agnostic call instruction detection with legacy fallback."""
+    try:
+        return bool(idaapi.is_call_insn(insn))
+    except Exception:
+        return insn.itype in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]
+
+
+def _direct_call_targets(ea: int, insn: idaapi.insn_t) -> list[int]:
+    """Return direct call targets for a decoded call instruction."""
+    if not _is_call_instruction(insn):
+        return []
+
+    targets = [
+        target
+        for target in idautils.CodeRefsFrom(ea, 0)
+        if isinstance(target, int) and target != idaapi.BADADDR
+    ]
+    if targets:
+        return list(dict.fromkeys(targets))
+
+    target = idc.get_operand_value(ea, 0)
+    target_type = idc.get_operand_type(ea, 0)
+    if target_type in [idaapi.o_mem, idaapi.o_near, idaapi.o_far]:
+        return [target]
+    return []
+
+
 def get_callees(addr: str) -> list[dict]:
     """Get callees for a single function address"""
     try:
@@ -1213,12 +1249,9 @@ def get_callees(addr: str) -> list[dict]:
         callees: list[dict[str, str]] = []
         current_ea = func_start
         while current_ea < func_end:
-            insn = idaapi.insn_t()
-            idaapi.decode_insn(insn, current_ea)
-            if insn.itype in [idaapi.NN_call, idaapi.NN_callfi, idaapi.NN_callni]:
-                target = idc.get_operand_value(current_ea, 0)
-                target_type = idc.get_operand_type(current_ea, 0)
-                if target_type in [idaapi.o_mem, idaapi.o_near, idaapi.o_far]:
+            insn = _decode_insn_at(current_ea)
+            if insn is not None:
+                for target in _direct_call_targets(current_ea, insn):
                     func_type = (
                         "internal"
                         if idaapi.get_func(target) is not None
@@ -1255,13 +1288,8 @@ def get_callers(addr: str, limit: int = 50) -> list[Function]:
             func = get_function(caller_addr, raise_error=False)
             if not func:
                 continue
-            insn = idaapi.insn_t()
-            idaapi.decode_insn(insn, caller_addr)
-            if insn.itype not in [
-                idaapi.NN_call,
-                idaapi.NN_callfi,
-                idaapi.NN_callni,
-            ]:
+            insn = _decode_insn_at(caller_addr)
+            if insn is None or not _is_call_instruction(insn):
                 continue
             callers[func["addr"]] = func
 


### PR DESCRIPTION
## Summary
- replace architecture-specific `NN_call*` checks with `idaapi.is_call_insn(insn)`
- use `CodeRefsFrom` to collect call destinations for caller/callee graph queries
- add regression coverage for the architecture-agnostic call detection path

## Why
The old caller/callee implementation was tied to x86-style `NN_call*` instruction IDs. On non-x86 targets such as MIPS, live headless runs could still observe real code xrefs, but `get_callers`/`get_callees` returned empty results because the callsite filter never matched. This broke downstream graph consumers even when the underlying IDA database had the route information.

## Validation
- local unit tests in this repo
- live downstream validation through a rebuilt `sdk-idapro` managed bundle on a MIPS target, where `get_callers(0x10001370)` began returning `main` and downstream route witnesses became available
