### PR TITLE
Fix dbg_start failure after successful debugger launch

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -35,6 +35,7 @@ from .utils import (
 
 class DebugControlResult(TypedDict, total=False):
     ip: str
+    started: bool
     exited: bool
     error: str
 
@@ -190,6 +191,15 @@ def list_breakpoints() -> list[Breakpoint]:
     return breakpoints
 
 
+def _get_debug_start_result() -> DebugControlResult | None:
+    ip = ida_dbg.get_ip_val()
+    if ip is not None:
+        return {"started": True, "ip": hex(ip)}
+    if ida_dbg.is_debugger_on():
+        return {"started": True}
+    return None
+
+
 # ============================================================================
 # Debugger Control Operations
 # ============================================================================
@@ -208,10 +218,25 @@ def dbg_start() -> DebugControlResult:
             if addr != ida_idaapi.BADADDR:
                 ida_dbg.add_bpt(addr, 0, idaapi.BPT_SOFT)
 
-    if idaapi.start_process("", "", "") == 1:
-        ip = ida_dbg.get_ip_val()
-        if ip is not None:
-            return {"ip": hex(ip)}
+    result = idaapi.start_process("", "", "")
+    if result == -1:
+        raise IDAError("Failed to start debugger")
+    if result == 0:
+        raise IDAError("Debugger start was cancelled")
+
+    started = _get_debug_start_result()
+    if started is not None:
+        return started
+
+    for _ in range(5):
+        ida_dbg.wait_for_next_event(
+            ida_dbg.WFNE_ANY | ida_dbg.WFNE_SUSP | ida_dbg.WFNE_SILENT,
+            1,
+        )
+        started = _get_debug_start_result()
+        if started is not None:
+            return started
+
     raise IDAError("Failed to start debugger")
 
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -1,0 +1,58 @@
+"""Tests for debugger control helpers."""
+
+from ..framework import test
+from .. import api_debug
+
+
+class _SavedAttr:
+    def __init__(self, obj, name, value):
+        self.obj = obj
+        self.name = name
+        self.old = getattr(obj, name)
+        setattr(obj, name, value)
+
+    def restore(self):
+        setattr(self.obj, self.name, self.old)
+
+
+@test()
+def test_dbg_start_reports_success_when_debugger_is_running_without_ip():
+    """dbg_start should report success even if IP is not immediately available after launch."""
+    patches = [
+        _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+        _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 1),
+        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: None),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+    ]
+    try:
+        result = api_debug.dbg_start()
+        assert result == {"started": True}
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_start_waits_briefly_for_first_ip():
+    """dbg_start should wait for the first suspend event before giving up on IP reporting."""
+    calls = {"waits": 0}
+    ip_values = iter([None, None, 0x401000])
+
+    def wait_for_next_event(_flags, _timeout):
+        calls["waits"] += 1
+        return 1
+
+    patches = [
+        _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+        _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 1),
+        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: next(ip_values)),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: False),
+        _SavedAttr(api_debug.ida_dbg, "wait_for_next_event", wait_for_next_event),
+    ]
+    try:
+        result = api_debug.dbg_start()
+        assert result == {"started": True, "ip": "0x401000"}
+        assert calls["waits"] >= 1
+    finally:
+        for patch in reversed(patches):
+            patch.restore()


### PR DESCRIPTION
idaapi.start_process() is asynchronous. The old implementation only reported success if get_ip_val() was immediately available after launch.
In some cases the debugger starts correctly, but the initial IP is not populated yet, causing a false failure.

The fix is to treat start_process() == 1 as a successful launch attempt.
We briefly wait for debugger events to fetch the initial IP. If none is available, the call still succeeds, just without IP.
That should be fine, as the application could be running and doesn't necessarily need to break right away.