### PR TITLE
Fix dbg_bps schema mismatch by normalizing breakpoint enabled to bool

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -183,7 +183,7 @@ def list_breakpoints() -> list[Breakpoint]:
             breakpoints.append(
                 Breakpoint(
                     addr=hex(bpt.ea),
-                    enabled=bpt.flags & ida_dbg.BPT_ENABLED,
+                    enabled=bool(bpt.flags & ida_dbg.BPT_ENABLED),
                     condition=str(bpt.condition) if bpt.condition else None,
                 )
             )


### PR DESCRIPTION
`dbg_bps` could fail MCP structured-output validation because breakpoint enabled values were returned as integers instead of booleans.