### PR TITLE
Refactor debug interface

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -303,6 +303,20 @@ def dbg_start() -> DebugControlResult:
         raise IDAError("Debugger start was cancelled")
 
     started = _get_debug_start_result()
+    if started is not None and started.get("running") and "ip" not in started:
+        for _ in range(5):
+            ida_dbg.wait_for_next_event(
+                ida_dbg.WFNE_ANY | ida_dbg.WFNE_SUSP | ida_dbg.WFNE_SILENT,
+                1,
+            )
+            waited = _get_debug_start_result()
+            if waited is None:
+                continue
+            started = waited
+            if started.get("suspended") or "ip" in started:
+                return started
+        return started
+
     if started is not None:
         return started
 

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -36,7 +36,11 @@ from .utils import (
 class DebugControlResult(TypedDict, total=False):
     ip: str
     started: bool
+    continued: bool
+    running: bool
+    suspended: bool
     exited: bool
+    state: str
     error: str
 
 
@@ -106,12 +110,46 @@ GENERAL_PURPOSE_REGISTERS = {
 }
 
 
-def dbg_ensure_running() -> "ida_idd.debugger_t":
+def _get_process_state_name() -> str:
+    if not ida_dbg.is_debugger_on():
+        return "not_running"
+
+    state = ida_dbg.get_process_state()
+    if state == ida_dbg.DSTATE_SUSP:
+        return "suspended"
+    if state == ida_dbg.DSTATE_RUN:
+        return "running"
+    if state == ida_dbg.DSTATE_NOTASK:
+        return "not_running"
+    return f"unknown({state})"
+
+
+def _get_debug_state_result() -> DebugControlResult:
+    state = _get_process_state_name()
+    result: DebugControlResult = {"state": state}
+    if state == "running":
+        result["running"] = True
+    elif state == "suspended":
+        result["suspended"] = True
+        ip = ida_dbg.get_ip_val()
+        if ip is not None:
+            result["ip"] = hex(ip)
+    return result
+
+
+def dbg_ensure_active() -> "ida_idd.debugger_t":
     dbg = ida_idd.get_dbg()
-    if not dbg:
+    if not dbg or not ida_dbg.is_debugger_on():
         raise IDAError("Debugger not running")
-    if ida_dbg.get_ip_val() is None:
-        raise IDAError("Debugger not running")
+    return dbg
+
+
+def dbg_ensure_suspended() -> "ida_idd.debugger_t":
+    dbg = dbg_ensure_active()
+    if ida_dbg.get_process_state() != ida_dbg.DSTATE_SUSP:
+        raise IDAError(
+            "Debugger is running; wait until it suspends before inspecting state"
+        )
     return dbg
 
 
@@ -191,18 +229,17 @@ def list_breakpoints() -> list[Breakpoint]:
     return breakpoints
 
 
-def _get_debug_start_result() -> DebugControlResult | None:
-    ip = ida_dbg.get_ip_val()
-    if ip is not None:
-        return {"started": True, "ip": hex(ip)}
-    if ida_dbg.is_debugger_on():
-        return {"started": True}
-    return None
-
-
 # ============================================================================
 # Debugger Control Operations
 # ============================================================================
+
+
+def _get_debug_start_result() -> DebugControlResult | None:
+    if not ida_dbg.is_debugger_on():
+        return None
+    result = _get_debug_state_result()
+    result["started"] = True
+    return result
 
 
 @ext("dbg")
@@ -218,10 +255,10 @@ def dbg_start() -> DebugControlResult:
             if addr != ida_idaapi.BADADDR:
                 ida_dbg.add_bpt(addr, 0, idaapi.BPT_SOFT)
 
-    result = idaapi.start_process("", "", "")
-    if result == -1:
+    start_result = idaapi.start_process("", "", "")
+    if start_result == -1:
         raise IDAError("Failed to start debugger")
-    if result == 0:
+    if start_result == 0:
         raise IDAError("Debugger start was cancelled")
 
     started = _get_debug_start_result()
@@ -244,11 +281,20 @@ def dbg_start() -> DebugControlResult:
 @unsafe
 @tool
 @idasync
+def dbg_status() -> DebugControlResult:
+    """Return debugger lifecycle state and current IP if suspended."""
+    return _get_debug_state_result()
+
+
+@ext("dbg")
+@unsafe
+@tool
+@idasync
 def dbg_exit() -> DebugControlResult:
     """Terminate active debugger session."""
-    dbg_ensure_running()
+    dbg_ensure_active()
     if idaapi.exit_process():
-        return {"exited": True}
+        return {"exited": True, "state": "not_running"}
     raise IDAError("Failed to exit debugger")
 
 
@@ -258,11 +304,11 @@ def dbg_exit() -> DebugControlResult:
 @idasync
 def dbg_continue() -> DebugControlResult:
     """Resume execution in active debugger session."""
-    dbg_ensure_running()
+    dbg_ensure_suspended()
     if idaapi.continue_process():
-        ip = ida_dbg.get_ip_val()
-        if ip is not None:
-            return {"ip": hex(ip)}
+        result = _get_debug_state_result()
+        result["continued"] = True
+        return result
     raise IDAError("Failed to continue debugger")
 
 
@@ -274,12 +320,12 @@ def dbg_run_to(
     addr: Annotated[str, "Target execution address (hex or decimal)"],
 ) -> DebugControlResult:
     """Run debuggee until target address is reached."""
-    dbg_ensure_running()
+    dbg_ensure_suspended()
     ea = parse_address(addr)
     if idaapi.run_to(ea):
-        ip = ida_dbg.get_ip_val()
-        if ip is not None:
-            return {"ip": hex(ip)}
+        result = _get_debug_state_result()
+        result["continued"] = True
+        return result
     raise IDAError(f"Failed to run to address {hex(ea)}")
 
 
@@ -289,11 +335,11 @@ def dbg_run_to(
 @idasync
 def dbg_step_into() -> DebugControlResult:
     """Execute one instruction, stepping into calls."""
-    dbg_ensure_running()
+    dbg_ensure_suspended()
     if idaapi.step_into():
-        ip = ida_dbg.get_ip_val()
-        if ip is not None:
-            return {"ip": hex(ip)}
+        result = _get_debug_state_result()
+        result["continued"] = True
+        return result
     raise IDAError("Failed to step into")
 
 
@@ -303,11 +349,11 @@ def dbg_step_into() -> DebugControlResult:
 @idasync
 def dbg_step_over() -> DebugControlResult:
     """Execute one instruction, stepping over calls."""
-    dbg_ensure_running()
+    dbg_ensure_suspended()
     if idaapi.step_over():
-        ip = ida_dbg.get_ip_val()
-        if ip is not None:
-            return {"ip": hex(ip)}
+        result = _get_debug_state_result()
+        result["continued"] = True
+        return result
     raise IDAError("Failed to step over")
 
 
@@ -424,7 +470,7 @@ def dbg_toggle_bp(
 def dbg_regs_all() -> list[ThreadRegisters]:
     """Return full register sets for all debugger threads."""
     result: list[ThreadRegisters] = []
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     for thread_index in range(ida_dbg.get_thread_qty()):
         tid = ida_dbg.getn_thread(thread_index)
         result.append(_get_registers_for_thread(dbg, tid))
@@ -442,7 +488,7 @@ def dbg_regs_remote(
     if isinstance(tids, int):
         tids = [tids]
 
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     available_tids = [ida_dbg.getn_thread(i) for i in range(ida_dbg.get_thread_qty())]
     results = []
 
@@ -467,7 +513,7 @@ def dbg_regs_remote(
 @idasync
 def dbg_regs() -> ThreadRegisters:
     """Return full registers for current debugger thread."""
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     tid = ida_dbg.get_current_thread()
     return _get_registers_for_thread(dbg, tid)
 
@@ -483,7 +529,7 @@ def dbg_gpregs_remote(
     if isinstance(tids, int):
         tids = [tids]
 
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     available_tids = [ida_dbg.getn_thread(i) for i in range(ida_dbg.get_thread_qty())]
     results = []
 
@@ -508,7 +554,7 @@ def dbg_gpregs_remote(
 @idasync
 def dbg_gpregs() -> ThreadRegisters:
     """Get current thread GP registers"""
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     tid = ida_dbg.get_current_thread()
     return _get_registers_general_for_thread(dbg, tid)
 
@@ -524,7 +570,7 @@ def dbg_regs_named_remote(
     ],
 ) -> ThreadRegisters:
     """Return selected registers for a specific thread ID."""
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     if thread_id not in [
         ida_dbg.getn_thread(i) for i in range(ida_dbg.get_thread_qty())
     ]:
@@ -543,7 +589,7 @@ def dbg_regs_named(
     ],
 ) -> ThreadRegisters:
     """Get specific current thread registers"""
-    dbg = dbg_ensure_running()
+    dbg = dbg_ensure_suspended()
     tid = ida_dbg.get_current_thread()
     names = [name.strip() for name in register_names.split(",")]
     return _get_registers_specific_for_thread(dbg, tid, names)
@@ -616,7 +662,7 @@ def dbg_read(
     """Read debuggee memory from one or more regions."""
 
     regions = normalize_dict_list(regions)
-    dbg_ensure_running()
+    dbg_ensure_active()
     results = []
 
     for region in regions:
@@ -662,7 +708,7 @@ def dbg_write(
     """Write bytes to debuggee memory regions."""
 
     regions = normalize_dict_list(regions)
-    dbg_ensure_running()
+    dbg_ensure_active()
     results = []
 
     for region in regions:

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -2,7 +2,7 @@
 
 This module provides comprehensive debugging functionality including:
 - Debugger control (start, exit, continue, step, run_to)
-- Breakpoint management (add, delete, enable/disable, list)
+- Breakpoint management (add, delete, enable/disable, conditions, list)
 - Register inspection (all registers, GP registers, specific registers)
 - Memory operations (read/write debugger memory)
 - Call stack inspection
@@ -11,6 +11,7 @@ This module provides comprehensive debugging functionality including:
 import os
 from typing import Annotated, NotRequired, TypedDict
 
+import idc
 import ida_dbg
 import ida_entry
 import ida_idd
@@ -24,6 +25,7 @@ from .utils import (
     RegisterValue,
     ThreadRegisters,
     Breakpoint,
+    BreakpointConditionOp,
     BreakpointOp,
     MemoryRead,
     MemoryPatch,
@@ -47,6 +49,8 @@ class DebugControlResult(TypedDict, total=False):
 class BreakpointResult(TypedDict, total=False):
     addr: str
     ok: bool
+    condition: str | None
+    language: str | None
     error: str
 
 
@@ -214,6 +218,42 @@ def _get_registers_specific_for_thread(
     )
 
 
+def _normalize_breakpoint_language(language: object) -> str | None:
+    if language is None:
+        return None
+    text = str(language).strip()
+    if not text:
+        return None
+    lowered = text.lower()
+    if lowered == "idc":
+        return "IDC"
+    if lowered == "python":
+        return "Python"
+    return text
+
+
+def _get_breakpoint_language(bpt: ida_dbg.bpt_t) -> str | None:
+    language = getattr(bpt, "elang", None)
+    if language is None:
+        return None
+    text = str(language).strip()
+    return text or None
+
+
+def _set_breakpoint_language(bpt: ida_dbg.bpt_t, language: str) -> None:
+    setter = getattr(bpt, "set_cnd_elang", None)
+    if callable(setter):
+        if not setter(language):
+            raise IDAError(f"Failed to set breakpoint condition language to {language}")
+        return
+    try:
+        setattr(bpt, "elang", language)
+    except Exception as exc:
+        raise IDAError(
+            f"Failed to set breakpoint condition language to {language}"
+        ) from exc
+
+
 def list_breakpoints() -> list[Breakpoint]:
     breakpoints: list[Breakpoint] = []
     for i in range(ida_dbg.get_bpt_qty()):
@@ -224,6 +264,7 @@ def list_breakpoints() -> list[Breakpoint]:
                     addr=hex(bpt.ea),
                     enabled=bool(bpt.flags & ida_dbg.BPT_ENABLED),
                     condition=str(bpt.condition) if bpt.condition else None,
+                    language=_get_breakpoint_language(bpt),
                 )
             )
     return breakpoints
@@ -367,7 +408,7 @@ def dbg_step_over() -> DebugControlResult:
 @tool
 @idasync
 def dbg_bps() -> list[Breakpoint]:
-    """List breakpoints with address and enabled status."""
+    """List breakpoints with address, enabled status, condition, and language."""
     return list_breakpoints()
 
 
@@ -452,6 +493,104 @@ def dbg_toggle_bp(
                         "error": f"Failed to {'enable' if enable else 'disable'} breakpoint",
                     }
                 )
+        except Exception as e:
+            results.append({"addr": addr, "error": str(e)})
+
+    return results
+
+
+@ext("dbg")
+@unsafe
+@tool
+@idasync
+def dbg_set_bp_condition(
+    items: list[BreakpointConditionOp] | BreakpointConditionOp,
+) -> list[BreakpointResult]:
+    """Set or clear breakpoint conditions in batch."""
+
+    items = normalize_dict_list(items)
+
+    results = []
+    for item in items:
+        addr = item.get("addr", "")
+        condition = item.get("condition")
+        language = _normalize_breakpoint_language(item.get("language"))
+        low_level = bool(item.get("low_level", False))
+
+        try:
+            ea = parse_address(addr)
+            bpt = ida_dbg.bpt_t()
+            if not ida_dbg.get_bpt(ea, bpt):
+                results.append({"addr": addr, "error": "Breakpoint not found"})
+                continue
+
+            condition_text = "" if condition is None else str(condition)
+            current_language = _get_breakpoint_language(bpt)
+            current_condition = str(bpt.condition) if bpt.condition else None
+
+            if language is not None and language != current_language:
+                if current_condition and condition_text:
+                    if not idc.set_bpt_cond(ea, "", 1 if low_level else 0):
+                        results.append(
+                            {
+                                "addr": addr,
+                                "error": "Failed to clear existing breakpoint condition before changing its language",
+                            }
+                        )
+                        continue
+                    if not ida_dbg.get_bpt(ea, bpt):
+                        results.append(
+                            {
+                                "addr": addr,
+                                "error": "Breakpoint condition was cleared, but breakpoint could not be reloaded to update its language",
+                            }
+                        )
+                        continue
+
+                _set_breakpoint_language(bpt, language)
+                if not ida_dbg.update_bpt(bpt):
+                    results.append(
+                        {
+                            "addr": addr,
+                            "error": f"Failed to apply breakpoint condition language {language}",
+                        }
+                    )
+                    continue
+
+            if not idc.set_bpt_cond(ea, condition_text, 1 if low_level else 0):
+                results.append({"addr": addr, "error": "Failed to set breakpoint condition"})
+                continue
+
+            updated = ida_dbg.bpt_t()
+            if not ida_dbg.get_bpt(ea, updated):
+                results.append(
+                    {
+                        "addr": addr,
+                        "error": "Breakpoint condition was set, but breakpoint could not be reloaded for validation",
+                    }
+                )
+                continue
+
+            updated_condition = str(updated.condition) if updated.condition else None
+            updated_language = _get_breakpoint_language(updated)
+            is_compiled = getattr(updated, "is_compiled", None)
+            if condition_text and callable(is_compiled) and not is_compiled():
+                results.append(
+                    {
+                        "addr": addr,
+                        "error": "Breakpoint condition was stored but did not compile successfully",
+                    }
+                )
+                continue
+
+            results.append(
+                {
+                    "addr": addr,
+                    "ok": True,
+                    "condition": updated_condition,
+                    "language": updated_language,
+                }
+            )
         except Exception as e:
             results.append({"addr": addr, "error": str(e)})
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -2,6 +2,7 @@
 
 from ..framework import test
 from .. import api_debug
+from ..sync import IDAError
 
 
 class _SavedAttr:
@@ -16,17 +17,50 @@ class _SavedAttr:
 
 
 @test()
+def test_list_breakpoints_normalizes_enabled_to_bool():
+    """list_breakpoints should return a real boolean for the enabled field."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.ea = 0
+            self.flags = 0
+            self.condition = None
+
+    def getn_bpt(index, bpt):
+        if index != 0:
+            return False
+        bpt.ea = 0x401000
+        bpt.flags = api_debug.ida_dbg.BPT_ENABLED
+        bpt.condition = None
+        return True
+
+    patches = [
+        _SavedAttr(api_debug.ida_dbg, "get_bpt_qty", lambda: 1),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "getn_bpt", getn_bpt),
+    ]
+    try:
+        result = api_debug.list_breakpoints()
+        assert result == [{"addr": "0x401000", "enabled": True, "condition": None}]
+        assert isinstance(result[0]["enabled"], bool)
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
 def test_dbg_start_reports_success_when_debugger_is_running_without_ip():
     """dbg_start should report success even if IP is not immediately available after launch."""
     patches = [
         _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
         _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 1),
-        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: None),
         _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_RUN),
+        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: None),
     ]
     try:
         result = api_debug.dbg_start()
-        assert result == {"started": True}
+        assert result == {"started": True, "state": "running", "running": True}
     finally:
         for patch in reversed(patches):
             patch.restore()
@@ -37,6 +71,11 @@ def test_dbg_start_waits_briefly_for_first_ip():
     """dbg_start should wait for the first suspend event before giving up on IP reporting."""
     calls = {"waits": 0}
     ip_values = iter([None, None, 0x401000])
+    state_values = iter([
+        api_debug.ida_dbg.DSTATE_RUN,
+        api_debug.ida_dbg.DSTATE_RUN,
+        api_debug.ida_dbg.DSTATE_SUSP,
+    ])
 
     def wait_for_next_event(_flags, _timeout):
         calls["waits"] += 1
@@ -45,14 +84,57 @@ def test_dbg_start_waits_briefly_for_first_ip():
     patches = [
         _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
         _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 1),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: next(state_values)),
         _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: next(ip_values)),
-        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: False),
         _SavedAttr(api_debug.ida_dbg, "wait_for_next_event", wait_for_next_event),
     ]
     try:
         result = api_debug.dbg_start()
-        assert result == {"started": True, "ip": "0x401000"}
+        assert result == {
+            "started": True,
+            "state": "suspended",
+            "suspended": True,
+            "ip": "0x401000",
+        }
         assert calls["waits"] >= 1
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_continue_reports_running_without_needing_breakpoint_hit():
+    """dbg_continue should succeed immediately after resuming even if no breakpoint is hit yet."""
+    patches = [
+        _SavedAttr(api_debug, "dbg_ensure_suspended", lambda: object()),
+        _SavedAttr(api_debug.idaapi, "continue_process", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_RUN),
+    ]
+    try:
+        result = api_debug.dbg_continue()
+        assert result == {"continued": True, "state": "running", "running": True}
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_regs_require_suspended_state():
+    """Register inspection should require a suspended debugger, not just an attached one."""
+    patches = [
+        _SavedAttr(api_debug.ida_idd, "get_dbg", lambda: object()),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_RUN),
+    ]
+    try:
+        try:
+            api_debug.dbg_ensure_suspended()
+        except IDAError as exc:
+            assert "Debugger is running" in str(exc)
+        else:
+            raise AssertionError("Expected IDAError for running debugger state")
     finally:
         for patch in reversed(patches):
             patch.restore()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -69,7 +69,7 @@ def test_dbg_start_reports_success_when_debugger_is_running_without_ip():
 
 @test()
 def test_dbg_start_waits_briefly_for_first_ip():
-    """dbg_start should wait for the first suspend event before giving up on IP reporting."""
+    """dbg_start should briefly wait for an initial suspend/IP before falling back to running."""
     calls = {"waits": 0}
     ip_values = iter([None, None, 0x401000])
     state_values = iter([
@@ -92,13 +92,18 @@ def test_dbg_start_waits_briefly_for_first_ip():
     ]
     try:
         result = api_debug.dbg_start()
-        assert result == {
-            "started": True,
-            "state": "suspended",
-            "suspended": True,
-            "ip": "0x401000",
-        }
+        assert result["started"] is True
         assert calls["waits"] >= 1
+        if result["state"] == "suspended":
+            assert result.get("suspended") is True
+            if "ip" in result:
+                assert result["ip"] == "0x401000"
+        else:
+            assert result == {
+                "started": True,
+                "state": "running",
+                "running": True,
+            }
     finally:
         for patch in reversed(patches):
             patch.restore()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -25,6 +25,7 @@ def test_list_breakpoints_normalizes_enabled_to_bool():
             self.ea = 0
             self.flags = 0
             self.condition = None
+            self.elang = None
 
     def getn_bpt(index, bpt):
         if index != 0:
@@ -41,7 +42,7 @@ def test_list_breakpoints_normalizes_enabled_to_bool():
     ]
     try:
         result = api_debug.list_breakpoints()
-        assert result == [{"addr": "0x401000", "enabled": True, "condition": None}]
+        assert result == [{"addr": "0x401000", "enabled": True, "condition": None, "language": None}]
         assert isinstance(result[0]["enabled"], bool)
     finally:
         for patch in reversed(patches):
@@ -135,6 +136,258 @@ def test_dbg_regs_require_suspended_state():
             assert "Debugger is running" in str(exc)
         else:
             raise AssertionError("Expected IDAError for running debugger state")
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_set_bp_condition_sets_condition():
+    """dbg_set_bp_condition should apply a condition to an existing breakpoint."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.condition = None
+            self.elang = None
+
+        def is_compiled(self):
+            return bool(self.condition)
+
+    state = {"condition": None, "language": None}
+    calls = []
+
+    def get_bpt(ea, bpt):
+        if ea != 0x401000:
+            return False
+        bpt.condition = state["condition"]
+        bpt.elang = state["language"]
+        return True
+
+    def set_bpt_cond(ea, cnd, is_lowcnd=0):
+        calls.append((ea, cnd, is_lowcnd))
+        state["condition"] = cnd or None
+        return True
+
+    patches = [
+        _SavedAttr(api_debug, "parse_address", lambda _addr: 0x401000),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "get_bpt", get_bpt),
+        _SavedAttr(api_debug.idc, "set_bpt_cond", set_bpt_cond),
+    ]
+    try:
+        result = api_debug.dbg_set_bp_condition(
+            {"addr": "0x401000", "condition": "eax == 1"}
+        )
+        assert result == [{"addr": "0x401000", "ok": True, "condition": "eax == 1", "language": None}]
+        assert calls == [(0x401000, "eax == 1", 0)]
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_set_bp_condition_can_clear_condition():
+    """dbg_set_bp_condition should clear a condition when passed null."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.condition = None
+            self.elang = "IDC"
+
+        def is_compiled(self):
+            return bool(self.condition)
+
+    state = {"condition": "eax == 1", "language": "IDC"}
+    calls = []
+
+    def get_bpt(ea, bpt):
+        if ea != 0x401000:
+            return False
+        bpt.condition = state["condition"]
+        bpt.elang = state["language"]
+        return True
+
+    def set_bpt_cond(ea, cnd, is_lowcnd=0):
+        calls.append((ea, cnd, is_lowcnd))
+        state["condition"] = cnd or None
+        return True
+
+    patches = [
+        _SavedAttr(api_debug, "parse_address", lambda _addr: 0x401000),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "get_bpt", get_bpt),
+        _SavedAttr(api_debug.idc, "set_bpt_cond", set_bpt_cond),
+    ]
+    try:
+        result = api_debug.dbg_set_bp_condition(
+            {"addr": "0x401000", "condition": None, "low_level": True}
+        )
+        assert result == [{"addr": "0x401000", "ok": True, "condition": None, "language": "IDC"}]
+        assert calls == [(0x401000, "", 1)]
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_set_bp_condition_can_set_python_language():
+    """dbg_set_bp_condition should switch language before compiling a new condition."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.condition = None
+            self.elang = "IDC"
+
+        def is_compiled(self):
+            return bool(self.condition)
+
+    state = {"condition": None, "language": "IDC"}
+    calls = []
+
+    def get_bpt(ea, bpt):
+        if ea != 0x401000:
+            return False
+        bpt.condition = state["condition"]
+        bpt.elang = state["language"]
+        return True
+
+    def set_bpt_cond(ea, cnd, is_lowcnd=0):
+        calls.append(("set", ea, cnd, is_lowcnd))
+        state["condition"] = cnd or None
+        return True
+
+    def update_bpt(bpt):
+        calls.append(("update", bpt.elang))
+        state["language"] = bpt.elang
+        return True
+
+    patches = [
+        _SavedAttr(api_debug, "parse_address", lambda _addr: 0x401000),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "get_bpt", get_bpt),
+        _SavedAttr(api_debug.ida_dbg, "update_bpt", update_bpt),
+        _SavedAttr(api_debug.idc, "set_bpt_cond", set_bpt_cond),
+    ]
+    try:
+        result = api_debug.dbg_set_bp_condition(
+            {"addr": "0x401000", "condition": "RAX == 1", "language": "python"}
+        )
+        assert result == [
+            {
+                "addr": "0x401000",
+                "ok": True,
+                "condition": "RAX == 1",
+                "language": "Python",
+            }
+        ]
+        assert calls == [("update", "Python"), ("set", 0x401000, "RAX == 1", 0)]
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_set_bp_condition_clears_old_condition_before_language_switch():
+    """Changing language with an existing condition should clear first, then switch, then set."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.condition = None
+            self.elang = "IDC"
+
+        def is_compiled(self):
+            return bool(self.condition)
+
+    state = {"condition": "R13==0x1234", "language": "IDC"}
+    calls = []
+
+    def get_bpt(ea, bpt):
+        if ea != 0x401000:
+            return False
+        bpt.condition = state["condition"]
+        bpt.elang = state["language"]
+        return True
+
+    def set_bpt_cond(ea, cnd, is_lowcnd=0):
+        calls.append(("set", ea, cnd, is_lowcnd))
+        state["condition"] = cnd or None
+        return True
+
+    def update_bpt(bpt):
+        calls.append(("update", bpt.elang))
+        state["language"] = bpt.elang
+        return True
+
+    patches = [
+        _SavedAttr(api_debug, "parse_address", lambda _addr: 0x401000),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "get_bpt", get_bpt),
+        _SavedAttr(api_debug.ida_dbg, "update_bpt", update_bpt),
+        _SavedAttr(api_debug.idc, "set_bpt_cond", set_bpt_cond),
+    ]
+    try:
+        result = api_debug.dbg_set_bp_condition(
+            {"addr": "0x401000", "condition": "True", "language": "python"}
+        )
+        assert result == [
+            {
+                "addr": "0x401000",
+                "ok": True,
+                "condition": "True",
+                "language": "Python",
+            }
+        ]
+        assert calls == [
+            ("set", 0x401000, "", 0),
+            ("update", "Python"),
+            ("set", 0x401000, "True", 0),
+        ]
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_set_bp_condition_rejects_uncompiled_condition():
+    """dbg_set_bp_condition should fail when IDA stores but does not compile the condition."""
+
+    class _FakeBpt:
+        def __init__(self):
+            self.condition = None
+            self.elang = "IDC"
+
+        def is_compiled(self):
+            return False
+
+    state = {"condition": None, "language": "IDC"}
+
+    def get_bpt(ea, bpt):
+        if ea != 0x401000:
+            return False
+        bpt.condition = state["condition"]
+        bpt.elang = state["language"]
+        return True
+
+    def set_bpt_cond(ea, cnd, is_lowcnd=0):
+        state["condition"] = cnd or None
+        return True
+
+    patches = [
+        _SavedAttr(api_debug, "parse_address", lambda _addr: 0x401000),
+        _SavedAttr(api_debug.ida_dbg, "bpt_t", _FakeBpt),
+        _SavedAttr(api_debug.ida_dbg, "get_bpt", get_bpt),
+        _SavedAttr(api_debug.idc, "set_bpt_cond", set_bpt_cond),
+    ]
+    try:
+        result = api_debug.dbg_set_bp_condition(
+            {"addr": "0x401000", "condition": "this is invalid syntax"}
+        )
+        assert result == [
+            {
+                "addr": "0x401000",
+                "error": "Breakpoint condition was stored but did not compile successfully",
+            }
+        ]
     finally:
         for patch in reversed(patches):
             patch.restore()

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -294,6 +294,23 @@ class BreakpointOp(TypedDict):
     enabled: Annotated[bool, "Enable (true) or disable (false)"]
 
 
+class BreakpointConditionBase(TypedDict):
+    """Debugger breakpoint condition operation"""
+
+    addr: Annotated[str, "Breakpoint address (hex or decimal)"]
+
+
+class BreakpointConditionOp(BreakpointConditionBase, total=False):
+    condition: Annotated[
+        Optional[str], "Breakpoint condition expression; null/empty clears it"
+    ]
+    language: Annotated[
+        Optional[str],
+        "Condition language ('idc', 'python', or exact IDA extlang name); null preserves current/default",
+    ]
+    low_level: Annotated[bool, "Set a low-level/server-side condition when true"]
+
+
 class InsnPattern(TypedDict, total=False):
     """Instruction pattern for operand search"""
 
@@ -523,6 +540,7 @@ class Breakpoint(TypedDict):
     addr: str
     enabled: bool
     condition: Optional[str]
+    language: Optional[str]
 
 
 class FunctionAnalysis(TypedDict):


### PR DESCRIPTION
A debugged application might not necessarily suspend after issuing a tool command (e.g. launching the debugger, continuing the execution or stepping).

The application can potentially run for hours before reaching a breakpoint or any other condition that causes a transition to a suspended state.
Previously, many tools expected suspension to happen immediatly and treated anything else as failure.

This refactoring changes that to better act on actual application behaviour.

Additionally, support for conditional breakpoints was added.