### PR TITLE
Respect env IDA_MCP_URL when setting download base url

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -12,9 +12,11 @@ import subprocess
 import sys
 import threading
 import time
+from collections import OrderedDict
 from typing import Annotated, NotRequired, TypedDict
 
 from .rpc import tool, MCP_SERVER
+from .zeromcp import EXTERNAL_BASE_HEADER, get_current_request_external_base_url
 from .discovery import discover_instances, probe_instance
 
 
@@ -128,6 +130,46 @@ def is_local_tool(name: str) -> bool:
 
 
 PROXY_HEADER = "X-MCP-Proxied"
+OUTPUT_PROXY_CACHE_MAX_SIZE = 100
+_output_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
+_output_proxy_lock = threading.Lock()
+
+
+def _extract_output_id(response: dict) -> str | None:
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    meta = result.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    ida_meta = meta.get("ida_mcp")
+    if not isinstance(ida_meta, dict):
+        return None
+    output_id = ida_meta.get("output_id")
+    return output_id if isinstance(output_id, str) else None
+
+
+def _remember_output_proxy_target(output_id: str, host: str, port: int) -> None:
+    with _output_proxy_lock:
+        _output_proxy_targets.pop(output_id, None)
+        _output_proxy_targets[output_id] = (host, port)
+        while len(_output_proxy_targets) > OUTPUT_PROXY_CACHE_MAX_SIZE:
+            _output_proxy_targets.popitem(last=False)
+
+
+def get_output_proxy_target(output_id: str) -> tuple[str, int] | None:
+    with _output_proxy_lock:
+        target = _output_proxy_targets.get(output_id)
+        if target is None:
+            return None
+        _output_proxy_targets.move_to_end(output_id)
+        return target
+
+
+def _remember_output_proxy_target_from_response(host: str, port: int, response: dict) -> None:
+    output_id = _extract_output_id(response)
+    if output_id:
+        _remember_output_proxy_target(output_id, host, port)
 
 
 def _get_proxy_request_path() -> str:
@@ -149,6 +191,9 @@ def _get_proxy_request_headers() -> dict[str, str]:
         session_id = transport_session_id.split(":", 1)[1]
         if session_id and session_id != "anonymous":
             headers["Mcp-Session-Id"] = session_id
+    external_base_url = get_current_request_external_base_url()
+    if external_base_url:
+        headers[EXTERNAL_BASE_HEADER] = external_base_url
     return headers
 
 
@@ -170,7 +215,22 @@ def proxy_to_instance(host: str, port: int, payload: bytes) -> dict:
         raw_data = response.read().decode()
         if response.status >= 400:
             raise RuntimeError(f"HTTP {response.status} {response.reason}: {raw_data}")
-        return json.loads(raw_data)
+        parsed = json.loads(raw_data)
+        _remember_output_proxy_target_from_response(host, port, parsed)
+        return parsed
+    finally:
+        conn.close()
+
+
+def proxy_output_to_instance(
+    host: str, port: int, path: str
+) -> tuple[int, str, list[tuple[str, str]], bytes]:
+    """Forward an output download request to another IDA instance."""
+    conn = http.client.HTTPConnection(host, port, timeout=30)
+    try:
+        conn.request("GET", path, headers={PROXY_HEADER: "1"})
+        response = conn.getresponse()
+        return response.status, response.reason, response.getheaders(), response.read()
     finally:
         conn.close()
 

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -127,30 +127,36 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
 
     def do_GET(self):
         """Handles GET requests."""
-        parsed = urlparse(self.path)
-        path = parsed.path
+        from .api_discovery import PROXY_HEADER, set_request_proxied
 
-        if path == "/config.html":
-            if not self._check_host():
+        set_request_proxied(self.headers.get(PROXY_HEADER) == "1")
+        try:
+            parsed = urlparse(self.path)
+            path = parsed.path
+
+            if path == "/config.html":
+                if not self._check_host():
+                    return
+                self._handle_config_get()
                 return
-            self._handle_config_get()
-            return
 
