### PR TITLE
Replace idalib-mcp with supervisor worker architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ def dangerous_op(...):
 ```bash
 uv run ida-pro-mcp
 uv run ida-pro-mcp --transport http://127.0.0.1:8744/sse
+uv run idalib-mcp --stdio path/to/binary
 uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/binary
 uv run idalib-mcp --isolated-contexts --host 127.0.0.1 --port 8745 path/to/binary
 uv run ida-pro-mcp --unsafe

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ _Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://githu
 
 `idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Starting without an `input_path` is supported; use `idalib_open(input_path, ...)` to open databases dynamically and `idalib_close(session_id)` to close them. This allows one headless MCP server to work with arbitrary files over its lifetime.
 
+If the requested IDB is already open in a GUI IDA instance running the plugin, `idalib-mcp` will use that GUI instance instead of spawning a duplicate headless worker. If the GUI instance later disappears, the next routed request reopens the database in a headless worker when possible. Unsaved GUI-only changes must be saved first if they should be visible after fallback.
+
 Tools target either the database bound to the current MCP context or an explicit `database` argument.
 
 ```sh
@@ -210,7 +212,7 @@ With `--isolated-contexts`, strict Streamable HTTP session semantics are enabled
 - `idalib_switch(session_id)`: Rebind the active context policy to an existing session.
 - `idalib_current()`: Return the session bound to the active context policy.
 - `idalib_unbind()`: Remove the active context binding.
-- `idalib_list()`: Includes `is_active`, `is_current_context`, `bound_contexts`, and `worker_pid`.
+- `idalib_list()`: Includes `is_active`, `is_current_context`, `bound_contexts`, backend (`worker` or `gui`), and process IDs.
 
 Worker controls:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Another thing to keep in mind is that LLMs will not perform well on obfuscated c
 
 You should also use a tool like Lumina or FLIRT to try and resolve all the open source library code and the C++ STL, this will further improve the accuracy.
 
-## SSE Transport & Headless MCP
+## Transports & Headless MCP
 
 You can run an SSE server to connect to the user interface like this:
 
@@ -138,15 +138,47 @@ You can run an SSE server to connect to the user interface like this:
 uv run ida-pro-mcp --transport http://127.0.0.1:8744/sse
 ```
 