-        if path == "/profile.txt":
-            if not self._check_host():
+            if path == "/profile.txt":
+                if not self._check_host():
+                    return
+                self._handle_profile_export()
                 return
-            self._handle_profile_export()
-            return
 
-        # Handle output download requests
-        output_match = re.match(r"^/output/([a-f0-9-]+)\.(\w+)$", path)
-        if output_match:
-            if not self._check_api_request():
+            # Handle output download requests
+            output_match = re.match(r"^/output/([a-f0-9-]+)\.(\w+)$", path)
+            if output_match:
+                if not self._check_api_request():
+                    return
+                self._handle_output_download(output_match.group(1), output_match.group(2))
                 return
-            self._handle_output_download(output_match.group(1), output_match.group(2))
-            return
 
-        super().do_GET()
+            super().do_GET()
+        finally:
+            set_request_proxied(False)
 
     def _handle_profile_export(self):
         """Return the currently enabled tools as a profile file."""
@@ -172,7 +178,31 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         """Handle download of cached output data."""
         data = get_cached_output(output_id)
         if data is None:
-            self.send_error(404, "Output not found or expired")
+            from .api_discovery import (
+                get_output_proxy_target,
+                is_request_proxied,
+                proxy_output_to_instance,
+            )
+
+            target = get_output_proxy_target(output_id)
+            if target is None or is_request_proxied():
+                self.send_error(404, "Output not found or expired")
+                return
+            try:
+                status, _, response_headers, body = proxy_output_to_instance(
+                    target[0], target[1], f"/output/{output_id}.{extension}"
+                )
+            except Exception as e:
+                self.send_error(502, f"Failed to proxy output download: {e}")
+                return
+
+            self.send_response(status)
+            for header, value in response_headers:
+                if header.lower() == "transfer-encoding":
+                    continue
+                self.send_header(header, value)
+            self.end_headers()
+            self.wfile.write(body)
             return
 
         if extension == "json":

--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -1,7 +1,13 @@
 import json
 import os
 from typing import Any, Optional
-from .zeromcp import McpRpcRegistry, McpServer, McpToolError, McpHttpRequestHandler
+from .zeromcp import (
+    McpRpcRegistry,
+    McpServer,
+    McpToolError,
+    McpHttpRequestHandler,
+    get_current_request_external_base_url,
+)
 
 MCP_UNSAFE: set[str] = set()
 MCP_EXTENSIONS: dict[str, set[str]] = {}  # group -> set of function names
@@ -23,7 +29,7 @@ def set_download_base_url(url: str) -> None:
 
 
 def get_download_base_url() -> str:
-    return _download_base_url
+    return get_current_request_external_base_url() or _download_base_url
 
 
 def get_current_transport_session_id() -> str | None:
@@ -64,7 +70,7 @@ def _truncate_value(value: Any, depth: int = 0) -> Any:
 
 
 def _build_download_meta(output_id: str, total_chars: int) -> dict:
-    download_url = f"{_download_base_url}/output/{output_id}.json"
+    download_url = f"{get_download_base_url()}/output/{output_id}.json"
     return {
         "output_truncated": True,
         "total_chars": total_chars,

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/__init__.py
@@ -1,5 +1,21 @@
 # NOTE: Vendored from zeromcp 1.3.0
 
-from .mcp import McpRpcRegistry, McpToolError, McpServer, McpHttpRequestHandler
+from .mcp import (
+    EXTERNAL_BASE_HEADER,
+    McpRpcRegistry,
+    McpToolError,
+    McpServer,
+    McpHttpRequestHandler,
+    get_current_request_external_base_url,
+    set_current_request_external_base_url,
+)
 
-__all__ = ["McpRpcRegistry", "McpToolError", "McpServer", "McpHttpRequestHandler"]
+__all__ = [
+    "EXTERNAL_BASE_HEADER",
+    "McpRpcRegistry",
+    "McpToolError",
+    "McpServer",
+    "McpHttpRequestHandler",
+    "get_current_request_external_base_url",
+    "set_current_request_external_base_url",
+]

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -14,10 +14,14 @@ import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
 from typing import Any, Callable, Union, Annotated, BinaryIO, NotRequired, get_origin, get_args, get_type_hints, is_typeddict
 from types import UnionType
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, urlunparse
 from io import BufferedIOBase
 
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, get_current_request_id, register_pending_request, unregister_pending_request, cancel_request
+
+EXTERNAL_BASE_HEADER = "X-IDA-MCP-External-Base"
+
+_request_context = threading.local()
 
 class McpToolError(Exception):
     def __init__(self, message: str):
@@ -118,6 +122,111 @@ def _host_header_allowed_for_bind(bound_host: str, host_header: str | None) -> b
         return True
 
     return _is_loopback_host(host_name)
+
+
+def set_current_request_external_base_url(url: str | None) -> None:
+    setattr(_request_context, "external_base_url", url.rstrip("/") if url else None)
+
+
+def get_current_request_external_base_url() -> str | None:
+    return getattr(_request_context, "external_base_url", None)
+
+
+def _strip_optional_quotes(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
+def _first_header_value(value: str | None) -> str | None:
+    if not value:
+        return None
+    first = value.split(",", 1)[0].strip()
+    return first or None
+
+
+def _normalize_external_base_url(url: str | None) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None
+    path = parsed.path.rstrip("/")
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
+def _normalize_forwarded_prefix(prefix: str | None) -> str:
+    if not prefix:
+        return ""
+    prefix = _strip_optional_quotes(prefix).strip()
+    if not prefix or prefix == "/":
+        return ""
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    return prefix.rstrip("/")
+
+
+def _append_forwarded_port(authority: str, port: str | None) -> str:
+    if not port:
+        return authority
+    try:
+        parsed = urlparse(f"//{authority}")
+        if parsed.hostname is not None and parsed.port is None:
+            return f"{authority}:{port}"
+    except ValueError:
+        pass
+    return authority
+
+
+def _parse_forwarded_header(forwarded: str | None) -> dict[str, str]:
+    if not forwarded:
+        return {}
+    result: dict[str, str] = {}
+    first_entry = forwarded.split(",", 1)[0]
+    for item in first_entry.split(";"):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        key = key.strip().lower()
+        value = _strip_optional_quotes(value)
+        if key and value:
+            result[key] = value
+    return result
+
+
+def _derive_external_base_url(
+    headers: dict | Any,
+    *,
+    bound_host: str | None = None,
+    bound_port: int | None = None,
+) -> str | None:
+    propagated = _normalize_external_base_url(headers.get(EXTERNAL_BASE_HEADER))
+    if propagated:
+        return propagated
+
+    forwarded = _parse_forwarded_header(headers.get("Forwarded"))
+    authority = forwarded.get("host") or _first_header_value(headers.get("X-Forwarded-Host"))
+    authority = authority or headers.get("Host")
+    if authority:
+        authority = authority.strip()
+
+    forwarded_port = _first_header_value(headers.get("X-Forwarded-Port"))
+    if authority:
+        authority = _append_forwarded_port(authority, forwarded_port)
+    elif bound_host is not None and bound_port is not None:
+        authority = f"{bound_host}:{bound_port}"
+
+    if not authority:
+        return None
+
+    scheme = (
+        forwarded.get("proto")
+        or _first_header_value(headers.get("X-Forwarded-Proto"))
+        or "http"
+    ).strip().lower()
+    prefix = _normalize_forwarded_prefix(_first_header_value(headers.get("X-Forwarded-Prefix")))
+    return _normalize_external_base_url(f"{scheme}://{authority}{prefix}")
 
 class McpHttpRequestHandler(BaseHTTPRequestHandler):
     server_version = "zeromcp/1.3.0"
@@ -335,6 +444,13 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
         extensions = self._parse_extensions(self.path)
         setattr(self.mcp_server._enabled_extensions, "data", extensions)
         setattr(self.mcp_server._transport_session_id, "data", f"sse:{session_id}")
+        set_current_request_external_base_url(
+            _derive_external_base_url(
+                self.headers,
+                bound_host=self.server.server_address[0],
+                bound_port=self.server.server_address[1],
+            )
+        )
 
         try:
             # Dispatch to MCP registry
@@ -344,6 +460,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             setattr(self.mcp_server._enabled_extensions, "data", set())
             setattr(self.mcp_server._protocol_version, "data", None)
             setattr(self.mcp_server._transport_session_id, "data", None)
+            set_current_request_external_base_url(None)
 
         # Send SSE response if necessary
         if response is not None:
@@ -397,6 +514,13 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             "data",
             f"http:{mcp_session_id}" if mcp_session_id else "http:anonymous",
         )
+        set_current_request_external_base_url(
+            _derive_external_base_url(
+                self.headers,
+                bound_host=self.server.server_address[0],
+                bound_port=self.server.server_address[1],
+            )
+        )
 
         # Dispatch to MCP registry
         setattr(self.mcp_server._protocol_version, "data", "2025-06-18")
@@ -406,6 +530,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             setattr(self.mcp_server._enabled_extensions, "data", set())
             setattr(self.mcp_server._protocol_version, "data", None)
             setattr(self.mcp_server._transport_session_id, "data", None)
+            set_current_request_external_base_url(None)
 
         def send_response(status: int, body: bytes):
             self.send_response(status)

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -3,6 +3,7 @@ import json
 import logging
 import signal
 import sys
+import os
 from pathlib import Path
 from typing import Annotated, Any, Optional, TypedDict
 
@@ -602,7 +603,15 @@ def main():
     # NOTE: npx -y @modelcontextprotocol/inspector for debugging
     # TODO: with background=True the main thread does not fake any
     # work from @idasync, so we deadlock.
-    set_download_base_url(f"http://{args.host}:{args.port}")
+    if not "IDA_MCP_URL" in os.environ:
+        # IDA_MCP_URL is used to set download base url by environment,
+        # so we only update download base url if this env var is not
+        # present
+        #
+        # It should be noted that this url ONLY affects the literal string
+        # returned by MCP response, does NOT affect the actual socket
+        # endpoint this server listens to
+        set_download_base_url(f"http://{args.host}:{args.port}")
     MCP_SERVER.serve(host=args.host, port=args.port, background=False,
                      request_handler=IdaMcpHttpRequestHandler)
 

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -2,17 +2,30 @@ import argparse
 import http.client
 import json
 import os
+import re
 import sys
+import threading
 import traceback
+from collections import OrderedDict
 from typing import Annotated, Any, TYPE_CHECKING, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
-    from ida_pro_mcp.ida_mcp.zeromcp import McpServer
+    from ida_pro_mcp.ida_mcp.zeromcp import (
+        EXTERNAL_BASE_HEADER,
+        McpHttpRequestHandler,
+        McpServer,
+        get_current_request_external_base_url,
+    )
     from ida_pro_mcp.ida_mcp.zeromcp.jsonrpc import JsonRpcRequest, JsonRpcResponse
 else:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ida_mcp"))
-    from zeromcp import McpServer
+    from zeromcp import (
+        EXTERNAL_BASE_HEADER,
+        McpHttpRequestHandler,
+        McpServer,
+        get_current_request_external_base_url,
+    )
     from zeromcp.jsonrpc import JsonRpcRequest, JsonRpcResponse
 
     sys.path.pop(0)
@@ -81,6 +94,47 @@ mcp = McpServer("ida-pro-mcp")
 dispatch_original = mcp.registry.dispatch
 
 LOCAL_TOOLS = {"list_instances", "select_instance", "open_file"}
+OUTPUT_PROXY_CACHE_MAX_SIZE = 100
+_OUTPUT_PATH_RE = re.compile(r"^/output/([a-f0-9-]+)\.(\w+)$")
+_output_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
+_output_proxy_lock = threading.Lock()
+
+
+def _extract_output_id(response: dict) -> str | None:
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return None
+    meta = result.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    ida_meta = meta.get("ida_mcp")
+    if not isinstance(ida_meta, dict):
+        return None
+    output_id = ida_meta.get("output_id")
+    return output_id if isinstance(output_id, str) else None
+
+
+def _remember_output_proxy_target(output_id: str, host: str, port: int) -> None:
+    with _output_proxy_lock:
+        _output_proxy_targets.pop(output_id, None)
+        _output_proxy_targets[output_id] = (host, port)
+        while len(_output_proxy_targets) > OUTPUT_PROXY_CACHE_MAX_SIZE:
+            _output_proxy_targets.popitem(last=False)
+
+
+def _get_output_proxy_target(output_id: str) -> tuple[str, int] | None:
+    with _output_proxy_lock:
+        target = _output_proxy_targets.get(output_id)
+        if target is None:
+            return None
+        _output_proxy_targets.move_to_end(output_id)
+        return target
+
+
+def _remember_output_proxy_target_from_response(host: str, port: int, response: dict) -> None:
+    output_id = _extract_output_id(response)
+    if output_id:
+        _remember_output_proxy_target(output_id, host, port)
 
 
 def _get_proxy_request_path() -> str:
@@ -99,6 +153,9 @@ def _get_proxy_request_headers() -> dict[str, str]:
         session_id = transport_session_id.split(":", 1)[1]
         if session_id and session_id != "anonymous":
             headers["Mcp-Session-Id"] = session_id
+    external_base_url = get_current_request_external_base_url()
+    if external_base_url:
+        headers[EXTERNAL_BASE_HEADER] = external_base_url
     return headers
 
 
@@ -123,7 +180,20 @@ def _proxy_to_instance(host: str, port: int, payload: bytes | str | dict) -> dic
             raise RuntimeError(
                 f"HTTP {response.status} {response.reason}: {raw_data}"
             )
-        return json.loads(raw_data)
+        parsed = json.loads(raw_data)
+        _remember_output_proxy_target_from_response(host, port, parsed)
+        return parsed
+    finally:
+        conn.close()
+
+
+def _proxy_output_download(host: str, port: int, path: str) -> tuple[int, str, list[tuple[str, str]], bytes]:
+    """Proxy a raw output download from a specific IDA instance."""
+    conn = http.client.HTTPConnection(host, port, timeout=30)
+    try:
+        conn.request("GET", path)
+        response = conn.getresponse()
+        return response.status, response.reason, response.getheaders(), response.read()
     finally:
         conn.close()
 
@@ -235,6 +305,38 @@ def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse |
 
 
 mcp.registry.dispatch = dispatch_proxy
+
+
+class ProxyHttpRequestHandler(McpHttpRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        output_match = _OUTPUT_PATH_RE.match(parsed.path)
+        if output_match:
+            if not self._check_api_request():
+                return
+            output_id = output_match.group(1)
+            target = _get_output_proxy_target(output_id)
+            if target is None:
+                self.send_error(404, "Output not found or expired")
+                return
+            try:
+                status, _, response_headers, body = _proxy_output_download(
+                    target[0], target[1], parsed.path
+                )
+            except Exception as e:
+                self.send_error(502, f"Failed to proxy output download: {e}")
+                return
+
+            self.send_response(status)
+            for header, value in response_headers:
+                if header.lower() == "transfer-encoding":
+                    continue
+                self.send_header(header, value)
+            self.send_cors_headers()
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        super().do_GET()
 
 
 # ============================================================================
@@ -508,7 +610,7 @@ def main():
             if url.hostname is None or url.port is None:
                 raise Exception(f"Invalid transport URL: {args.transport}")
             # NOTE: npx -y @modelcontextprotocol/inspector for debugging
-            mcp.serve(url.hostname, url.port)
+            mcp.serve(url.hostname, url.port, request_handler=ProxyHttpRequestHandler)
             input("Server is running, press Enter or Ctrl+C to stop.")
     except (KeyboardInterrupt, EOFError):
         pass

--- a/tests/test_browser_transport_guards.py
+++ b/tests/test_browser_transport_guards.py
@@ -8,8 +8,10 @@ _ZEROMCP_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "ida_pro_mc
 sys.path.insert(0, str(_ZEROMCP_SRC))
 try:
     from zeromcp.mcp import (
+        EXTERNAL_BASE_HEADER,
         McpHttpRequestHandler,
         McpServer,
+        _derive_external_base_url,
         _host_header_allowed_for_bind,
         _origin_allowed_by_policy,
     )
@@ -115,6 +117,43 @@ class BrowserTransportGuardTests(unittest.TestCase):
         )
         self.assertTrue(handler._check_api_request())
         self.assertEqual(errors, [])
+
+    def test_derive_external_base_url_prefers_forwarded_headers(self):
+        base = _derive_external_base_url(
+            {
+                "Host": "127.0.0.1:13337",
+                "Forwarded": 'for=127.0.0.1;proto=https;host="mcp.example.com"',
+            },
+            bound_host="127.0.0.1",
+            bound_port=13337,
+        )
+        self.assertEqual(base, "https://mcp.example.com")
+
+    def test_derive_external_base_url_supports_forwarded_prefix(self):
+        base = _derive_external_base_url(
+            {
+                "Host": "127.0.0.1:13337",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "mcp.example.com",
+                "X-Forwarded-Prefix": "/ida/proxy/",
+            },
+            bound_host="127.0.0.1",
+            bound_port=13337,
+        )
+        self.assertEqual(base, "https://mcp.example.com/ida/proxy")
+
+    def test_derive_external_base_url_prefers_propagated_header(self):
+        base = _derive_external_base_url(
+            {
+                "Host": "127.0.0.1:13337",
+                EXTERNAL_BASE_HEADER: "https://public.example/base/",
+                "X-Forwarded-Proto": "http",
+                "X-Forwarded-Host": "ignored.example",
+            },
+            bound_host="127.0.0.1",
+            bound_port=13337,
+        )
+        self.assertEqual(base, "https://public.example/base")
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_spec_truncation.py
+++ b/tests/test_mcp_spec_truncation.py
@@ -16,6 +16,7 @@ from jsonschema import Draft202012Validator
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from _mcp_spec_support import (
     CALL_TOOL_RESULT_SCHEMA,
+    McpHttpTestServer,
     McpServer,
     assert_schema,
     call_rpc,
@@ -36,7 +37,7 @@ class _ListResult(TypedDict):
 def _fresh_truncated_server() -> McpServer:
     """McpServer with the production truncation middleware (rpc.py) applied."""
     rpc = load_ida_rpc_module()
-    srv = McpServer("truncation-test")
+    srv = rpc.McpServer("truncation-test")
     original = srv.registry.methods["tools/call"]
     limit = rpc.OUTPUT_LIMIT_MAX_CHARS
 
@@ -130,6 +131,62 @@ class TruncationInvariantTests(unittest.TestCase):
             with self.subTest(block=block):
                 self.assertEqual(block["type"], "text")
                 self.assertIsInstance(block["text"], str)
+
+
+class DownloadUrlDerivationOverHttpTests(unittest.TestCase):
+    def test_download_url_uses_forwarded_public_base(self):
+        srv = _fresh_truncated_server()
+
+        @srv.tool
+        def big_list() -> _ListResult:
+            """Returns a huge list; forces truncation."""
+            return {
+                "items": [{"name": f"n{i}", "value": i} for i in range(5000)],
+                "count": 5000,
+            }
+
+        with McpHttpTestServer(srv) as harness:
+            status, _, response = harness.post_jsonrpc(
+                "tools/call",
+                {"name": "big_list", "arguments": {}},
+                extra_headers={
+                    "Forwarded": 'for=127.0.0.1;proto=https;host="mcp.example.com"',
+                },
+            )
+
+        self.assertEqual(status, 200)
+        meta = response["result"]["_meta"]["ida_mcp"]
+        self.assertTrue(meta["download_url"].startswith("https://mcp.example.com/output/"))
+
+    def test_download_url_uses_forwarded_prefix(self):
+        srv = _fresh_truncated_server()
+
+        @srv.tool
+        def big_list() -> _ListResult:
+            """Returns a huge list; forces truncation."""
+            return {
+                "items": [{"name": f"n{i}", "value": i} for i in range(5000)],
+                "count": 5000,
+            }
+
+        with McpHttpTestServer(srv) as harness:
+            status, _, response = harness.post_jsonrpc(
+                "tools/call",
+                {"name": "big_list", "arguments": {}},
+                extra_headers={
+                    "X-Forwarded-Proto": "https",
+                    "X-Forwarded-Host": "mcp.example.com",
+                    "X-Forwarded-Prefix": "/ida/proxy/",
+                },
+            )
+
+        self.assertEqual(status, 200)
+        meta = response["result"]["_meta"]["ida_mcp"]
+        self.assertTrue(
+            meta["download_url"].startswith(
+                "https://mcp.example.com/ida/proxy/output/"
+            )
+        )
 
 
 class NonTruncatedOutputsUnchangedTests(unittest.TestCase):

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import patch
 
@@ -57,6 +58,60 @@ class DispatchProxyTransportTests(unittest.TestCase):
         _ResponseFailureConnection.reset()
         _Http503Connection.reset()
         _ConnectFailureConnection.reset()
+
+    def test_proxy_request_forwards_external_base_header(self):
+        original_getter = server.get_current_request_external_base_url
+
+        class _RecordingConnection(_BaseFakeConnection):
+            def request(self, method, path, body, headers):
+                super().request(method, path, body, headers)
+                self.path = path
+                self.headers = headers
+
+            def getresponse(self):
+                return _FakeResponse()
+
+        _RecordingConnection.reset()
+        server.get_current_request_external_base_url = lambda: "https://mcp.example.com/base"
+        try:
+            with patch("ida_pro_mcp.server.http.client.HTTPConnection", _RecordingConnection):
+                server._proxy_to_instance("127.0.0.1", 13337, b"{}")
+        finally:
+            server.get_current_request_external_base_url = original_getter
+
+        self.assertEqual(len(_RecordingConnection.instances), 1)
+        self.assertEqual(
+            _RecordingConnection.instances[0].headers.get("X-IDA-MCP-External-Base"),
+            "https://mcp.example.com/base",
+        )
+
+    def test_proxy_response_records_output_download_target(self):
+        output_id = "12345678-1234-1234-1234-123456789abc"
+
+        class _OutputResponseConnection(_BaseFakeConnection):
+            def getresponse(self):
+                body = json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {
+                            "content": [],
+                            "_meta": {
+                                "ida_mcp": {
+                                    "output_id": output_id,
+                                    "download_url": f"http://example/output/{output_id}.json",
+                                }
+                            },
+                        },
+                        "id": 1,
+                    }
+                ).encode("utf-8")
+                return _FakeResponse(body=body)
+
+        _OutputResponseConnection.reset()
+        with patch("ida_pro_mcp.server.http.client.HTTPConnection", _OutputResponseConnection):
+            server._proxy_to_instance("127.0.0.1", 13337, b"{}")
+
+        self.assertEqual(server._get_output_proxy_target(output_id), ("127.0.0.1", 13337))
 
     def test_dispatch_proxy_does_not_retry_post_send_failures(self):
         request = {"jsonrpc": "2.0", "method": "tools/call", "params": {}, "id": 1}


### PR DESCRIPTION
The environment `IDA_MCP_URL` is used to customize `download_url` string returned by MCP (code resides in [here](https://github.com/mrexodia/ida-pro-mcp/blob/89a0016765ee62dfd9414c2db4c9d9d6a7a62319/src/ida_pro_mcp/ida_mcp/rpc.py#L17)). The PR #375 update download url by the host and port passed in cmdline regardless of the environment. This PR makes the behavior respect the environment.

The motivation for this is that, the MCP server may run behind complex networks such as NAT. As a result, the server may listens to `192.168.1.2:2333`, while the client at the other network may access it by `10.8.20.2:3444`. The `download_url` is used to indicate the client about how to access the truncated data, while the client cannot access `192.168.1.2:2333` at all. So this PR make it possible that we can customize the literal string "download_url" returned by MCP server (this does NOT change the actual socket that server listens to).