-After installing [`idalib`](https://docs.hex-rays.com/user-guide/idalib) you can also run a headless SSE server:
+After installing [`idalib`](https://docs.hex-rays.com/user-guide/idalib) you can also run a headless MCP server. You can start with an initial binary:
 
 ```sh
 uv run idalib-mcp --host 127.0.0.1 --port 8745 path/to/executable
 ```
 
+Or start without a binary and open/close arbitrary files later with `idalib_open(...)` / `idalib_close(...)`:
+
+```sh
+uv run idalib-mcp --host 127.0.0.1 --port 8745
+```
+
+For stdio-based clients, use:
+
+```sh
+uv run idalib-mcp --stdio
+```
+
 _Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://github.com/williballenthin).
 
 ## Headless idalib Session Model
+
+`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Starting without an `input_path` is supported; use `idalib_open(input_path, ...)` to open databases dynamically and `idalib_close(session_id)` to close them. This allows one headless MCP server to work with arbitrary files over its lifetime.
+
+Tools target either the database bound to the current MCP context or an explicit `database` argument.
+
+```sh
+uv run idalib-mcp --stdio --max-workers 4
+```
+
+Typical flow:
+
+```python
+idalib_open("/path/to/binary_a.exe", session_id="binary_a")
+idalib_open("/path/to/library.dll", session_id="library")
+
+decompile("main", database="binary_a")
+xrefs_to("ImportantExport", database="library")
+```
+
+`database` accepts a session ID, filename, or input path. If omitted, tools use the database bound to the active context.
 
 Use `--isolated-contexts` to enable strict per-transport isolation:
 
@@ -158,15 +190,14 @@ uv run idalib-mcp --isolated-contexts --host 127.0.0.1 --port 8745 path/to/execu
 
 Use it when multiple agents connect to the same `idalib-mcp` server and you want deterministic context isolation:
 
-- Prevent one agent from changing another agent's active session accidentally.
-- Run concurrent analyses safely (for example agent A on binary X and agent B on binary Y).
-- Still allow intentional collaboration by binding multiple agents to the same open session ID.
-- Improve reproducibility because each agent's context binding is explicit.
+- Prevent one agent from changing another agent's active database accidentally.
+- Keep each transport context's default database explicit.
+- Still allow intentional collaboration by passing `database=...` or binding multiple agents to the same session ID.
 
 When `--isolated-contexts` is enabled:
 
 - Each transport context has its own binding (`Mcp-Session-Id` for `/mcp`, `session` for `/sse`, `stdio:default` for stdio).
-- Unbound contexts fail fast for IDB-dependent tools/resources.
+- Unbound contexts fail fast for IDB-dependent tools/resources unless `database` is provided.
 - `idalib_switch(session_id)` and `idalib_open(...)` bind the caller context only.
 
 ### Streamable HTTP behavior
@@ -175,11 +206,16 @@ With `--isolated-contexts`, strict Streamable HTTP session semantics are enabled
 
 ### Context tools
 
-- `idalib_open(input_path, ...)`: Open binary and bind it to the active context policy.
+- `idalib_open(input_path, ...)`: Open binary in a worker and bind it to the active context policy.
 - `idalib_switch(session_id)`: Rebind the active context policy to an existing session.
 - `idalib_current()`: Return the session bound to the active context policy.
 - `idalib_unbind()`: Remove the active context binding.
-- `idalib_list()`: Includes `is_active`, `is_current_context`, and `bound_contexts`.
+- `idalib_list()`: Includes `is_active`, `is_current_context`, `bound_contexts`, and `worker_pid`.
+
+Worker controls:
+
+- `--max-workers N`: maximum simultaneous database workers (`0` = unlimited, default `4`).
+- `IDA_MCP_MAX_WORKERS`: environment default for `--max-workers`.
 
 
 ## MCP Resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 ida-pro-mcp = "ida_pro_mcp.server:main"
-idalib-mcp = "ida_pro_mcp.idalib_server:main"
+idalib-mcp = "ida_pro_mcp.idalib_supervisor:main"
 ida-mcp-test = "ida_pro_mcp.test:main"
 
 [tool.pyright]

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -1,5 +1,6 @@
 """Core API Functions - IDB metadata and basic queries"""
 
+import logging
 import re
 import time
 from typing import Annotated, Any, NotRequired, TypedDict
@@ -38,6 +39,9 @@ from .utils import (
     paginate,
     pattern_filter,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class ServerHealthResult(TypedDict):
@@ -158,7 +162,7 @@ def init_caches():
     t0 = time.perf_counter()
     strings = _get_strings_cache()
     t1 = time.perf_counter()
-    print(f"[MCP] Cached {len(strings)} strings in {(t1 - t0) * 1000:.0f}ms")
+    logger.info("[MCP] Cached %d strings in %.0fms", len(strings), (t1 - t0) * 1000)
 
 
 # ============================================================================

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -1,5 +1,6 @@
 import html
 import json
+import logging
 import re
 import ida_netnode
 from urllib.parse import urlparse, parse_qs
@@ -17,6 +18,8 @@ from .rpc import (
 )
 
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T")
 
 
@@ -29,8 +32,11 @@ def config_json_get(key: str, default: T) -> T:
     try:
         return json.loads(json_blob)
     except Exception as e:
-        print(
-            f"[WARNING] Invalid JSON stored in netnode '{key}': '{json_blob}' from netnode: {e}"
+        logger.warning(
+            "Invalid JSON stored in netnode %r: %r from netnode: %s",
+            key,
+            json_blob,
+            e,
         )
         return default
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -67,6 +67,7 @@ def _saved_target():
     old_session = getattr(server.mcp._transport_session_id, "data", None)
     old_exts = getattr(server.mcp._enabled_extensions, "data", set())
     old_targets = server._session_proxy_targets.copy()
+    old_target_last_seen = server._session_proxy_last_seen.copy()
     try:
         yield
     finally:
@@ -74,6 +75,8 @@ def _saved_target():
         server.IDA_PORT = old_port
         server._session_proxy_targets.clear()
         server._session_proxy_targets.update(old_targets)
+        server._session_proxy_last_seen.clear()
+        server._session_proxy_last_seen.update(old_target_last_seen)
         server.mcp._transport_session_id.data = old_session
         server.mcp._enabled_extensions.data = old_exts
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -2,6 +2,7 @@
 
 import argparse
 import contextlib
+import json
 import os
 import sys
 
@@ -65,11 +66,14 @@ def _saved_target():
     old_port = server.IDA_PORT
     old_session = getattr(server.mcp._transport_session_id, "data", None)
     old_exts = getattr(server.mcp._enabled_extensions, "data", set())
+    old_targets = server._session_proxy_targets.copy()
     try:
         yield
     finally:
         server.IDA_HOST = old_host
         server.IDA_PORT = old_port
+        server._session_proxy_targets.clear()
+        server._session_proxy_targets.update(old_targets)
         server.mcp._transport_session_id.data = old_session
         server.mcp._enabled_extensions.data = old_exts
 
@@ -87,6 +91,82 @@ def test_tools_list_keeps_discovery_and_launch_tools_when_ida_unreachable():
         assert "select_instance" in tool_names
         assert "list_instances" in tool_names
         assert "open_file" in tool_names
+
+
+@test()
+def test_streamable_http_initialize_returns_session_id():
+    """Streamable HTTP initialize should issue a session id for per-client state."""
+    test_mcp = server.McpServer("session-test")
+    test_mcp.serve("127.0.0.1", 0, request_handler=server.McpHttpRequestHandler)
+    port = test_mcp._http_server.server_address[1]
+    conn = server.http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        conn.request("POST", "/mcp", payload, {"Content-Type": "application/json"})
+        response = conn.getresponse()
+        response.read()
+        session_id = response.getheader("Mcp-Session-Id")
+        assert response.status == 200
+        assert session_id, "Expected initialize response to include Mcp-Session-Id"
+        assert test_mcp.has_http_session(session_id)
+    finally:
+        conn.close()
+        test_mcp.stop()
+
+
+@test()
+def test_select_instance_is_scoped_to_transport_session():
+    """Each MCP transport session should keep its own selected proxy target."""
+    with _saved_target():
+        original_probe = server.probe_instance
+        server.probe_instance = lambda host, port: True
+        try:
+            server.mcp._transport_session_id.data = "http:session-a"
+            result_a = server.select_instance(port=11111, host="127.0.0.1")
+            assert result_a["success"] is True
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            result_b = server.select_instance(port=22222, host="127.0.0.1")
+            assert result_b["success"] is True
+
+            server.mcp._transport_session_id.data = "http:session-a"
+            assert server._get_active_ida_target() == ("127.0.0.1", 11111)
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            assert server._get_active_ida_target() == ("127.0.0.1", 22222)
+        finally:
+            server.probe_instance = original_probe
+
+
+@test()
+def test_select_instance_does_not_change_process_default_for_session():
+    """Session-scoped selection must not overwrite the default target for other clients."""
+    with _saved_target():
+        original_probe = server.probe_instance
+        server.probe_instance = lambda host, port: True
+        server.IDA_HOST = "127.0.0.1"
+        server.IDA_PORT = 13337
+        try:
+            server.mcp._transport_session_id.data = "http:session-a"
+            result = server.select_instance(port=14444, host="127.0.0.1")
+            assert result["success"] is True
+            assert (server.IDA_HOST, server.IDA_PORT) == ("127.0.0.1", 13337)
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            assert server._get_active_ida_target() == ("127.0.0.1", 13337)
+        finally:
+            server.probe_instance = original_probe
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
@@ -1,5 +1,6 @@
 import json
 import inspect
+import logging
 import os
 import threading
 import time
@@ -64,6 +65,8 @@ def _parse_bool_env(name: str, default: bool) -> bool:
         return False
     return default
 
+
+logger = logging.getLogger(__name__)
 
 _LOG_REQUESTS = _parse_bool_env("IDA_MCP_LOG_REQUESTS", True)
 _LOG_SKIP_METHODS = {
@@ -138,7 +141,7 @@ class JsonRpcRegistry:
             params_str = json.dumps(params, default=str)
             if len(params_str) > 200:
                 params_str = params_str[:200] + "..."
-            print(f"[MCP] >> {method}({params_str})")
+            logger.debug("[MCP] >> %s(%s)", method, params_str)
 
         # Set current request ID in thread-local for cancellation tracking
         _current_request.id = request_id
@@ -150,7 +153,7 @@ class JsonRpcRegistry:
                 result_str = json.dumps(result, default=str)
                 if len(result_str) > 200:
                     result_str = result_str[:200] + "..."
-                print(f"[MCP] << {method} ({elapsed_ms:.1f}ms) {result_str}")
+                logger.debug("[MCP] << %s (%.1fms) %s", method, elapsed_ms, result_str)
             if is_notification:
                 return None
             return {
@@ -161,7 +164,7 @@ class JsonRpcRegistry:
         except JsonRpcException as e:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             if log_method:
-                print(f"[MCP] << {method} ({elapsed_ms:.1f}ms) ERROR: {e.message}")
+                logger.debug("[MCP] << %s (%.1fms) ERROR: %s", method, elapsed_ms, e.message)
             if is_notification:
                 return None
             return self._error(request_id, e.code, e.message, e.data)
@@ -169,14 +172,14 @@ class JsonRpcRegistry:
             # LSP error code -32800: Request cancelled
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             if log_method:
-                print(f"[MCP] << {method} ({elapsed_ms:.1f}ms) CANCELLED")
+                logger.debug("[MCP] << %s (%.1fms) CANCELLED", method, elapsed_ms)
             if is_notification:
                 return None
             return self._error(request_id, -32800, str(e) or "Request cancelled")
         except Exception as e:
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             if log_method:
-                print(f"[MCP] << {method} ({elapsed_ms:.1f}ms) EXCEPTION: {e}")
+                logger.debug("[MCP] << %s (%.1fms) EXCEPTION: %s", method, elapsed_ms, e)
             if is_notification:
                 return None
             error = self.map_exception(e)

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -9,8 +9,8 @@ import gzip
 import zlib
 import ipaddress
 import inspect
+import logging
 import threading
-import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
 from typing import Any, Callable, Union, Annotated, BinaryIO, NotRequired, get_origin, get_args, get_type_hints, is_typeddict
 from types import UnionType
@@ -20,6 +20,8 @@ from io import BufferedIOBase
 from .jsonrpc import JsonRpcRegistry, JsonRpcError, JsonRpcException, get_current_request_id, register_pending_request, unregister_pending_request, cancel_request
 
 EXTERNAL_BASE_HEADER = "X-IDA-MCP-External-Base"
+
+logger = logging.getLogger(__name__)
 
 _request_context = threading.local()
 
@@ -501,8 +503,9 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
                     )
                     return
                 if not self.mcp_server.has_http_session(mcp_session_id):
-                    print(
-                        f"[MCP] Re-registering HTTP session {mcp_session_id} after reconnect"
+                    logger.info(
+                        "[MCP] Re-registering HTTP session %s after reconnect",
+                        mcp_session_id,
                     )
                     self.mcp_server.register_http_session(mcp_session_id)
 
@@ -598,7 +601,7 @@ class McpServer:
 
     def serve(self, host: str, port: int, *, background = True, request_handler = McpHttpRequestHandler):
         if self._running:
-            print("[MCP] Server is already running")
+            logger.info("[MCP] Server is already running")
             return
 
         # Create server with deferred binding
@@ -639,16 +642,15 @@ class McpServer:
         # Only start thread after successful bind
         self._running = True
 
-        print("[MCP] Server started:")
-        print(f"  Streamable HTTP: http://{host}:{port}/mcp")
-        print(f"  SSE: http://{host}:{port}/sse")
+        logger.info("[MCP] Server started")
+        logger.info("  Streamable HTTP: http://%s:%s/mcp", host, port)
+        logger.info("  SSE: http://%s:%s/sse", host, port)
 
         def serve_forever():
             try:
                 self._http_server.serve_forever() # type: ignore
-            except Exception as e:
-                print(f"[MCP] Server error: {e}")
-                traceback.print_exc()
+            except Exception:
+                logger.exception("[MCP] Server error")
             finally:
                 self._running = False
 
@@ -681,7 +683,7 @@ class McpServer:
             self._server_thread.join()
             self._server_thread = None
 
-        print("[MCP] Server stopped")
+        logger.info("[MCP] Server stopped")
 
     def stdio(self, stdin: BinaryIO | None = None, stdout: BinaryIO | None = None):
         stdin = stdin or sys.stdin.buffer
@@ -814,7 +816,11 @@ class McpServer:
     def _mcp_notifications_cancelled(self, requestId: int | str, reason: str | None = None) -> None:
         """MCP notifications/cancelled - cancel an in-flight request"""
         if cancel_request(requestId):
-            print(f"[MCP] Cancelled request {requestId}: {reason or 'no reason'}")
+            logger.info(
+                "[MCP] Cancelled request %s: %s",
+                requestId,
+                reason or "no reason",
+            )
         # Notifications don't return a response
 
     def _mcp_resources_list(self, _meta: dict | None = None) -> dict:

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -564,8 +564,10 @@ class McpServer:
         self._server_thread: threading.Thread | None = None
         self._running = False
         self._sse_connections: dict[str, _McpSseConnection] = {}
-        self._http_sessions: set[str] = set()
+        self._http_sessions: dict[str, float] = {}
         self._http_sessions_lock = threading.Lock()
+        self.http_session_ttl_sec = 24 * 60 * 60
+        self.http_session_max_count = 4096
         self._protocol_version = threading.local()
         self._transport_session_id = threading.local()
         self._enabled_extensions = threading.local()  # set[str] per request
@@ -712,13 +714,39 @@ class McpServer:
     def get_current_transport_session_id(self) -> str | None:
         return getattr(self._transport_session_id, "data", None)
 
+    def _prune_http_sessions_locked(self, now: float) -> None:
+        if self.http_session_ttl_sec > 0:
+            cutoff = now - self.http_session_ttl_sec
+            expired = [
+                session_id
+                for session_id, last_seen in self._http_sessions.items()
+                if last_seen < cutoff
+            ]
+            for session_id in expired:
+                self._http_sessions.pop(session_id, None)
+
+        if self.http_session_max_count > 0:
+            while len(self._http_sessions) > self.http_session_max_count:
+                oldest = next(iter(self._http_sessions))
+                self._http_sessions.pop(oldest, None)
+
     def register_http_session(self, session_id: str) -> None:
+        now = time.monotonic()
         with self._http_sessions_lock:
-            self._http_sessions.add(session_id)
+            # Refresh existing IDs by moving them to the insertion-order tail.
+            self._http_sessions.pop(session_id, None)
+            self._http_sessions[session_id] = now
+            self._prune_http_sessions_locked(now)
 
     def has_http_session(self, session_id: str) -> bool:
+        now = time.monotonic()
         with self._http_sessions_lock:
-            return session_id in self._http_sessions
+            self._prune_http_sessions_locked(now)
+            if session_id not in self._http_sessions:
+                return False
+            self._http_sessions.pop(session_id, None)
+            self._http_sessions[session_id] = now
+            return True
 
     def cors_localhost(self, origin: str) -> bool:
         """Allow CORS requests from localhost on ANY port."""

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -489,25 +489,24 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             pass
 
         mcp_session_id = self.headers.get("Mcp-Session-Id")
-        if self.mcp_server.require_streamable_http_session:
-            if request_method == "initialize":
-                if mcp_session_id is None:
-                    mcp_session_id = str(uuid.uuid4())
+        if request_method == "initialize":
+            if mcp_session_id is None:
+                mcp_session_id = str(uuid.uuid4())
+            self.mcp_server.register_http_session(mcp_session_id)
+        elif self.mcp_server.require_streamable_http_session:
+            if mcp_session_id is None:
+                self.send_error(
+                    400,
+                    "Missing Mcp-Session-Id header. Call initialize first and "
+                    "reuse the returned Mcp-Session-Id.",
+                )
+                return
+            if not self.mcp_server.has_http_session(mcp_session_id):
+                logger.info(
+                    "[MCP] Re-registering HTTP session %s after reconnect",
+                    mcp_session_id,
+                )
                 self.mcp_server.register_http_session(mcp_session_id)
-            else:
-                if mcp_session_id is None:
-                    self.send_error(
-                        400,
-                        "Missing Mcp-Session-Id header. Call initialize first and "
-                        "reuse the returned Mcp-Session-Id.",
-                    )
-                    return
-                if not self.mcp_server.has_http_session(mcp_session_id):
-                    logger.info(
-                        "[MCP] Re-registering HTTP session %s after reconnect",
-                        mcp_session_id,
-                    )
-                    self.mcp_server.register_http_session(mcp_session_id)
 
         # Parse extensions from query params and store in thread-local
         extensions = self._parse_extensions(self.path)

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -5,7 +5,7 @@ import signal
 import sys
 import os
 from pathlib import Path
-from typing import Annotated, Any, Optional, TypedDict
+from typing import Annotated, Any, NotRequired, Optional, TypedDict
 
 # idapro must go first to initialize idalib
 import idapro
@@ -24,9 +24,10 @@ from ida_pro_mcp.ida_mcp.http import IdaMcpHttpRequestHandler
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 
 class IdalibContextFields(TypedDict):
-    context_id: str
-    transport_context_id: str | None
-    isolated_contexts: bool
+    # Optional because error paths can fail before a request context is resolved.
+    context_id: NotRequired[str]
+    transport_context_id: NotRequired[str | None]
+    isolated_contexts: NotRequired[bool]
 
 
 class IdalibSessionInfo(TypedDict):
@@ -37,6 +38,12 @@ class IdalibSessionInfo(TypedDict):
     last_accessed: str
     is_analyzing: bool
     metadata: dict[str, Any]
+
+
+class IdalibSessionListInfo(IdalibSessionInfo, total=False):
+    is_active: bool
+    is_current_context: bool
+    bound_contexts: int
 
 
 class IdalibOpenResult(IdalibContextFields, total=False):
@@ -66,7 +73,7 @@ class IdalibUnbindResult(IdalibContextFields, total=False):
 
 
 class IdalibListResult(IdalibContextFields, total=False):
-    sessions: list[IdalibSessionInfo]
+    sessions: list[IdalibSessionListInfo]
     count: int
     current_context_session_id: str | None
     error: str

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -408,7 +408,7 @@ class IdalibSupervisor:
         worker: WorkerSession,
         payload: dict[str, Any],
         *,
-        timeout: float = 300.0,
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         body = json.dumps(payload).encode("utf-8")
         conn = http.client.HTTPConnection(worker.host, worker.port, timeout=timeout)

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -505,11 +505,33 @@ class IdalibSupervisor:
 
     def _register_session_locked(self, session: WorkerSession, resolved_path: str, context_id: str | None) -> None:
         self.sessions[session.session_id] = session
-        self.path_to_session[self._path_key(resolved_path)] = session.session_id
         for candidate in self._candidate_idb_paths(resolved_path):
-            self.path_to_session.setdefault(candidate, session.session_id)
+            self.path_to_session[candidate] = session.session_id
         if context_id is not None:
             self.bind_context(context_id, session.session_id)
+
+    def _unregister_session_locked(self, session_id: str) -> WorkerSession | None:
+        session = self.sessions.pop(session_id, None)
+        stale_paths = [
+            path_key
+            for path_key, bound_session_id in self.path_to_session.items()
+            if bound_session_id == session_id
+        ]
+        for path_key in stale_paths:
+            self.path_to_session.pop(path_key, None)
+        stale_contexts = [
+            context for context, bound in self.context_bindings.items() if bound == session_id
+        ]
+        for context in stale_contexts:
+            self.context_bindings.pop(context, None)
+        return session
+
+    def _discard_opened_worker_session(self, worker: WorkerSession, session_id: str) -> None:
+        try:
+            self.call_worker_tool(worker, "idalib_close", {"session_id": session_id})
+        except Exception:
+            logger.debug("Worker idalib_close failed for discarded session %s", session_id, exc_info=True)
+        self._terminate_worker(worker)
 
     def _make_gui_session(self, resolved_path: str, session_id: str, instance: dict[str, Any]) -> WorkerSession:
         idb_path = str(instance.get("idb_path") or resolved_path)
@@ -536,19 +558,22 @@ class IdalibSupervisor:
         context_id: str | None = None,
     ) -> WorkerSession:
         resolved = self._normalize_input_path(input_path)
+        requested_session_id = session_id
         with self._lock:
             existing = self.path_to_session.get(self._path_key(resolved))
             if existing is not None:
-                if session_id is not None and session_id != existing:
-                    raise ValueError(
-                        f"Binary already open as session '{existing}', cannot reuse "
-                        f"different session_id '{session_id}'."
-                    )
-                session = self.sessions[existing]
-                session.last_accessed = datetime.now()
-                if context_id is not None:
-                    self.bind_context(context_id, existing)
-                return session
+                session = self.sessions.get(existing)
+                if session is not None and session.is_alive():
+                    if requested_session_id is not None and requested_session_id != existing:
+                        raise ValueError(
+                            f"Binary already open as session '{existing}', cannot reuse "
+                            f"different session_id '{requested_session_id}'."
+                        )
+                    session.last_accessed = datetime.now()
+                    if context_id is not None:
+                        self.bind_context(context_id, existing)
+                    return session
+                self._unregister_session_locked(existing)
 
             if session_id is None:
                 session_id = str(uuid.uuid4())[:8]
@@ -600,26 +625,41 @@ class IdalibSupervisor:
             pid=worker.process.pid if worker.process is not None else None,
         )
         with self._lock:
-            self._register_session_locked(session, resolved, context_id)
-        return session
+            existing = self.path_to_session.get(self._path_key(resolved))
+            if existing is not None:
+                existing_session = self.sessions.get(existing)
+                if existing_session is not None and existing_session.is_alive():
+                    existing_session.last_accessed = datetime.now()
+                    if context_id is not None:
+                        self.bind_context(context_id, existing)
+                    collision_error = None
+                    if requested_session_id is not None and requested_session_id != existing:
+                        collision_error = ValueError(
+                            f"Binary already open as session '{existing}', cannot reuse "
+                            f"different session_id '{requested_session_id}'."
+                        )
+                else:
+                    self._unregister_session_locked(existing)
+                    existing_session = None
+                    collision_error = None
+            else:
+                existing_session = None
+                collision_error = None
+
+            if existing_session is None:
+                self._register_session_locked(session, resolved, context_id)
+                return session
+
+        self._discard_opened_worker_session(worker, session_id)
+        if collision_error is not None:
+            raise collision_error
+        return existing_session
 
     def close_session(self, session_id: str) -> bool:
         with self._lock:
-            session = self.sessions.pop(session_id, None)
+            session = self._unregister_session_locked(session_id)
             if session is None:
                 return False
-            stale_paths = [
-                path_key
-                for path_key, bound_session_id in self.path_to_session.items()
-                if bound_session_id == session_id
-            ]
-            for path_key in stale_paths:
-                self.path_to_session.pop(path_key, None)
-            stale_contexts = [
-                context for context, bound in self.context_bindings.items() if bound == session_id
-            ]
-            for context in stale_contexts:
-                self.context_bindings.pop(context, None)
         if session.backend == "worker":
             try:
                 self.call_worker_tool(session, "idalib_close", {"session_id": session_id})

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import copy
 import http.client
+import importlib.util
 import json
 import logging
 import os
@@ -68,6 +69,20 @@ def _import_zeromcp():
 McpServer = _import_zeromcp()
 
 
+def _import_discovery():
+    """Import pure-Python GUI instance discovery without importing ida_mcp."""
+    path = Path(__file__).resolve().parent / "ida_mcp" / "discovery.py"
+    spec = importlib.util.spec_from_file_location("ida_pro_mcp_idalib_supervisor_discovery", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not import discovery module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_discovery = _import_discovery()
+
+
 class IdalibContextFields(TypedDict):
     context_id: NotRequired[str]
     transport_context_id: NotRequired[str | None]
@@ -88,6 +103,9 @@ class IdalibSessionListInfo(IdalibSessionInfo, total=False):
     is_active: bool
     is_current_context: bool
     bound_contexts: int
+    backend: str
+    owned: bool
+    pid: int | None
     worker_pid: int | None
 
 
@@ -167,6 +185,9 @@ class WorkerSession:
     host: str = "127.0.0.1"
     port: int = 0
     process: subprocess.Popen | None = None
+    backend: str = "worker"
+    owned: bool = True
+    pid: int | None = None
 
     def to_dict(self) -> IdalibSessionInfo:
         return {
@@ -185,10 +206,18 @@ class WorkerSession:
             "is_active": self.is_alive(),
             "is_current_context": current,
             "bound_contexts": bound_contexts,
+            "backend": self.backend,
+            "owned": self.owned,
+            "pid": self.pid if self.pid is not None else (self.process.pid if self.process is not None else None),
             "worker_pid": self.process.pid if self.process is not None else None,
         }
 
     def is_alive(self) -> bool:
+        if self.backend == "gui":
+            try:
+                return bool(_discovery.probe_instance(self.host, self.port, timeout=0.5))
+            except Exception:
+                return False
         return self.process is not None and self.process.poll() is None
 
 
@@ -276,6 +305,9 @@ class IdalibSupervisor:
             host="127.0.0.1",
             port=port,
             process=process,
+            backend="worker",
+            owned=True,
+            pid=process.pid,
         )
         try:
             self._wait_worker_ready(worker)
@@ -301,6 +333,8 @@ class IdalibSupervisor:
         raise TimeoutError(f"idalib worker did not become ready: {last_error}")
 
     def _terminate_worker(self, worker: WorkerSession) -> None:
+        if worker.backend != "worker" or not worker.owned:
+            return
         proc = worker.process
         if proc is None or proc.poll() is not None:
             return
@@ -325,9 +359,8 @@ class IdalibSupervisor:
 
     def _schema_or_idle_worker(self) -> WorkerSession:
         with self._lock:
-            if self.sessions:
-                worker = next(iter(self.sessions.values()))
-                if worker.is_alive():
+            for worker in self.sessions.values():
+                if worker.backend == "worker" and worker.is_alive():
                     return worker
             if self._schema_worker is not None and self._schema_worker.is_alive():
                 return self._schema_worker
@@ -347,7 +380,12 @@ class IdalibSupervisor:
         if worker is not None:
             return worker
 
-        if self.max_workers <= 0 or len(self.sessions) < self.max_workers:
+        owned_workers = sum(
+            1
+            for session in self.sessions.values()
+            if session.backend == "worker" and session.owned
+        )
+        if self.max_workers <= 0 or owned_workers < self.max_workers:
             return self._spawn_worker()
 
         raise RuntimeError(
@@ -426,6 +464,69 @@ class IdalibSupervisor:
             raise FileNotFoundError(f"Input file not found: {input_path}")
         return str(path.resolve())
 
+    def _path_key(self, path: str) -> str:
+        return os.path.normcase(str(Path(path).resolve()))
+
+    def _candidate_idb_paths(self, resolved_path: str) -> set[str]:
+        path = Path(resolved_path)
+        candidates = {self._path_key(str(path))}
+        lower_name = path.name.lower()
+        if not lower_name.endswith((".i64", ".idb")):
+            candidates.add(self._path_key(str(path) + ".i64"))
+            candidates.add(self._path_key(str(path) + ".idb"))
+        return candidates
+
+    def _find_gui_instance_for_path(self, resolved_path: str) -> dict[str, Any] | None:
+        candidates = self._candidate_idb_paths(resolved_path)
+        try:
+            instances = _discovery.discover_instances()
+        except Exception:
+            logger.debug("GUI instance discovery failed", exc_info=True)
+            return None
+
+        matches = []
+        for instance in instances:
+            idb_path = str(instance.get("idb_path") or "")
+            if not idb_path:
+                continue
+            try:
+                idb_key = self._path_key(idb_path)
+            except Exception:
+                idb_key = os.path.normcase(idb_path)
+            if idb_key in candidates:
+                matches.append(instance)
+
+        if len(matches) > 1:
+            logger.warning(
+                "Multiple GUI IDA instances matched %s; using the first registered instance",
+                resolved_path,
+            )
+        return matches[0] if matches else None
+
+    def _register_session_locked(self, session: WorkerSession, resolved_path: str, context_id: str | None) -> None:
+        self.sessions[session.session_id] = session
+        self.path_to_session[self._path_key(resolved_path)] = session.session_id
+        for candidate in self._candidate_idb_paths(resolved_path):
+            self.path_to_session.setdefault(candidate, session.session_id)
+        if context_id is not None:
+            self.bind_context(context_id, session.session_id)
+
+    def _make_gui_session(self, resolved_path: str, session_id: str, instance: dict[str, Any]) -> WorkerSession:
+        idb_path = str(instance.get("idb_path") or resolved_path)
+        filename = Path(idb_path).name or Path(resolved_path).name
+        return WorkerSession(
+            session_id=session_id,
+            input_path=idb_path,
+            filename=filename,
+            metadata={"backend": "gui", "requested_path": resolved_path},
+            host=str(instance.get("host") or "127.0.0.1"),
+            port=int(instance.get("port") or 0),
+            process=None,
+            backend="gui",
+            owned=False,
+            pid=int(instance["pid"]) if instance.get("pid") is not None else None,
+        )
+
     def open_session(
         self,
         input_path: str,
@@ -436,7 +537,7 @@ class IdalibSupervisor:
     ) -> WorkerSession:
         resolved = self._normalize_input_path(input_path)
         with self._lock:
-            existing = self.path_to_session.get(os.path.normcase(resolved))
+            existing = self.path_to_session.get(self._path_key(resolved))
             if existing is not None:
                 if session_id is not None and session_id != existing:
                     raise ValueError(
@@ -453,6 +554,18 @@ class IdalibSupervisor:
                 session_id = str(uuid.uuid4())[:8]
             elif session_id in self.sessions:
                 raise ValueError(f"Session already exists: {session_id}")
+
+            gui_instance = self._find_gui_instance_for_path(resolved)
+            if gui_instance is not None:
+                session = self._make_gui_session(resolved, session_id, gui_instance)
+                self._register_session_locked(session, resolved, context_id)
+                logger.info(
+                    "Using GUI IDA instance %s:%s for %s",
+                    session.host,
+                    session.port,
+                    resolved,
+                )
+                return session
 
             worker = self._allocate_worker_locked()
 
@@ -482,12 +595,12 @@ class IdalibSupervisor:
             host=worker.host,
             port=worker.port,
             process=worker.process,
+            backend="worker",
+            owned=True,
+            pid=worker.process.pid if worker.process is not None else None,
         )
         with self._lock:
-            self.sessions[session_id] = session
-            self.path_to_session[os.path.normcase(resolved)] = session_id
-            if context_id is not None:
-                self.bind_context(context_id, session_id)
+            self._register_session_locked(session, resolved, context_id)
         return session
 
     def close_session(self, session_id: str) -> bool:
@@ -495,29 +608,88 @@ class IdalibSupervisor:
             session = self.sessions.pop(session_id, None)
             if session is None:
                 return False
-            self.path_to_session.pop(os.path.normcase(str(Path(session.input_path).resolve())), None)
+            stale_paths = [
+                path_key
+                for path_key, bound_session_id in self.path_to_session.items()
+                if bound_session_id == session_id
+            ]
+            for path_key in stale_paths:
+                self.path_to_session.pop(path_key, None)
             stale_contexts = [
                 context for context, bound in self.context_bindings.items() if bound == session_id
             ]
             for context in stale_contexts:
                 self.context_bindings.pop(context, None)
-        try:
-            self.call_worker_tool(session, "idalib_close", {"session_id": session_id})
-        except Exception:
-            logger.debug("Worker idalib_close failed for %s", session_id, exc_info=True)
+        if session.backend == "worker":
+            try:
+                self.call_worker_tool(session, "idalib_close", {"session_id": session_id})
+            except Exception:
+                logger.debug("Worker idalib_close failed for %s", session_id, exc_info=True)
         self._terminate_worker(session)
         return True
+
+    def _reopen_gui_session_headless(self, session: WorkerSession) -> WorkerSession:
+        logger.info(
+            "GUI IDA backend for session %s is unavailable; reopening headless",
+            session.session_id,
+        )
+        resolved = self._normalize_input_path(session.input_path)
+        with self._lock:
+            worker = self._allocate_worker_locked()
+        try:
+            opened = self.call_worker_tool(
+                worker,
+                "idalib_open",
+                {
+                    "input_path": resolved,
+                    "run_auto_analysis": False,
+                    "session_id": session.session_id,
+                },
+            )
+            if isinstance(opened, dict) and opened.get("error"):
+                raise RuntimeError(str(opened["error"]))
+        except Exception:
+            self._terminate_worker(worker)
+            raise
+
+        worker_session = opened.get("session", {}) if isinstance(opened, dict) else {}
+        replacement = WorkerSession(
+            session_id=session.session_id,
+            input_path=str(worker_session.get("input_path") or resolved),
+            filename=str(worker_session.get("filename") or Path(resolved).name),
+            is_analyzing=bool(worker_session.get("is_analyzing", False)),
+            metadata={**session.metadata, **dict(worker_session.get("metadata") or {}), "fallback_from_gui": True},
+            host=worker.host,
+            port=worker.port,
+            process=worker.process,
+            backend="worker",
+            owned=True,
+            pid=worker.process.pid if worker.process is not None else None,
+        )
+        with self._lock:
+            self.sessions[session.session_id] = replacement
+            self._register_session_locked(replacement, resolved, None)
+        return replacement
 
     def resolve_session(self, database: str | None = None) -> WorkerSession:
         with self._lock:
             session_id: str | None = None
             if database:
-                matches = [
-                    s.session_id
-                    for s in self.sessions.values()
-                    if database in {s.session_id, s.filename, s.input_path}
-                    or os.path.normcase(database) == os.path.normcase(s.input_path)
-                ]
+                matches: list[str] = [database] if database in self.sessions else []
+                if not matches:
+                    try:
+                        mapped = self.path_to_session.get(self._path_key(database))
+                    except Exception:
+                        mapped = self.path_to_session.get(os.path.normcase(database))
+                    if mapped is not None:
+                        matches = [mapped]
+                if not matches:
+                    matches = [
+                        s.session_id
+                        for s in self.sessions.values()
+                        if database in {s.session_id, s.filename, s.input_path}
+                        or os.path.normcase(database) == os.path.normcase(s.input_path)
+                    ]
                 if not matches:
                     # Try resolved path match without requiring it to exist now.
                     try:
@@ -547,10 +719,13 @@ class IdalibSupervisor:
             session = self.sessions.get(session_id)
             if session is None:
                 raise RuntimeError(f"Session is stale or missing: {session_id}")
-            if not session.is_alive():
-                raise RuntimeError(f"Worker for session '{session_id}' is not running")
             session.last_accessed = datetime.now()
+
+        if session.is_alive():
             return session
+        if session.backend == "gui":
+            return self._reopen_gui_session_headless(session)
+        raise RuntimeError(f"Worker for session '{session_id}' is not running")
 
     def list_sessions(self, context_id: str) -> list[IdalibSessionListInfo]:
         with self._lock:
@@ -767,7 +942,8 @@ def idalib_save(
         session = sup.resolve_session(session_id)
         if session_id:
             sup.bind_context(context_id, session.session_id)
-        result = sup.call_worker_tool(session, "idalib_save", {"path": path})
+        tool_name = "idb_save" if session.backend == "gui" else "idalib_save"
+        result = sup.call_worker_tool(session, tool_name, {"path": path})
         if isinstance(result, dict):
             return {**result, **sup.context_fields(context_id)}
         return {"ok": False, **sup.context_fields(context_id), "error": "Unexpected save result"}
@@ -786,6 +962,15 @@ def idalib_health(
         session = sup.resolve_session(session_id)
         if session_id:
             sup.bind_context(context_id, session.session_id)
+        if session.backend == "gui":
+            health = sup.call_worker_tool(session, "server_health", {})
+            return {
+                "ready": bool(isinstance(health, dict) and not health.get("error")),
+                **sup.context_fields(context_id),
+                "session": session.to_dict(),
+                "health": health if isinstance(health, dict) else None,
+                "error": None,
+            }
         result = sup.call_worker_tool(session, "idalib_health", {})
         if isinstance(result, dict):
             return {**result, **sup.context_fields(context_id)}
@@ -808,6 +993,23 @@ def idalib_warmup(
         session = sup.resolve_session(session_id)
         if session_id:
             sup.bind_context(context_id, session.session_id)
+        if session.backend == "gui":
+            warmup = sup.call_worker_tool(
+                session,
+                "server_warmup",
+                {
+                    "wait_auto_analysis": wait_auto_analysis,
+                    "build_caches": build_caches,
+                    "init_hexrays": init_hexrays,
+                },
+            )
+            return {
+                "ready": bool(isinstance(warmup, dict) and warmup.get("ok")),
+                **sup.context_fields(context_id),
+                "session": session.to_dict(),
+                "warmup": warmup if isinstance(warmup, dict) else None,
+                "error": None,
+            }
         result = sup.call_worker_tool(
             session,
             "idalib_warmup",
@@ -861,7 +1063,10 @@ def _handle_tools_call(request_obj: dict[str, Any]) -> dict[str, Any] | None:
 
     forwarded = copy.deepcopy(request_obj)
     forwarded.setdefault("params", {})["arguments"] = arguments
-    return sup.forward_raw(session, forwarded)
+    try:
+        return sup.forward_raw(session, forwarded)
+    except Exception as e:
+        return _jsonrpc_result(request_id, _call_tool_result({"error": str(e)}, is_error=True))
 
 
 def _handle_resources_list(request_obj: dict[str, Any]) -> dict[str, Any]:
@@ -885,9 +1090,9 @@ def _handle_resources_read(request_obj: dict[str, Any]) -> dict[str, Any] | None
         return _original_dispatch(request_obj)
     try:
         session = sup.resolve_session(None)
+        return sup.forward_raw(session, request_obj)
     except Exception as e:
         return _jsonrpc_error(request_obj.get("id"), -32001, str(e))
-    return sup.forward_raw(session, request_obj)
 
 
 def dispatch_supervisor(request: dict | str | bytes | bytearray) -> dict | None:

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -646,13 +646,25 @@ class IdalibSupervisor:
                 existing_session = None
                 collision_error = None
 
+            session_collision_error = None
             if existing_session is None:
+                existing_by_id = self.sessions.get(session_id)
+                if existing_by_id is not None:
+                    if existing_by_id.is_alive():
+                        existing_by_id.last_accessed = datetime.now()
+                        session_collision_error = ValueError(f"Session already exists: {session_id}")
+                    else:
+                        self._unregister_session_locked(session_id)
+
+            if existing_session is None and session_collision_error is None:
                 self._register_session_locked(session, resolved, context_id)
                 return session
 
         self._discard_opened_worker_session(worker, session_id)
         if collision_error is not None:
             raise collision_error
+        if session_collision_error is not None:
+            raise session_collision_error
         return existing_session
 
     def close_session(self, session_id: str) -> bool:

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -375,15 +375,25 @@ class IdalibSupervisor:
         self._schema_worker = None
         return None
 
+    def _prune_dead_worker_sessions_locked(self) -> None:
+        stale_session_ids = [
+            session.session_id
+            for session in self.sessions.values()
+            if session.backend == "worker" and session.owned and not session.is_alive()
+        ]
+        for session_id in stale_session_ids:
+            self._unregister_session_locked(session_id)
+
     def _allocate_worker_locked(self) -> WorkerSession:
         worker = self._take_schema_worker_for_session()
         if worker is not None:
             return worker
 
+        self._prune_dead_worker_sessions_locked()
         owned_workers = sum(
             1
             for session in self.sessions.values()
-            if session.backend == "worker" and session.owned
+            if session.backend == "worker" and session.owned and session.is_alive()
         )
         if self.max_workers <= 0 or owned_workers < self.max_workers:
             return self._spawn_worker()
@@ -738,9 +748,28 @@ class IdalibSupervisor:
             pid=worker.process.pid if worker.process is not None else None,
         )
         with self._lock:
-            self.sessions[session.session_id] = replacement
-            self._register_session_locked(replacement, resolved, None)
-        return replacement
+            current = self.sessions.get(session.session_id)
+            if current is session:
+                self._register_session_locked(replacement, resolved, None)
+                return replacement
+            if current is not None and current.is_alive():
+                current.last_accessed = datetime.now()
+                replacement_session = current
+                reopen_error = None
+            else:
+                if current is not None:
+                    self._unregister_session_locked(session.session_id)
+                replacement_session = None
+                reopen_error = RuntimeError(
+                    f"Session '{session.session_id}' was closed or replaced while reopening headlessly"
+                )
+
+        self._discard_opened_worker_session(worker, session.session_id)
+        if replacement_session is not None:
+            return replacement_session
+        if reopen_error is not None:
+            raise reopen_error
+        raise RuntimeError(f"Session '{session.session_id}' changed while reopening headlessly")
 
     def resolve_session(self, database: str | None = None) -> WorkerSession:
         with self._lock:

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -668,12 +668,31 @@ class IdalibSupervisor:
         self._terminate_worker(session)
         return True
 
+    def _resolve_gui_fallback_path(self, session: WorkerSession) -> str:
+        candidates = [session.input_path]
+        requested_path = session.metadata.get("requested_path")
+        if isinstance(requested_path, str) and requested_path and requested_path not in candidates:
+            candidates.append(requested_path)
+
+        errors = []
+        for candidate in candidates:
+            try:
+                return self._normalize_input_path(candidate)
+            except FileNotFoundError as e:
+                errors.append(str(e))
+
+        raise FileNotFoundError(
+            "Could not reopen GUI-backed session headlessly. Tried: "
+            + ", ".join(candidates)
+            + (f" ({'; '.join(errors)})" if errors else "")
+        )
+
     def _reopen_gui_session_headless(self, session: WorkerSession) -> WorkerSession:
         logger.info(
             "GUI IDA backend for session %s is unavailable; reopening headless",
             session.session_id,
         )
-        resolved = self._normalize_input_path(session.input_path)
+        resolved = self._resolve_gui_fallback_path(session)
         with self._lock:
             worker = self._allocate_worker_locked()
         try:

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -1,0 +1,1000 @@
+"""Headless idalib MCP supervisor.
+
+This module is the public ``idalib-mcp`` entry point. It intentionally does
+not import idapro/IDAPython modules. Instead it exposes the MCP transport and
+routes IDA-facing calls to per-database ``idalib_server`` worker subprocesses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import http.client
+import json
+import logging
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from threading import RLock
+from typing import Annotated, Any, NotRequired, Optional, TypedDict
+
+
+logger = logging.getLogger(__name__)
+
+STDIO_DEFAULT_CONTEXT_ID = "stdio:default"
+SHARED_FALLBACK_CONTEXT_ID = "shared:fallback"
+_DATABASE_ARG = "database"
+_DATABASE_ARG_SCHEMA = {
+    "type": "string",
+    "description": (
+        "Database/session to route this call to. Accepts a session_id, filename, "
+        "or input path. If omitted, uses the database bound to the current MCP context."
+    ),
+}
+
+IDALIB_MANAGEMENT_TOOLS = {
+    "idalib_open",
+    "idalib_close",
+    "idalib_switch",
+    "idalib_unbind",
+    "idalib_list",
+    "idalib_current",
+    "idalib_save",
+    "idalib_health",
+    "idalib_warmup",
+}
+
+
+def _import_zeromcp():
+    """Import vendored zeromcp without importing ida_mcp/__init__.py."""
+    import http.server  # noqa: F401 - prevent local http.py shadowing stdlib
+
+    pkg_dir = Path(__file__).resolve().parent / "ida_mcp"
+    sys.path.insert(0, str(pkg_dir))
+    try:
+        from zeromcp import McpServer  # type: ignore
+    finally:
+        sys.path.remove(str(pkg_dir))
+    return McpServer
+
+
+McpServer = _import_zeromcp()
+
+
+class IdalibContextFields(TypedDict):
+    context_id: NotRequired[str]
+    transport_context_id: NotRequired[str | None]
+    isolated_contexts: NotRequired[bool]
+
+
+class IdalibSessionInfo(TypedDict):
+    session_id: str
+    input_path: str
+    filename: str
+    created_at: str
+    last_accessed: str
+    is_analyzing: bool
+    metadata: dict[str, Any]
+
+
+class IdalibSessionListInfo(IdalibSessionInfo, total=False):
+    is_active: bool
+    is_current_context: bool
+    bound_contexts: int
+    worker_pid: int | None
+
+
+class IdalibOpenResult(IdalibContextFields, total=False):
+    success: bool
+    session: IdalibSessionInfo
+    message: str
+    error: str
+
+
+class IdalibCloseResult(TypedDict, total=False):
+    success: bool
+    message: str
+    error: str
+
+
+class IdalibSwitchResult(IdalibContextFields, total=False):
+    success: bool
+    session: IdalibSessionInfo
+    message: str
+    error: str
+
+
+class IdalibUnbindResult(IdalibContextFields, total=False):
+    success: bool
+    message: str
+    error: str
+
+
+class IdalibListResult(IdalibContextFields, total=False):
+    sessions: list[IdalibSessionListInfo]
+    count: int
+    current_context_session_id: str | None
+    error: str
+
+
+class IdalibCurrentResult(IdalibContextFields, total=False):
+    session_id: str
+    input_path: str
+    filename: str
+    created_at: str
+    last_accessed: str
+    is_analyzing: bool
+    metadata: dict[str, Any]
+    error: str
+
+
+class IdalibSaveResult(IdalibContextFields, total=False):
+    ok: bool
+    path: str
+    error: str | None
+
+
+class IdalibHealthResult(IdalibContextFields, total=False):
+    ready: bool
+    session: IdalibSessionInfo | None
+    health: dict[str, Any] | None
+    error: str | None
+
+
+class IdalibWarmupResult(IdalibContextFields, total=False):
+    ready: bool
+    session: IdalibSessionInfo | None
+    warmup: dict[str, Any] | None
+    error: str | None
+
+
+@dataclass
+class WorkerSession:
+    session_id: str
+    input_path: str
+    filename: str
+    created_at: datetime = field(default_factory=datetime.now)
+    last_accessed: datetime = field(default_factory=datetime.now)
+    is_analyzing: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+    host: str = "127.0.0.1"
+    port: int = 0
+    process: subprocess.Popen | None = None
+
+    def to_dict(self) -> IdalibSessionInfo:
+        return {
+            "session_id": self.session_id,
+            "input_path": self.input_path,
+            "filename": self.filename,
+            "created_at": self.created_at.isoformat(),
+            "last_accessed": self.last_accessed.isoformat(),
+            "is_analyzing": self.is_analyzing,
+            "metadata": self.metadata,
+        }
+
+    def to_list_dict(self, *, current: bool, bound_contexts: int) -> IdalibSessionListInfo:
+        return {
+            **self.to_dict(),
+            "is_active": self.is_alive(),
+            "is_current_context": current,
+            "bound_contexts": bound_contexts,
+            "worker_pid": self.process.pid if self.process is not None else None,
+        }
+
+    def is_alive(self) -> bool:
+        return self.process is not None and self.process.poll() is None
+
+
+class IdalibSupervisor:
+    def __init__(
+        self,
+        mcp: Any,
+        *,
+        isolated_contexts: bool = False,
+        max_workers: int = 4,
+        worker_args: list[str] | None = None,
+    ):
+        self.mcp = mcp
+        self.isolated_contexts = isolated_contexts
+        self.max_workers = max_workers
+        self.worker_args = worker_args or []
+        self.sessions: dict[str, WorkerSession] = {}
+        self.path_to_session: dict[str, str] = {}
+        self.context_bindings: dict[str, str] = {}
+        self._schema_worker: WorkerSession | None = None
+        self._tools_cache: dict[tuple[str, ...], list[dict]] = {}
+        self._resources_cache: dict[str, list[dict]] = {}
+        self._lock = RLock()
+
+    # ------------------------------------------------------------------
+    # Context helpers
+    # ------------------------------------------------------------------
+
+    def resolve_context_id(self) -> str:
+        transport_context_id = self.mcp.get_current_transport_session_id()
+        if self.isolated_contexts:
+            if transport_context_id is None:
+                raise RuntimeError(
+                    "No MCP transport context is active for this request. "
+                    "Use MCP initialize and send Mcp-Session-Id on /mcp requests."
+                )
+            return transport_context_id
+        return SHARED_FALLBACK_CONTEXT_ID
+
+    def context_fields(self, context_id: str) -> IdalibContextFields:
+        return {
+            "context_id": context_id,
+            "transport_context_id": self.mcp.get_current_transport_session_id(),
+            "isolated_contexts": self.isolated_contexts,
+        }
+
+    def bind_context(self, context_id: str, session_id: str) -> None:
+        self.context_bindings[context_id] = session_id
+
+    def unbind_context(self, context_id: str) -> bool:
+        return self.context_bindings.pop(context_id, None) is not None
+
+    # ------------------------------------------------------------------
+    # Worker process lifecycle
+    # ------------------------------------------------------------------
+
+    def _pick_port(self) -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    def _spawn_worker(self) -> WorkerSession:
+        port = self._pick_port()
+        cmd = [
+            sys.executable,
+            "-m",
+            "ida_pro_mcp.idalib_server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            *self.worker_args,
+        ]
+        logger.info("Spawning idalib worker on 127.0.0.1:%d", port)
+        process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        worker = WorkerSession(
+            session_id=f"__worker_schema_{uuid.uuid4().hex[:8]}",
+            input_path="",
+            filename="",
+            host="127.0.0.1",
+            port=port,
+            process=process,
+        )
+        try:
+            self._wait_worker_ready(worker)
+        except Exception:
+            self._terminate_worker(worker)
+            raise
+        return worker
+
+    def _wait_worker_ready(self, worker: WorkerSession, timeout: float = 120.0) -> None:
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if worker.process is not None and worker.process.poll() is not None:
+                raise RuntimeError(
+                    f"idalib worker exited early with code {worker.process.returncode}"
+                )
+            try:
+                self._worker_rpc(worker, {"jsonrpc": "2.0", "id": 1, "method": "ping"}, timeout=2.0)
+                return
+            except Exception as e:
+                last_error = e
+                time.sleep(0.2)
+        raise TimeoutError(f"idalib worker did not become ready: {last_error}")
+
+    def _terminate_worker(self, worker: WorkerSession) -> None:
+        proc = worker.process
+        if proc is None or proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            workers = list(self.sessions.values())
+            if self._schema_worker is not None:
+                workers.append(self._schema_worker)
+            self.sessions.clear()
+            self.path_to_session.clear()
+            self.context_bindings.clear()
+            self._schema_worker = None
+        for worker in workers:
+            self._terminate_worker(worker)
+
+    def _schema_or_idle_worker(self) -> WorkerSession:
+        with self._lock:
+            if self.sessions:
+                worker = next(iter(self.sessions.values()))
+                if worker.is_alive():
+                    return worker
+            if self._schema_worker is not None and self._schema_worker.is_alive():
+                return self._schema_worker
+            self._schema_worker = self._spawn_worker()
+            return self._schema_worker
+
+    def _take_schema_worker_for_session(self) -> WorkerSession | None:
+        if self._schema_worker is not None and self._schema_worker.is_alive():
+            worker = self._schema_worker
+            self._schema_worker = None
+            return worker
+        self._schema_worker = None
+        return None
+
+    def _allocate_worker_locked(self) -> WorkerSession:
+        worker = self._take_schema_worker_for_session()
+        if worker is not None:
+            return worker
+
+        if self.max_workers <= 0 or len(self.sessions) < self.max_workers:
+            return self._spawn_worker()
+
+        raise RuntimeError(
+            f"Maximum idalib worker count reached ({self.max_workers}). "
+            "Close a database with idalib_close or increase --max-workers."
+        )
+
+    # ------------------------------------------------------------------
+    # JSON-RPC forwarding
+    # ------------------------------------------------------------------
+
+    def _worker_request_path(self) -> str:
+        enabled = sorted(getattr(self.mcp._enabled_extensions, "data", set()))
+        if enabled:
+            return f"/mcp?ext={','.join(enabled)}"
+        return "/mcp"
+
+    def _worker_rpc(
+        self,
+        worker: WorkerSession,
+        payload: dict[str, Any],
+        *,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        conn = http.client.HTTPConnection(worker.host, worker.port, timeout=timeout)
+        try:
+            conn.request(
+                "POST",
+                self._worker_request_path(),
+                body,
+                {
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+            )
+            response = conn.getresponse()
+            raw = response.read().decode("utf-8")
+            if response.status >= 400:
+                raise RuntimeError(f"HTTP {response.status} {response.reason}: {raw}")
+            return json.loads(raw)
+        finally:
+            conn.close()
+
+    def forward_raw(self, worker: WorkerSession, request_obj: dict[str, Any]) -> dict[str, Any]:
+        return self._worker_rpc(worker, request_obj)
+
+    def call_worker_tool(
+        self, worker: WorkerSession, name: str, arguments: dict[str, Any] | None = None
+    ) -> Any:
+        response = self._worker_rpc(
+            worker,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments or {}},
+            },
+        )
+        if "error" in response:
+            raise RuntimeError(response["error"].get("message", "Unknown worker error"))
+        result = response.get("result", {})
+        if result.get("isError"):
+            content = result.get("content") or []
+            message = content[0].get("text", "Unknown worker tool error") if content else "Unknown worker tool error"
+            raise RuntimeError(message)
+        return result.get("structuredContent")
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    def _normalize_input_path(self, input_path: str) -> str:
+        path = Path(input_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Input file not found: {input_path}")
+        return str(path.resolve())
+
+    def open_session(
+        self,
+        input_path: str,
+        *,
+        run_auto_analysis: bool = True,
+        session_id: str | None = None,
+        context_id: str | None = None,
+    ) -> WorkerSession:
+        resolved = self._normalize_input_path(input_path)
+        with self._lock:
+            existing = self.path_to_session.get(os.path.normcase(resolved))
+            if existing is not None:
+                if session_id is not None and session_id != existing:
+                    raise ValueError(
+                        f"Binary already open as session '{existing}', cannot reuse "
+                        f"different session_id '{session_id}'."
+                    )
+                session = self.sessions[existing]
+                session.last_accessed = datetime.now()
+                if context_id is not None:
+                    self.bind_context(context_id, existing)
+                return session
+
+            if session_id is None:
+                session_id = str(uuid.uuid4())[:8]
+            elif session_id in self.sessions:
+                raise ValueError(f"Session already exists: {session_id}")
+
+            worker = self._allocate_worker_locked()
+
+        try:
+            opened = self.call_worker_tool(
+                worker,
+                "idalib_open",
+                {
+                    "input_path": resolved,
+                    "run_auto_analysis": run_auto_analysis,
+                    "session_id": session_id,
+                },
+            )
+            if isinstance(opened, dict) and opened.get("error"):
+                raise RuntimeError(str(opened["error"]))
+        except Exception:
+            self._terminate_worker(worker)
+            raise
+
+        worker_session = opened.get("session", {}) if isinstance(opened, dict) else {}
+        session = WorkerSession(
+            session_id=session_id,
+            input_path=str(worker_session.get("input_path") or resolved),
+            filename=str(worker_session.get("filename") or Path(resolved).name),
+            is_analyzing=bool(worker_session.get("is_analyzing", False)),
+            metadata=dict(worker_session.get("metadata") or {}),
+            host=worker.host,
+            port=worker.port,
+            process=worker.process,
+        )
+        with self._lock:
+            self.sessions[session_id] = session
+            self.path_to_session[os.path.normcase(resolved)] = session_id
+            if context_id is not None:
+                self.bind_context(context_id, session_id)
+        return session
+
+    def close_session(self, session_id: str) -> bool:
+        with self._lock:
+            session = self.sessions.pop(session_id, None)
+            if session is None:
+                return False
+            self.path_to_session.pop(os.path.normcase(str(Path(session.input_path).resolve())), None)
+            stale_contexts = [
+                context for context, bound in self.context_bindings.items() if bound == session_id
+            ]
+            for context in stale_contexts:
+                self.context_bindings.pop(context, None)
+        try:
+            self.call_worker_tool(session, "idalib_close", {"session_id": session_id})
+        except Exception:
+            logger.debug("Worker idalib_close failed for %s", session_id, exc_info=True)
+        self._terminate_worker(session)
+        return True
+
+    def resolve_session(self, database: str | None = None) -> WorkerSession:
+        with self._lock:
+            session_id: str | None = None
+            if database:
+                matches = [
+                    s.session_id
+                    for s in self.sessions.values()
+                    if database in {s.session_id, s.filename, s.input_path}
+                    or os.path.normcase(database) == os.path.normcase(s.input_path)
+                ]
+                if not matches:
+                    # Try resolved path match without requiring it to exist now.
+                    try:
+                        normalized = os.path.normcase(str(Path(database).resolve()))
+                    except Exception:
+                        normalized = os.path.normcase(database)
+                    matches = [
+                        s.session_id
+                        for s in self.sessions.values()
+                        if os.path.normcase(s.input_path) == normalized
+                    ]
+                if len(matches) > 1:
+                    raise RuntimeError(f"Database selector is ambiguous: {database}")
+                if not matches:
+                    raise RuntimeError(f"Database/session not found: {database}")
+                session_id = matches[0]
+            else:
+                context_id = self.resolve_context_id()
+                session_id = self.context_bindings.get(context_id)
+                if session_id is None and not self.isolated_contexts:
+                    session_id = self.context_bindings.get(SHARED_FALLBACK_CONTEXT_ID)
+                if session_id is None:
+                    raise RuntimeError(
+                        "No database bound for this context. Use idalib_open(...), "
+                        "idalib_switch(session_id), or pass database=..."
+                    )
+            session = self.sessions.get(session_id)
+            if session is None:
+                raise RuntimeError(f"Session is stale or missing: {session_id}")
+            if not session.is_alive():
+                raise RuntimeError(f"Worker for session '{session_id}' is not running")
+            session.last_accessed = datetime.now()
+            return session
+
+    def list_sessions(self, context_id: str) -> list[IdalibSessionListInfo]:
+        with self._lock:
+            current = self.context_bindings.get(context_id)
+            binding_counts: dict[str, int] = {}
+            for bound in self.context_bindings.values():
+                binding_counts[bound] = binding_counts.get(bound, 0) + 1
+            return [
+                session.to_list_dict(
+                    current=session.session_id == current,
+                    bound_contexts=binding_counts.get(session.session_id, 0),
+                )
+                for session in self.sessions.values()
+            ]
+
+    # ------------------------------------------------------------------
+    # Schema/resource forwarding
+    # ------------------------------------------------------------------
+
+    def worker_tools(self) -> list[dict]:
+        cache_key = tuple(sorted(getattr(self.mcp._enabled_extensions, "data", set())))
+        with self._lock:
+            cached = self._tools_cache.get(cache_key)
+            if cached is not None:
+                return copy.deepcopy(cached)
+        worker = self._schema_or_idle_worker()
+        response = self._worker_rpc(worker, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        tools = response.get("result", {}).get("tools", [])
+        filtered = [t for t in tools if t.get("name") not in IDALIB_MANAGEMENT_TOOLS]
+        injected = [self._inject_database_arg(t) for t in filtered]
+        with self._lock:
+            self._tools_cache[cache_key] = injected
+        return copy.deepcopy(injected)
+
+    def _inject_database_arg(self, tool: dict) -> dict:
+        tool = copy.deepcopy(tool)
+        schema = tool.setdefault("inputSchema", {"type": "object", "properties": {}})
+        schema.setdefault("type", "object")
+        props = schema.setdefault("properties", {})
+        props.setdefault(_DATABASE_ARG, _DATABASE_ARG_SCHEMA)
+        required = schema.setdefault("required", [])
+        if _DATABASE_ARG in required:
+            required.remove(_DATABASE_ARG)
+        return tool
+
+    def worker_resources(self, method: str) -> list[dict]:
+        with self._lock:
+            cached = self._resources_cache.get(method)
+            if cached is not None:
+                return copy.deepcopy(cached)
+        worker = self._schema_or_idle_worker()
+        response = self._worker_rpc(worker, {"jsonrpc": "2.0", "id": 1, "method": method})
+        key = "resources" if method == "resources/list" else "resourceTemplates"
+        items = response.get("result", {}).get(key, [])
+        with self._lock:
+            self._resources_cache[method] = items
+        return copy.deepcopy(items)
+
+
+mcp = McpServer("ida-pro-mcp")
+supervisor: IdalibSupervisor | None = None
+_original_dispatch = mcp.registry.dispatch
+
+
+def _require_supervisor() -> IdalibSupervisor:
+    if supervisor is None:
+        raise RuntimeError("idalib supervisor not initialized")
+    return supervisor
+
+
+def _call_tool_result(result: Any, *, is_error: bool = False) -> dict:
+    response: dict[str, Any] = {
+        "content": [{"type": "text", "text": json.dumps(result, separators=(",", ":"))}],
+        "isError": is_error,
+    }
+    if not is_error:
+        response["structuredContent"] = result if isinstance(result, dict) else {"result": result}
+    return response
+
+
+def _jsonrpc_result(request_id: Any, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "result": result, "id": request_id}
+
+
+def _jsonrpc_error(request_id: Any, code: int, message: str) -> dict | None:
+    if request_id is None:
+        return None
+    return {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": request_id}
+
+
+@mcp.tool
+def idalib_open(
+    input_path: Annotated[str, "Path to the binary file to analyze"],
+    run_auto_analysis: Annotated[bool, "Run automatic analysis on the binary"] = True,
+    session_id: Annotated[
+        Optional[str], "Custom session ID (auto-generated if not provided)"
+    ] = None,
+) -> IdalibOpenResult:
+    """Open a binary in its own idalib worker process and bind it to this context."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session = sup.open_session(
+            input_path,
+            run_auto_analysis=run_auto_analysis,
+            session_id=session_id,
+            context_id=context_id,
+        )
+        return {
+            "success": True,
+            **sup.context_fields(context_id),
+            "session": session.to_dict(),
+            "message": f"Binary opened and bound to context: {session.filename} ({session.session_id})",
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool
+def idalib_close(session_id: Annotated[str, "Session ID to close"]) -> IdalibCloseResult:
+    """Close a database worker and remove all context bindings targeting it."""
+    sup = _require_supervisor()
+    try:
+        if sup.close_session(session_id):
+            return {"success": True, "message": f"Session closed: {session_id}"}
+        return {"success": False, "error": f"Session not found: {session_id}"}
+    except Exception as e:
+        return {"error": f"Failed to close session: {e}"}
+
+
+@mcp.tool
+def idalib_switch(session_id: Annotated[str, "Session ID to bind to active context"]) -> IdalibSwitchResult:
+    """Bind the active idalib context to an existing database worker."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session = sup.resolve_session(session_id)
+        sup.bind_context(context_id, session.session_id)
+        return {
+            "success": True,
+            **sup.context_fields(context_id),
+            "session": session.to_dict(),
+            "message": f"Bound context to session: {session.session_id} ({session.filename})",
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool
+def idalib_unbind() -> IdalibUnbindResult:
+    """Unbind the active idalib context from any database."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        if sup.unbind_context(context_id):
+            return {
+                "success": True,
+                **sup.context_fields(context_id),
+                "message": "Context unbound successfully.",
+            }
+        return {
+            "success": False,
+            **sup.context_fields(context_id),
+            "error": "No bound session for this context.",
+        }
+    except Exception as e:
+        return {"error": f"Failed to unbind context: {e}"}
+
+
+@mcp.tool
+def idalib_list() -> IdalibListResult:
+    """List database workers with context-binding metadata."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        sessions = sup.list_sessions(context_id)
+        return {
+            "sessions": sessions,
+            "count": len(sessions),
+            **sup.context_fields(context_id),
+            "current_context_session_id": sup.context_bindings.get(context_id),
+        }
+    except Exception as e:
+        return {"error": f"Failed to list sessions: {e}"}
+
+
+@mcp.tool
+def idalib_current() -> IdalibCurrentResult:
+    """Return the database bound to the active idalib context."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session_id = sup.context_bindings.get(context_id)
+        if session_id is None:
+            return {
+                "error": "No session bound for this context. Use idalib_open(...) or idalib_switch(session_id) first.",
+                **sup.context_fields(context_id),
+            }
+        session = sup.resolve_session(session_id)
+        return {**session.to_dict(), **sup.context_fields(context_id)}
+    except Exception as e:
+        return {"error": f"Failed to get current session: {e}"}
+
+
+@mcp.tool
+def idalib_save(
+    path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
+    session_id: Annotated[Optional[str], "Optional session to save"] = None,
+) -> IdalibSaveResult:
+    """Save the selected database worker's IDB."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session = sup.resolve_session(session_id)
+        if session_id:
+            sup.bind_context(context_id, session.session_id)
+        result = sup.call_worker_tool(session, "idalib_save", {"path": path})
+        if isinstance(result, dict):
+            return {**result, **sup.context_fields(context_id)}
+        return {"ok": False, **sup.context_fields(context_id), "error": "Unexpected save result"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+@mcp.tool
+def idalib_health(
+    session_id: Annotated[Optional[str], "Optional session to probe"] = None,
+) -> IdalibHealthResult:
+    """Health/ready probe for a database worker."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session = sup.resolve_session(session_id)
+        if session_id:
+            sup.bind_context(context_id, session.session_id)
+        result = sup.call_worker_tool(session, "idalib_health", {})
+        if isinstance(result, dict):
+            return {**result, **sup.context_fields(context_id)}
+        return {"ready": False, **sup.context_fields(context_id), "session": None, "health": None, "error": "Unexpected health result"}
+    except Exception as e:
+        return {"ready": False, "error": str(e)}
+
+
+@mcp.tool
+def idalib_warmup(
+    session_id: Annotated[Optional[str], "Optional session to warm up"] = None,
+    wait_auto_analysis: Annotated[bool, "Wait for auto analysis queue"] = True,
+    build_caches: Annotated[bool, "Build core caches"] = True,
+    init_hexrays: Annotated[bool, "Initialize Hex-Rays plugin"] = True,
+) -> IdalibWarmupResult:
+    """Warm up selected database worker and core subsystems."""
+    sup = _require_supervisor()
+    try:
+        context_id = sup.resolve_context_id()
+        session = sup.resolve_session(session_id)
+        if session_id:
+            sup.bind_context(context_id, session.session_id)
+        result = sup.call_worker_tool(
+            session,
+            "idalib_warmup",
+            {
+                "wait_auto_analysis": wait_auto_analysis,
+                "build_caches": build_caches,
+                "init_hexrays": init_hexrays,
+            },
+        )
+        if isinstance(result, dict):
+            return {**result, **sup.context_fields(context_id)}
+        return {"ready": False, **sup.context_fields(context_id), "session": None, "warmup": None, "error": "Unexpected warmup result"}
+    except Exception as e:
+        return {"ready": False, "error": str(e)}
+
+
+@mcp.resource("ida://databases")
+def databases_resource() -> dict:
+    """List open idalib worker databases."""
+    sup = _require_supervisor()
+    context_id = sup.resolve_context_id()
+    return {
+        "databases": sup.list_sessions(context_id),
+        "count": len(sup.sessions),
+        **sup.context_fields(context_id),
+    }
+
+
+def _handle_tools_list(request_obj: dict[str, Any]) -> dict[str, Any]:
+    sup = _require_supervisor()
+    local_tools = mcp._mcp_tools_list().get("tools", [])
+    worker_tools = sup.worker_tools()
+    return _jsonrpc_result(request_obj.get("id"), {"tools": worker_tools + local_tools})
+
+
+def _handle_tools_call(request_obj: dict[str, Any]) -> dict[str, Any] | None:
+    sup = _require_supervisor()
+    params = request_obj.get("params") or {}
+    tool_name = params.get("name", "")
+    request_id = request_obj.get("id")
+
+    if tool_name in IDALIB_MANAGEMENT_TOOLS:
+        return _original_dispatch(request_obj)
+
+    arguments = copy.deepcopy(params.get("arguments") or {})
+    database = arguments.pop(_DATABASE_ARG, None)
+    try:
+        session = sup.resolve_session(database)
+    except Exception as e:
+        return _jsonrpc_result(request_id, _call_tool_result({"error": str(e)}, is_error=True))
+
+    forwarded = copy.deepcopy(request_obj)
+    forwarded.setdefault("params", {})["arguments"] = arguments
+    return sup.forward_raw(session, forwarded)
+
+
+def _handle_resources_list(request_obj: dict[str, Any]) -> dict[str, Any]:
+    sup = _require_supervisor()
+    local = mcp._mcp_resources_list().get("resources", [])
+    worker = sup.worker_resources("resources/list")
+    return _jsonrpc_result(request_obj.get("id"), {"resources": local + worker})
+
+
+def _handle_resource_templates_list(request_obj: dict[str, Any]) -> dict[str, Any]:
+    sup = _require_supervisor()
+    local = mcp._mcp_resource_templates_list().get("resourceTemplates", [])
+    worker = sup.worker_resources("resources/templates/list")
+    return _jsonrpc_result(request_obj.get("id"), {"resourceTemplates": local + worker})
+
+
+def _handle_resources_read(request_obj: dict[str, Any]) -> dict[str, Any] | None:
+    sup = _require_supervisor()
+    uri = (request_obj.get("params") or {}).get("uri", "")
+    if uri == "ida://databases":
+        return _original_dispatch(request_obj)
+    try:
+        session = sup.resolve_session(None)
+    except Exception as e:
+        return _jsonrpc_error(request_obj.get("id"), -32001, str(e))
+    return sup.forward_raw(session, request_obj)
+
+
+def dispatch_supervisor(request: dict | str | bytes | bytearray) -> dict | None:
+    if not isinstance(request, dict):
+        try:
+            request_obj = json.loads(request)
+        except Exception:
+            return _original_dispatch(request)
+    else:
+        request_obj = request
+
+    method = request_obj.get("method", "")
+    if method in {"initialize", "ping"} or method.startswith("notifications/"):
+        return _original_dispatch(request)
+    if method == "tools/list":
+        return _handle_tools_list(request_obj)
+    if method == "tools/call":
+        return _handle_tools_call(request_obj)
+    if method == "resources/list":
+        return _handle_resources_list(request_obj)
+    if method == "resources/templates/list":
+        return _handle_resource_templates_list(request_obj)
+    if method == "resources/read":
+        return _handle_resources_read(request_obj)
+    if method in {"prompts/list", "prompts/get"}:
+        return _original_dispatch(request_obj)
+
+    try:
+        session = _require_supervisor().resolve_session(None)
+    except Exception as e:
+        return _jsonrpc_error(request_obj.get("id"), -32001, str(e))
+    return _require_supervisor().forward_raw(session, request_obj)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MCP supervisor for IDA Pro via idalib")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show debug messages")
+    parser.add_argument("--stdio", action="store_true", help="Serve MCP over stdio instead of HTTP")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="HTTP host, default: 127.0.0.1")
+    parser.add_argument("--port", type=int, default=8745, help="HTTP port, default: 8745")
+    parser.add_argument(
+        "--isolated-contexts",
+        action="store_true",
+        help="Enable strict per-transport database binding isolation.",
+    )
+    parser.add_argument("--unsafe", action="store_true", help="Enable unsafe worker tools (DANGEROUS)")
+    parser.add_argument(
+        "--profile",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Restrict worker tools to names listed in a profile file.",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=int(os.environ.get("IDA_MCP_MAX_WORKERS", "4")),
+        help="Maximum simultaneous idalib worker databases (0 = unlimited, default: 4).",
+    )
+    parser.add_argument("input_path", type=Path, nargs="?", help="Optional binary to open on startup.")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+
+    worker_args: list[str] = []
+    if args.verbose:
+        worker_args.append("--verbose")
+    if args.unsafe:
+        worker_args.append("--unsafe")
+    if args.profile is not None:
+        worker_args.extend(["--profile", str(args.profile)])
+
+    global supervisor
+    supervisor = IdalibSupervisor(
+        mcp,
+        isolated_contexts=args.isolated_contexts,
+        max_workers=args.max_workers,
+        worker_args=worker_args,
+    )
+    mcp.registry.dispatch = dispatch_supervisor
+    mcp.require_streamable_http_session = args.isolated_contexts
+
+    if args.input_path is not None:
+        startup_context_id = STDIO_DEFAULT_CONTEXT_ID if args.isolated_contexts else SHARED_FALLBACK_CONTEXT_ID
+        try:
+            supervisor.open_session(str(args.input_path), context_id=startup_context_id)
+        except Exception as e:
+            raise SystemExit(f"Failed to open initial binary: {e}")
+
+    def cleanup_and_exit(signum, frame):
+        logger.info("Shutting down idalib supervisor...")
+        if supervisor is not None:
+            supervisor.shutdown()
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGINT, cleanup_and_exit)
+    signal.signal(signal.SIGTERM, cleanup_and_exit)
+
+    try:
+        if args.stdio:
+            mcp.stdio()
+        else:
+            mcp.serve(host=args.host, port=args.port, background=False)
+    finally:
+        if supervisor is not None:
+            supervisor.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import threading
+import time
 import traceback
 from collections import OrderedDict
 from typing import Annotated, Any, TYPE_CHECKING, TypedDict
@@ -100,7 +101,10 @@ OUTPUT_PROXY_CACHE_MAX_SIZE = 100
 _OUTPUT_PATH_RE = re.compile(r"^/output/([a-f0-9-]+)\.(\w+)$")
 _output_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
 _output_proxy_lock = threading.Lock()
-_session_proxy_targets: dict[str, tuple[str, int]] = {}
+SESSION_PROXY_TARGET_TTL_SEC = 24 * 60 * 60
+SESSION_PROXY_TARGET_MAX_SIZE = 4096
+_session_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
+_session_proxy_last_seen: dict[str, float] = {}
 _session_proxy_lock = threading.Lock()
 
 
@@ -109,14 +113,44 @@ def _get_proxy_session_key() -> str | None:
     return mcp.get_current_transport_session_id()
 
 
+def _prune_session_proxy_targets_locked(now: float | None = None) -> None:
+    """Remove expired or excess per-session IDA target selections."""
+    now = time.monotonic() if now is None else now
+
+    # Tests and older callers may mutate _session_proxy_targets directly. Treat
+    # entries without metadata as live, then include them in normal pruning.
+    for session_key in list(_session_proxy_targets):
+        _session_proxy_last_seen.setdefault(session_key, now)
+
+    if SESSION_PROXY_TARGET_TTL_SEC > 0:
+        cutoff = now - SESSION_PROXY_TARGET_TTL_SEC
+        for session_key, last_seen in list(_session_proxy_last_seen.items()):
+            if last_seen < cutoff:
+                _session_proxy_targets.pop(session_key, None)
+                _session_proxy_last_seen.pop(session_key, None)
+
+    for session_key in list(_session_proxy_last_seen):
+        if session_key not in _session_proxy_targets:
+            _session_proxy_last_seen.pop(session_key, None)
+
+    if SESSION_PROXY_TARGET_MAX_SIZE > 0:
+        while len(_session_proxy_targets) > SESSION_PROXY_TARGET_MAX_SIZE:
+            session_key, _ = _session_proxy_targets.popitem(last=False)
+            _session_proxy_last_seen.pop(session_key, None)
+
+
 def _get_active_ida_target() -> tuple[str, int]:
     """Return the IDA target selected for this MCP transport session."""
     session_key = _get_proxy_session_key()
     if session_key is not None:
+        now = time.monotonic()
         with _session_proxy_lock:
+            _prune_session_proxy_targets_locked(now)
             target = _session_proxy_targets.get(session_key)
-        if target is not None:
-            return target
+            if target is not None:
+                _session_proxy_targets.move_to_end(session_key)
+                _session_proxy_last_seen[session_key] = now
+                return target
     return IDA_HOST, IDA_PORT
 
 
@@ -125,8 +159,12 @@ def _set_active_ida_target(host: str, port: int) -> None:
     global IDA_HOST, IDA_PORT
     session_key = _get_proxy_session_key()
     if session_key is not None:
+        now = time.monotonic()
         with _session_proxy_lock:
+            _session_proxy_targets.pop(session_key, None)
             _session_proxy_targets[session_key] = (host, port)
+            _session_proxy_last_seen[session_key] = now
+            _prune_session_proxy_targets_locked(now)
         return
     IDA_HOST = host
     IDA_PORT = port
@@ -140,6 +178,7 @@ def _clear_active_ida_target() -> tuple[str, int]:
     if session_key is not None:
         with _session_proxy_lock:
             _session_proxy_targets.pop(session_key, None)
+            _session_proxy_last_seen.pop(session_key, None)
         return IDA_HOST, IDA_PORT
     IDA_HOST = DEFAULT_IDA_HOST
     IDA_PORT = DEFAULT_IDA_PORT

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -87,8 +87,10 @@ class ProxyOpenFileResult(TypedDict, total=False):
     result: Any
 
 
-IDA_HOST = "127.0.0.1"
-IDA_PORT = 13337
+DEFAULT_IDA_HOST = "127.0.0.1"
+DEFAULT_IDA_PORT = 13337
+IDA_HOST = DEFAULT_IDA_HOST
+IDA_PORT = DEFAULT_IDA_PORT
 
 mcp = McpServer("ida-pro-mcp")
 dispatch_original = mcp.registry.dispatch
@@ -98,6 +100,51 @@ OUTPUT_PROXY_CACHE_MAX_SIZE = 100
 _OUTPUT_PATH_RE = re.compile(r"^/output/([a-f0-9-]+)\.(\w+)$")
 _output_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
 _output_proxy_lock = threading.Lock()
+_session_proxy_targets: dict[str, tuple[str, int]] = {}
+_session_proxy_lock = threading.Lock()
+
+
+def _get_proxy_session_key() -> str | None:
+    """Return the active MCP transport session id, if one is available."""
+    return mcp.get_current_transport_session_id()
+
+
+def _get_active_ida_target() -> tuple[str, int]:
+    """Return the IDA target selected for this MCP transport session."""
+    session_key = _get_proxy_session_key()
+    if session_key is not None:
+        with _session_proxy_lock:
+            target = _session_proxy_targets.get(session_key)
+        if target is not None:
+            return target
+    return IDA_HOST, IDA_PORT
+
+
+def _set_active_ida_target(host: str, port: int) -> None:
+    """Select an IDA target for the current session, falling back to process-wide state."""
+    global IDA_HOST, IDA_PORT
+    session_key = _get_proxy_session_key()
+    if session_key is not None:
+        with _session_proxy_lock:
+            _session_proxy_targets[session_key] = (host, port)
+        return
+    IDA_HOST = host
+    IDA_PORT = port
+    set_ida_rpc(IDA_HOST, IDA_PORT)
+
+
+def _clear_active_ida_target() -> tuple[str, int]:
+    """Clear the current session's target selection and return the default target."""
+    global IDA_HOST, IDA_PORT
+    session_key = _get_proxy_session_key()
+    if session_key is not None:
+        with _session_proxy_lock:
+            _session_proxy_targets.pop(session_key, None)
+        return IDA_HOST, IDA_PORT
+    IDA_HOST = DEFAULT_IDA_HOST
+    IDA_PORT = DEFAULT_IDA_PORT
+    set_ida_rpc(IDA_HOST, IDA_PORT)
+    return IDA_HOST, IDA_PORT
 
 
 def _extract_output_id(response: dict) -> str | None:
@@ -200,7 +247,8 @@ def _proxy_output_download(host: str, port: int, path: str) -> tuple[int, str, l
 
 def _proxy_to_ida(payload: bytes | str | dict) -> dict:
     """Send a JSON-RPC request to the active IDA instance and return the response."""
-    return _proxy_to_instance(IDA_HOST, IDA_PORT, payload)
+    host, port = _get_active_ida_target()
+    return _proxy_to_instance(host, port, payload)
 
 
 def _call_ida_tool(host: str, port: int, name: str, arguments: dict[str, Any]) -> Any:
@@ -347,6 +395,7 @@ class ProxyHttpRequestHandler(McpHttpRequestHandler):
 @mcp.tool
 def list_instances() -> list[ProxyInstanceInfo]:
     """List discovered IDA Pro instances and indicate which one is active."""
+    active_host, active_port = _get_active_ida_target()
     result = []
     for inst in discover_instances():
         reachable = probe_instance(inst["host"], inst["port"])
@@ -354,7 +403,7 @@ def list_instances() -> list[ProxyInstanceInfo]:
             {
                 **inst,
                 "reachable": reachable,
-                "active": inst["host"] == IDA_HOST and inst["port"] == IDA_PORT,
+                "active": inst["host"] == active_host and inst["port"] == active_port,
             }
         )
     return result
@@ -370,22 +419,17 @@ def select_instance(
     Use list_instances first to see available instances, then select one by port.
     All subsequent tool calls will be routed to the selected instance.
     """
-    global IDA_HOST, IDA_PORT
     if port == 0:
-        IDA_HOST = "127.0.0.1"
-        IDA_PORT = 13337
-        set_ida_rpc(IDA_HOST, IDA_PORT)
+        default_host, default_port = _clear_active_ida_target()
         return {
             "success": True,
-            "host": IDA_HOST,
-            "port": IDA_PORT,
+            "host": default_host,
+            "port": default_port,
             "message": "Reset to default IDA target",
         }
     if not probe_instance(host, port):
         return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
-    IDA_HOST = host
-    IDA_PORT = port
-    set_ida_rpc(IDA_HOST, IDA_PORT)
+    _set_active_ida_target(host, port)
     return {"success": True, "host": host, "port": port}
 
 
@@ -413,8 +457,7 @@ def open_file(
     implementation so discovery/launch remains available even when the currently
     selected instance is down.
     """
-    target_host = IDA_HOST
-    target_port = IDA_PORT
+    target_host, target_port = _get_active_ida_target()
     if not probe_instance(target_host, target_port):
         target_host = ""
         target_port = 0
@@ -449,7 +492,16 @@ def open_file(
     except Exception as e:
         return {"success": False, "error": str(e)}
 
-    return result if isinstance(result, dict) else {"success": True, "result": result}
+    if isinstance(result, dict):
+        if (
+            switch
+            and result.get("success")
+            and result.get("host")
+            and result.get("port")
+        ):
+            _set_active_ida_target(str(result["host"]), int(result["port"]))
+        return result
+    return {"success": True, "result": result}
 
 
 # ============================================================================

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -93,6 +93,19 @@ class _TransportMcp:
         return self.session_id
 
 
+def _patch_discovery(*, instances, probe):
+    old_discover = supmod._discovery.discover_instances
+    old_probe = supmod._discovery.probe_instance
+    supmod._discovery.discover_instances = lambda: instances
+    supmod._discovery.probe_instance = lambda *_args, **_kwargs: probe
+
+    def restore():
+        supmod._discovery.discover_instances = old_discover
+        supmod._discovery.probe_instance = old_probe
+
+    return restore
+
+
 def test_supervisor_import_does_not_import_ida_modules():
     assert "idapro" not in sys.modules
     assert "idaapi" not in sys.modules
@@ -136,3 +149,66 @@ def test_resolve_session_accepts_session_id_filename_and_context(tmp_path):
     assert sup.resolve_session("sample").session_id == "sample"
     assert sup.resolve_session("sample.bin").session_id == "sample"
     assert sup.resolve_session(None).session_id == "sample"
+
+
+def test_open_session_uses_matching_gui_instance(tmp_path):
+    sample = tmp_path / "sample.bin"
+    idb = tmp_path / "sample.bin.i64"
+    sample.write_bytes(b"x")
+    idb.write_bytes(b"idb")
+    restore = _patch_discovery(
+        instances=[
+            {
+                "host": "127.0.0.1",
+                "port": 31337,
+                "pid": 999,
+                "binary": "sample.bin",
+                "idb_path": str(idb),
+                "started_at": "now",
+            }
+        ],
+        probe=True,
+    )
+    try:
+        sup = _FakeSupervisor()
+        session = sup.open_session(str(sample), session_id="gui", context_id="ctx")
+        assert session.backend == "gui"
+        assert session.host == "127.0.0.1"
+        assert session.port == 31337
+        assert session.pid == 999
+        assert sup.resolve_session(str(sample)).session_id == "gui"
+        assert sup.resolve_session(str(idb)).session_id == "gui"
+        assert sup.opened == []
+    finally:
+        restore()
+
+
+def test_closed_gui_session_reopens_headless(tmp_path):
+    sample = tmp_path / "sample.bin"
+    idb = tmp_path / "sample.bin.i64"
+    sample.write_bytes(b"x")
+    idb.write_bytes(b"idb")
+    restore = _patch_discovery(
+        instances=[
+            {
+                "host": "127.0.0.1",
+                "port": 31337,
+                "pid": 999,
+                "binary": "sample.bin",
+                "idb_path": str(idb),
+                "started_at": "now",
+            }
+        ],
+        probe=True,
+    )
+    try:
+        sup = _FakeSupervisor()
+        session = sup.open_session(str(sample), session_id="gui", context_id="ctx")
+        assert session.backend == "gui"
+        supmod._discovery.probe_instance = lambda *_args, **_kwargs: False
+        reopened = sup.resolve_session("gui")
+        assert reopened.backend == "worker"
+        assert reopened.session_id == "gui"
+        assert sup.opened[-1][1]["input_path"] == str(idb.resolve())
+    finally:
+        restore()

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -299,3 +299,35 @@ def test_closed_gui_session_reopens_headless(tmp_path):
         assert sup.opened[-1][1]["input_path"] == str(idb.resolve())
     finally:
         restore()
+
+
+def test_closed_gui_session_falls_back_to_requested_binary_if_idb_is_stale(tmp_path):
+    sample = tmp_path / "sample.bin"
+    idb = tmp_path / "sample.bin.i64"
+    sample.write_bytes(b"x")
+    idb.write_bytes(b"idb")
+    restore = _patch_discovery(
+        instances=[
+            {
+                "host": "127.0.0.1",
+                "port": 31337,
+                "pid": 999,
+                "binary": "sample.bin",
+                "idb_path": str(idb),
+                "started_at": "now",
+            }
+        ],
+        probe=True,
+    )
+    try:
+        sup = _FakeSupervisor()
+        session = sup.open_session(str(sample), session_id="gui", context_id="ctx")
+        assert session.backend == "gui"
+        idb.unlink()
+        supmod._discovery.probe_instance = lambda *_args, **_kwargs: False
+        reopened = sup.resolve_session("gui")
+        assert reopened.backend == "worker"
+        assert reopened.session_id == "gui"
+        assert sup.opened[-1][1]["input_path"] == str(sample.resolve())
+    finally:
+        restore()

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -43,7 +43,7 @@ class _FakeSupervisor(supmod.IdalibSupervisor):
             process=_FakeProcess(),
         )
 
-    def _worker_rpc(self, worker, payload, *, timeout=300.0):
+    def _worker_rpc(self, worker, payload, *, timeout=None):
         method = payload.get("method")
         if method == "tools/list":
             return {
@@ -113,6 +113,50 @@ def _patch_discovery(*, instances, probe):
 def test_supervisor_import_does_not_import_ida_modules():
     assert "idapro" not in sys.modules
     assert "idaapi" not in sys.modules
+
+
+def test_worker_rpc_default_has_no_socket_timeout(monkeypatch):
+    class _FakeResponse:
+        status = 200
+        reason = "OK"
+
+        def read(self):
+            return b'{"jsonrpc":"2.0","result":{"ok":true},"id":1}'
+
+    class _FakeConnection:
+        instances = []
+
+        def __init__(self, host, port, timeout=None):
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+            type(self).instances.append(self)
+
+        def request(self, method, path, body, headers):
+            pass
+
+        def getresponse(self):
+            return _FakeResponse()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(supmod.http.client, "HTTPConnection", _FakeConnection)
+    sup = supmod.IdalibSupervisor(supmod.McpServer("test"))
+    worker = supmod.WorkerSession(
+        session_id="worker",
+        input_path="",
+        filename="",
+        host="127.0.0.1",
+        port=12345,
+        process=_FakeProcess(),
+    )
+
+    sup._worker_rpc(worker, {"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    sup._worker_rpc(worker, {"jsonrpc": "2.0", "id": 2, "method": "ping"}, timeout=2.0)
+
+    assert _FakeConnection.instances[0].timeout is None
+    assert _FakeConnection.instances[1].timeout == 2.0
 
 
 def test_worker_tools_inject_database_and_filter_management_tools():

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -314,6 +314,53 @@ def test_open_session_race_rejects_different_requested_session_id(tmp_path):
         restore()
 
 
+def test_open_session_race_rejects_duplicate_session_id_for_different_path(tmp_path):
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    first.write_bytes(b"1")
+    second.write_bytes(b"2")
+
+    class _RaceSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__()
+            self.spawned = []
+
+        def _spawn_worker(self):
+            worker = super()._spawn_worker()
+            self.spawned.append(worker)
+            return worker
+
+        def call_worker_tool(self, worker, name, arguments=None):
+            result = super().call_worker_tool(worker, name, arguments)
+            if name == "idalib_open":
+                existing = supmod.WorkerSession(
+                    session_id=arguments["session_id"],
+                    input_path=str(first.resolve()),
+                    filename="first.bin",
+                    process=_FakeProcess(),
+                )
+                with self._lock:
+                    self._register_session_locked(existing, str(first.resolve()), None)
+            return result
+
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _RaceSupervisor()
+        try:
+            sup.open_session(str(second), session_id="shared")
+        except ValueError as e:
+            assert "Session already exists: shared" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+
+        assert set(sup.sessions) == {"shared"}
+        assert sup.sessions["shared"].input_path == str(first.resolve())
+        assert sup.path_to_session.get(sup._path_key(str(second.resolve()))) is None
+        assert sup.spawned[0].process.returncode == 0
+    finally:
+        restore()
+
+
 def test_closed_gui_session_reopens_headless(tmp_path):
     sample = tmp_path / "sample.bin"
     idb = tmp_path / "sample.bin.i64"

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -253,6 +253,33 @@ def test_open_session_removes_stale_existing_mapping(tmp_path):
         restore()
 
 
+def test_open_session_ignores_dead_workers_for_max_worker_limit(tmp_path):
+    stale_path = tmp_path / "stale.bin"
+    new_path = tmp_path / "new.bin"
+    stale_path.write_bytes(b"stale")
+    new_path.write_bytes(b"new")
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _FakeSupervisor()
+        sup.max_workers = 1
+        stale = supmod.WorkerSession(
+            session_id="stale",
+            input_path=str(stale_path.resolve()),
+            filename="stale.bin",
+            process=_DeadProcess(),
+        )
+        with sup._lock:
+            sup._register_session_locked(stale, str(stale_path.resolve()), "ctx")
+
+        session = sup.open_session(str(new_path), session_id="new", context_id="ctx")
+
+        assert session.session_id == "new"
+        assert "stale" not in sup.sessions
+        assert sup.context_bindings["ctx"] == "new"
+    finally:
+        restore()
+
+
 def test_open_session_race_discards_losing_worker_for_existing_path(tmp_path):
     sample = tmp_path / "sample.bin"
     sample.write_bytes(b"x")
@@ -420,5 +447,59 @@ def test_closed_gui_session_falls_back_to_requested_binary_if_idb_is_stale(tmp_p
         assert reopened.backend == "worker"
         assert reopened.session_id == "gui"
         assert sup.opened[-1][1]["input_path"] == str(sample.resolve())
+    finally:
+        restore()
+
+
+def test_closed_gui_session_does_not_reappear_if_closed_during_headless_fallback(tmp_path):
+    sample = tmp_path / "sample.bin"
+    idb = tmp_path / "sample.bin.i64"
+    sample.write_bytes(b"x")
+    idb.write_bytes(b"idb")
+
+    class _RaceSupervisor(_FakeSupervisor):
+        def __init__(self):
+            super().__init__()
+            self.spawned = []
+
+        def _spawn_worker(self):
+            worker = super()._spawn_worker()
+            self.spawned.append(worker)
+            return worker
+
+        def call_worker_tool(self, worker, name, arguments=None):
+            result = super().call_worker_tool(worker, name, arguments)
+            if name == "idalib_open":
+                self.close_session(arguments["session_id"])
+            return result
+
+    restore = _patch_discovery(
+        instances=[
+            {
+                "host": "127.0.0.1",
+                "port": 31337,
+                "pid": 999,
+                "binary": "sample.bin",
+                "idb_path": str(idb),
+                "started_at": "now",
+            }
+        ],
+        probe=True,
+    )
+    try:
+        sup = _RaceSupervisor()
+        session = sup.open_session(str(sample), session_id="gui", context_id="ctx")
+        assert session.backend == "gui"
+        supmod._discovery.probe_instance = lambda *_args, **_kwargs: False
+
+        try:
+            sup.resolve_session("gui")
+        except RuntimeError as e:
+            assert "was closed or replaced" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+        assert "gui" not in sup.sessions
+        assert sup.spawned[-1].process.returncode == 0
     finally:
         restore()

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -11,7 +11,7 @@ class _FakeProcess:
     returncode = None
 
     def poll(self):
-        return None
+        return self.returncode
 
     def terminate(self):
         self.returncode = 0
@@ -21,6 +21,10 @@ class _FakeProcess:
 
     def kill(self):
         self.returncode = -9
+
+
+class _DeadProcess(_FakeProcess):
+    returncode = 1
 
 
 class _FakeSupervisor(supmod.IdalibSupervisor):
@@ -179,6 +183,89 @@ def test_open_session_uses_matching_gui_instance(tmp_path):
         assert sup.resolve_session(str(sample)).session_id == "gui"
         assert sup.resolve_session(str(idb)).session_id == "gui"
         assert sup.opened == []
+    finally:
+        restore()
+
+
+def test_open_session_removes_stale_existing_mapping(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _FakeSupervisor()
+        stale = supmod.WorkerSession(
+            session_id="stale",
+            input_path=str(sample.resolve()),
+            filename="sample.bin",
+            process=_DeadProcess(),
+        )
+        with sup._lock:
+            sup._register_session_locked(stale, str(sample.resolve()), "ctx")
+        session = sup.open_session(str(sample), session_id="new", context_id="ctx")
+        assert session.session_id == "new"
+        assert "stale" not in sup.sessions
+        assert sup.context_bindings["ctx"] == "new"
+    finally:
+        restore()
+
+
+def test_open_session_race_discards_losing_worker_for_existing_path(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+
+    class _RaceSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None):
+            result = super().call_worker_tool(worker, name, arguments)
+            if name == "idalib_open":
+                existing = supmod.WorkerSession(
+                    session_id="winner",
+                    input_path=str(sample.resolve()),
+                    filename="sample.bin",
+                    process=_FakeProcess(),
+                )
+                with self._lock:
+                    self._register_session_locked(existing, str(sample.resolve()), None)
+            return result
+
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _RaceSupervisor()
+        session = sup.open_session(str(sample))
+        assert session.session_id == "winner"
+        assert set(sup.sessions) == {"winner"}
+        assert sup.opened[0][1]["session_id"] != "winner"
+    finally:
+        restore()
+
+
+def test_open_session_race_rejects_different_requested_session_id(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+
+    class _RaceSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None):
+            result = super().call_worker_tool(worker, name, arguments)
+            if name == "idalib_open":
+                existing = supmod.WorkerSession(
+                    session_id="winner",
+                    input_path=str(sample.resolve()),
+                    filename="sample.bin",
+                    process=_FakeProcess(),
+                )
+                with self._lock:
+                    self._register_session_locked(existing, str(sample.resolve()), None)
+            return result
+
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _RaceSupervisor()
+        try:
+            sup.open_session(str(sample), session_id="loser")
+        except ValueError as e:
+            assert "already open as session 'winner'" in str(e)
+        else:
+            raise AssertionError("expected ValueError")
+        assert set(sup.sessions) == {"winner"}
     finally:
         restore()
 

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -1,0 +1,138 @@
+"""idalib supervisor tests that do not require IDA/idalib."""
+
+import sys
+from pathlib import Path
+
+from ida_pro_mcp import idalib_supervisor as supmod
+
+
+class _FakeProcess:
+    pid = 12345
+    returncode = None
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        self.returncode = 0
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        self.returncode = -9
+
+
+class _FakeSupervisor(supmod.IdalibSupervisor):
+    def __init__(self):
+        super().__init__(supmod.McpServer("test"), max_workers=4)
+        self.forwarded: list[dict] = []
+        self.opened: list[tuple[str, dict]] = []
+
+    def _spawn_worker(self):
+        return supmod.WorkerSession(
+            session_id="__schema__",
+            input_path="",
+            filename="",
+            host="127.0.0.1",
+            port=1,
+            process=_FakeProcess(),
+        )
+
+    def _worker_rpc(self, worker, payload, *, timeout=300.0):
+        method = payload.get("method")
+        if method == "tools/list":
+            return {
+                "jsonrpc": "2.0",
+                "id": payload.get("id"),
+                "result": {
+                    "tools": [
+                        {
+                            "name": "decompile",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"addr": {"type": "string"}},
+                                "required": ["addr"],
+                            },
+                        },
+                        {"name": "idalib_open", "inputSchema": {"type": "object"}},
+                    ]
+                },
+            }
+        if method == "resources/list":
+            return {"jsonrpc": "2.0", "id": payload.get("id"), "result": {"resources": []}}
+        if method == "resources/templates/list":
+            return {"jsonrpc": "2.0", "id": payload.get("id"), "result": {"resourceTemplates": []}}
+        self.forwarded.append(payload)
+        return {"jsonrpc": "2.0", "id": payload.get("id"), "result": {"ok": True}}
+
+    def call_worker_tool(self, worker, name, arguments=None):
+        if name == "idalib_open":
+            assert arguments is not None
+            self.opened.append((name, arguments))
+            return {
+                "success": True,
+                "session": {
+                    "session_id": arguments["session_id"],
+                    "input_path": arguments["input_path"],
+                    "filename": Path(arguments["input_path"]).name,
+                    "created_at": "now",
+                    "last_accessed": "now",
+                    "is_analyzing": False,
+                    "metadata": {},
+                },
+            }
+        return {"ok": True, "error": None}
+
+
+class _TransportMcp:
+    def __init__(self, session_id="stdio:default"):
+        self.session_id = session_id
+
+    def get_current_transport_session_id(self):
+        return self.session_id
+
+
+def test_supervisor_import_does_not_import_ida_modules():
+    assert "idapro" not in sys.modules
+    assert "idaapi" not in sys.modules
+
+
+def test_worker_tools_inject_database_and_filter_management_tools():
+    sup = _FakeSupervisor()
+    tools = sup.worker_tools()
+    names = [tool["name"] for tool in tools]
+    assert names == ["decompile"]
+    schema = tools[0]["inputSchema"]
+    assert "database" in schema["properties"]
+    assert "database" not in schema.get("required", [])
+
+
+def test_tool_error_result_omits_structured_content():
+    result = supmod._call_tool_result({"error": "no database"}, is_error=True)
+    assert result["isError"] is True
+    assert "structuredContent" not in result
+
+
+def test_open_session_reuses_schema_worker_and_binds_context(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    sup.worker_tools()  # creates the idle/schema worker
+    session = sup.open_session(str(sample), session_id="sample", context_id="ctx")
+    assert session.session_id == "sample"
+    assert sup.context_bindings["ctx"] == "sample"
+    assert sup.opened[0][1]["session_id"] == "sample"
+
+
+def test_resolve_session_accepts_session_id_filename_and_context(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    sup.open_session(str(sample), session_id="sample", context_id="ctx")
+    sup.mcp = _TransportMcp()
+    sup.context_bindings[supmod.SHARED_FALLBACK_CONTEXT_ID] = "sample"
+
+    assert sup.resolve_session("sample").session_id == "sample"
+    assert sup.resolve_session("sample.bin").session_id == "sample"
+    assert sup.resolve_session(None).session_id == "sample"

--- a/tests/test_mcp_spec_http_e2e.py
+++ b/tests/test_mcp_spec_http_e2e.py
@@ -75,7 +75,7 @@ class HttpE2EBootstrapTests(unittest.TestCase):
         cls.harness.__exit__(None, None, None)
 
     def test_initialize_returns_valid_initialize_result(self):
-        _, _, body = self.harness.post_jsonrpc(
+        _, headers, body = self.harness.post_jsonrpc(
             "initialize",
             params={
                 "protocolVersion": "2024-11-05",
@@ -87,6 +87,9 @@ class HttpE2EBootstrapTests(unittest.TestCase):
         assert_schema(body["result"], INITIALIZE_RESULT_SCHEMA)
         self.assertEqual(body["result"]["serverInfo"]["name"], "e2e-test")
         self.assertEqual(body["result"]["serverInfo"]["version"], "9.9.9")
+        session_id = headers.get("Mcp-Session-Id")
+        self.assertTrue(session_id)
+        self.assertTrue(self.harness.server.has_http_session(session_id))
 
     def test_ping_returns_empty_result(self):
         _, _, body = self.harness.post_jsonrpc("ping")

--- a/tests/test_mcp_spec_http_e2e.py
+++ b/tests/test_mcp_spec_http_e2e.py
@@ -2,6 +2,7 @@
 
 import sys
 import pathlib
+import time
 import unittest
 from typing import Annotated, TypedDict
 
@@ -95,6 +96,23 @@ class HttpE2EBootstrapTests(unittest.TestCase):
         _, _, body = self.harness.post_jsonrpc("ping")
         assert_schema(body, JSONRPC_RESPONSE_SCHEMA)
         self.assertEqual(body["result"], {})
+
+    def test_http_session_registry_is_bounded(self):
+        srv = McpServer("session-bounds")
+        srv.http_session_max_count = 2
+        srv.register_http_session("a")
+        srv.register_http_session("b")
+        srv.register_http_session("c")
+        self.assertFalse(srv.has_http_session("a"))
+        self.assertTrue(srv.has_http_session("b"))
+        self.assertTrue(srv.has_http_session("c"))
+
+    def test_http_session_registry_expires_stale_entries(self):
+        srv = McpServer("session-ttl")
+        srv.http_session_ttl_sec = 1
+        srv.register_http_session("expired")
+        srv._http_sessions["expired"] = time.monotonic() - 10
+        self.assertFalse(srv.has_http_session("expired"))
 
 
 class HttpE2EToolsDiscoveryTests(unittest.TestCase):

--- a/tests/test_mcp_spec_schema_generation.py
+++ b/tests/test_mcp_spec_schema_generation.py
@@ -36,6 +36,33 @@ class WithOptional(TypedDict):
     maybe: NotRequired[int]
 
 
+class OptionalContextFields(TypedDict):
+    context_id: NotRequired[str]
+    transport_context_id: NotRequired[str | None]
+    isolated_contexts: NotRequired[bool]
+
+
+class IdalibStyleResult(OptionalContextFields, total=False):
+    success: bool
+    error: str
+
+
+class SessionInfo(TypedDict):
+    session_id: str
+    input_path: str
+
+
+class SessionListInfo(SessionInfo, total=False):
+    is_active: bool
+    is_current_context: bool
+    bound_contexts: int
+
+
+class SessionListResult(OptionalContextFields, total=False):
+    sessions: list[SessionListInfo]
+    error: str
+
+
 class VariantA(TypedDict):
     kind: str
     value_a: int
@@ -133,6 +160,16 @@ class OutputSchemaShapeTests(unittest.TestCase):
             return {"required_field": "x"}
         self.assertEqual(self._schema_of(f).get("type"), "object")
 
+    def test_inherited_notrequired_fields_are_not_required(self):
+        def f() -> IdalibStyleResult:
+            """doc."""
+            return {"error": "bad input"}
+        schema = self._schema_of(f)
+        self.assertEqual(schema.get("type"), "object")
+        self.assertNotIn("context_id", schema.get("required", []))
+        self.assertNotIn("transport_context_id", schema.get("required", []))
+        self.assertNotIn("isolated_contexts", schema.get("required", []))
+
     def test_optional_typed_dict_root_type_is_object(self):
         def f() -> Optional[Inner]:
             """doc."""
@@ -221,6 +258,30 @@ class StructuredContentValidatesAgainstOutputSchemaTests(unittest.TestCase):
         def f() -> WithOptional:
             """doc."""
             return {"required_field": "x", "maybe": 99}
+        osch, result = self._both(f)
+        Draft202012Validator(osch).validate(result["structuredContent"])
+
+    def test_inherited_notrequired_omitted_fields_roundtrip(self):
+        def f() -> IdalibStyleResult:
+            """doc."""
+            return {"error": "bad input"}
+        osch, result = self._both(f)
+        Draft202012Validator(osch).validate(result["structuredContent"])
+
+    def test_session_list_declared_metadata_roundtrip(self):
+        def f() -> SessionListResult:
+            """doc."""
+            return {
+                "sessions": [
+                    {
+                        "session_id": "s1",
+                        "input_path": "sample.bin",
+                        "is_active": True,
+                        "is_current_context": True,
+                        "bound_contexts": 1,
+                    }
+                ]
+            }
         osch, result = self._both(f)
         Draft202012Validator(osch).validate(result["structuredContent"])
 

--- a/tests/test_no_protocol_stdout_prints.py
+++ b/tests/test_no_protocol_stdout_prints.py
@@ -1,0 +1,26 @@
+"""Protocol/runtime modules must not write logs to stdout.
+
+stdio MCP uses stdout for JSON-RPC frames, so accidental print() calls in
+zeromcp corrupt the transport. Use logging (stderr by default) instead.
+"""
+
+import ast
+from pathlib import Path
+
+
+PROTOCOL_MODULES = [
+    Path("src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py"),
+    Path("src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py"),
+    Path("src/ida_pro_mcp/ida_mcp/http.py"),
+    Path("src/ida_pro_mcp/idalib_supervisor.py"),
+]
+
+
+def test_protocol_modules_do_not_call_print():
+    offenders: list[str] = []
+    for path in PROTOCOL_MODULES:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "print":
+                offenders.append(f"{path}:{node.lineno}")
+    assert offenders == []

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -58,6 +58,17 @@ class DispatchProxyTransportTests(unittest.TestCase):
         _ResponseFailureConnection.reset()
         _Http503Connection.reset()
         _ConnectFailureConnection.reset()
+        self._old_host = server.IDA_HOST
+        self._old_port = server.IDA_PORT
+        self._old_session = getattr(server.mcp._transport_session_id, "data", None)
+        self._old_targets = server._session_proxy_targets.copy()
+
+    def tearDown(self):
+        server.IDA_HOST = self._old_host
+        server.IDA_PORT = self._old_port
+        server._session_proxy_targets.clear()
+        server._session_proxy_targets.update(self._old_targets)
+        server.mcp._transport_session_id.data = self._old_session
 
     def test_proxy_request_forwards_external_base_header(self):
         original_getter = server.get_current_request_external_base_url
@@ -112,6 +123,51 @@ class DispatchProxyTransportTests(unittest.TestCase):
             server._proxy_to_instance("127.0.0.1", 13337, b"{}")
 
         self.assertEqual(server._get_output_proxy_target(output_id), ("127.0.0.1", 13337))
+
+    def test_select_instance_is_scoped_to_transport_session(self):
+        with patch("ida_pro_mcp.server.probe_instance", lambda host, port: True):
+            server.mcp._transport_session_id.data = "http:session-a"
+            result_a = server.select_instance(port=11111, host="127.0.0.1")
+            self.assertTrue(result_a["success"])
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            result_b = server.select_instance(port=22222, host="127.0.0.1")
+            self.assertTrue(result_b["success"])
+
+            server.mcp._transport_session_id.data = "http:session-a"
+            self.assertEqual(server._get_active_ida_target(), ("127.0.0.1", 11111))
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            self.assertEqual(server._get_active_ida_target(), ("127.0.0.1", 22222))
+
+    def test_select_instance_does_not_change_process_default_for_session(self):
+        server.IDA_HOST = "127.0.0.1"
+        server.IDA_PORT = 13337
+        with patch("ida_pro_mcp.server.probe_instance", lambda host, port: True):
+            server.mcp._transport_session_id.data = "http:session-a"
+            result = server.select_instance(port=14444, host="127.0.0.1")
+            self.assertTrue(result["success"])
+            self.assertEqual((server.IDA_HOST, server.IDA_PORT), ("127.0.0.1", 13337))
+
+            server.mcp._transport_session_id.data = "http:session-b"
+            self.assertEqual(server._get_active_ida_target(), ("127.0.0.1", 13337))
+
+    def test_proxy_to_ida_uses_session_scoped_target(self):
+        class _RecordingConnection(_BaseFakeConnection):
+            def request(self, method, path, body, headers):
+                super().request(method, path, body, headers)
+                self.path = path
+                self.headers = headers
+
+            def getresponse(self):
+                return _FakeResponse()
+
+        _RecordingConnection.reset()
+        server.mcp._transport_session_id.data = "http:session-a"
+        server._session_proxy_targets["http:session-a"] = ("127.0.0.1", 15555)
+        with patch("ida_pro_mcp.server.http.client.HTTPConnection", _RecordingConnection):
+            server._proxy_to_ida(b"{}")
+        self.assertEqual((_RecordingConnection.instances[0].host, _RecordingConnection.instances[0].port), ("127.0.0.1", 15555))
 
     def test_dispatch_proxy_does_not_retry_post_send_failures(self):
         request = {"jsonrpc": "2.0", "method": "tools/call", "params": {}, "id": 1}

--- a/tests/test_server_transport.py
+++ b/tests/test_server_transport.py
@@ -1,4 +1,5 @@
 import json
+import time
 import unittest
 from unittest.mock import patch
 
@@ -62,12 +63,19 @@ class DispatchProxyTransportTests(unittest.TestCase):
         self._old_port = server.IDA_PORT
         self._old_session = getattr(server.mcp._transport_session_id, "data", None)
         self._old_targets = server._session_proxy_targets.copy()
+        self._old_target_last_seen = server._session_proxy_last_seen.copy()
+        self._old_target_ttl = server.SESSION_PROXY_TARGET_TTL_SEC
+        self._old_target_max = server.SESSION_PROXY_TARGET_MAX_SIZE
 
     def tearDown(self):
         server.IDA_HOST = self._old_host
         server.IDA_PORT = self._old_port
         server._session_proxy_targets.clear()
         server._session_proxy_targets.update(self._old_targets)
+        server._session_proxy_last_seen.clear()
+        server._session_proxy_last_seen.update(self._old_target_last_seen)
+        server.SESSION_PROXY_TARGET_TTL_SEC = self._old_target_ttl
+        server.SESSION_PROXY_TARGET_MAX_SIZE = self._old_target_max
         server.mcp._transport_session_id.data = self._old_session
 
     def test_proxy_request_forwards_external_base_header(self):
@@ -151,6 +159,32 @@ class DispatchProxyTransportTests(unittest.TestCase):
 
             server.mcp._transport_session_id.data = "http:session-b"
             self.assertEqual(server._get_active_ida_target(), ("127.0.0.1", 13337))
+
+    def test_session_scoped_targets_are_bounded(self):
+        server.SESSION_PROXY_TARGET_MAX_SIZE = 2
+        server.SESSION_PROXY_TARGET_TTL_SEC = 0
+        with patch("ida_pro_mcp.server.probe_instance", lambda host, port: True):
+            server.mcp._transport_session_id.data = "http:session-a"
+            self.assertTrue(server.select_instance(port=11111, host="127.0.0.1")["success"])
+            server.mcp._transport_session_id.data = "http:session-b"
+            self.assertTrue(server.select_instance(port=22222, host="127.0.0.1")["success"])
+            server.mcp._transport_session_id.data = "http:session-c"
+            self.assertTrue(server.select_instance(port=33333, host="127.0.0.1")["success"])
+
+        self.assertNotIn("http:session-a", server._session_proxy_targets)
+        self.assertIn("http:session-b", server._session_proxy_targets)
+        self.assertIn("http:session-c", server._session_proxy_targets)
+
+    def test_session_scoped_targets_expire(self):
+        server.IDA_HOST = "127.0.0.1"
+        server.IDA_PORT = 13337
+        server.SESSION_PROXY_TARGET_TTL_SEC = 1
+        server.mcp._transport_session_id.data = "http:stale"
+        server._session_proxy_targets["http:stale"] = ("127.0.0.1", 15555)
+        server._session_proxy_last_seen["http:stale"] = time.monotonic() - 10
+
+        self.assertEqual(server._get_active_ida_target(), ("127.0.0.1", 13337))
+        self.assertNotIn("http:stale", server._session_proxy_targets)
 
     def test_proxy_to_ida_uses_session_scoped_target(self):
         class _RecordingConnection(_BaseFakeConnection):


### PR DESCRIPTION
## Summary
- make `idalib-mcp` a supervisor that routes each open database to its own idalib worker process
- add stdio support, dynamic open/close without an initial input path, and an explicit optional `database` routing argument
- route to existing GUI IDA MCP instances when a requested IDB is already open, with headless fallback if the GUI disappears
- fix idalib structuredContent schema optionality/list metadata and keep IDA target selection scoped per MCP transport session
- remove protocol/runtime stdout prints that can corrupt stdio MCP

## Tests
- `python -m pytest tests -q`
