### PR TITLE
Support disabling expensive tools

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -13,7 +13,7 @@ import ida_idaapi
 import ida_xref
 import ida_ua
 import ida_name
-from .rpc import tool
+from .rpc import tool, disable
 from .sync import idasync, tool_timeout, IDAError
 from .utils import (
     parse_address,
@@ -1722,6 +1722,7 @@ def basic_blocks(
 
 
 @tool
+@disable("expensive")
 @idasync
 def find(
     type: Annotated[

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -18,7 +18,7 @@ import ida_nalt
 import ida_typeinf
 import idc
 
-from .rpc import tool
+from .rpc import tool, disable
 from .sync import idasync
 from .utils import (
     ConvertedNumber,
@@ -847,6 +847,7 @@ def idb_save(
 
 
 @tool
+@disable("expensive")
 @idasync
 def find_regex(
     pattern: Annotated[str, "Regex pattern to search for in strings"],
@@ -960,6 +961,7 @@ def _all_segments() -> list[tuple[int, int]]:
 
 
 @tool
+@disable("expensive")
 @idasync
 def search_text(
     pattern: Annotated[str, "Text to search for in the rendered listing (literal substring by default)"],

--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -173,10 +173,16 @@ def _remember_output_proxy_target_from_response(host: str, port: int, response: 
 
 
 def _get_proxy_request_path() -> str:
-    """Build the proxied MCP path, preserving enabled extensions."""
+    """Build the proxied MCP path, preserving ext/disable query params."""
     enabled = sorted(getattr(MCP_SERVER._enabled_extensions, "data", set()))
+    disabled = sorted(getattr(MCP_SERVER._disabled_groups, "data", set()))
+    parts = []
     if enabled:
-        return f"/mcp?ext={','.join(enabled)}"
+        parts.append(f"ext={','.join(enabled)}")
+    if disabled:
+        parts.append(f"disable={','.join(disabled)}")
+    if parts:
+        return f"/mcp?{'&'.join(parts)}"
     return "/mcp"
 
 

--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -11,7 +11,12 @@ from .zeromcp import (
 
 MCP_UNSAFE: set[str] = set()
 MCP_EXTENSIONS: dict[str, set[str]] = {}  # group -> set of function names
-MCP_SERVER = McpServer("ida-pro-mcp", extensions=MCP_EXTENSIONS)
+MCP_DISABLE_GROUPS: dict[str, set[str]] = {}  # group -> set of function names
+MCP_SERVER = McpServer(
+    "ida-pro-mcp",
+    extensions=MCP_EXTENSIONS,
+    disabled_groups=MCP_DISABLE_GROUPS,
+)
 
 # ============================================================================
 # Output Size Limiting
@@ -172,6 +177,23 @@ def ext(group: str):
     return decorator
 
 
+def disable(group: str):
+    """Mark a tool as belonging to a disable group.
+
+    Tools in disable groups are visible by default, but can be hidden and rejected
+    via ?disable=group query param. Example: @disable("expensive") marks tools
+    that should be excluded for latency-sensitive clients.
+    """
+
+    def decorator(func):
+        if group not in MCP_DISABLE_GROUPS:
+            MCP_DISABLE_GROUPS[group] = set()
+        MCP_DISABLE_GROUPS[group].add(func.__name__)
+        return func
+
+    return decorator
+
+
 __all__ = [
     "McpRpcRegistry",
     "McpServer",
@@ -180,9 +202,11 @@ __all__ = [
     "MCP_SERVER",
     "MCP_UNSAFE",
     "MCP_EXTENSIONS",
+    "MCP_DISABLE_GROUPS",
     "tool",
     "unsafe",
     "ext",
+    "disable",
     "resource",
     "get_cached_output",
     "set_download_base_url",

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
@@ -26,6 +26,8 @@ class _SavedState:
         self._lport = api_discovery._LOCAL_PORT
         self._proxied = api_discovery.is_request_proxied()
         self._session = getattr(api_discovery.MCP_SERVER._transport_session_id, "data", None)
+        self._exts = getattr(api_discovery.MCP_SERVER._enabled_extensions, "data", set())
+        self._disabled = getattr(api_discovery.MCP_SERVER._disabled_groups, "data", set())
         return self
     def __exit__(self, *exc):
         api_discovery._redirect_host = self._host
@@ -36,6 +38,8 @@ class _SavedState:
         api_discovery._LOCAL_PORT = self._lport
         api_discovery.set_request_proxied(self._proxied)
         api_discovery.MCP_SERVER._transport_session_id.data = self._session
+        api_discovery.MCP_SERVER._enabled_extensions.data = self._exts
+        api_discovery.MCP_SERVER._disabled_groups.data = self._disabled
 
 
 def _make_jsonrpc(method, params=None, id=1):
@@ -314,24 +318,26 @@ def test_dispatch_proxy_error_preserves_request_id():
 
 
 @test()
-def test_api_discovery_proxy_to_instance_forwards_session_and_extensions():
-    """Forwarded proxy requests should preserve MCP session and enabled extensions."""
+def test_api_discovery_proxy_to_instance_forwards_session_extensions_and_disabled_groups():
+    """Forwarded proxy requests should preserve MCP session, ext, and disable query params."""
     with _SavedState():
         original_conn = api_discovery.http.client.HTTPConnection
         _RecordingConnection.calls = []
         api_discovery.http.client.HTTPConnection = _RecordingConnection
         api_discovery.MCP_SERVER._transport_session_id.data = "http:session-123"
         api_discovery.MCP_SERVER._enabled_extensions.data = {"dbg"}
+        api_discovery.MCP_SERVER._disabled_groups.data = {"slow"}
         try:
             api_discovery.proxy_to_instance("127.0.0.1", 13337, b"{}")
             assert len(_RecordingConnection.calls) == 1
             call = _RecordingConnection.calls[0]
-            assert call["path"] == "/mcp?ext=dbg"
+            assert call["path"] == "/mcp?ext=dbg&disable=slow"
             assert call["headers"].get(api_discovery.PROXY_HEADER) == "1"
             assert call["headers"].get("Mcp-Session-Id") == "session-123"
         finally:
             api_discovery.http.client.HTTPConnection = original_conn
             api_discovery.MCP_SERVER._enabled_extensions.data = set()
+            api_discovery.MCP_SERVER._disabled_groups.data = set()
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_http.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_http.py
@@ -10,8 +10,14 @@ visibility, and ORIGINAL_TOOLS snapshot.
 """
 
 from ..framework import test
-from ..rpc import MCP_SERVER, MCP_UNSAFE, MCP_EXTENSIONS
+from ..rpc import MCP_SERVER, MCP_UNSAFE, MCP_EXTENSIONS, MCP_DISABLE_GROUPS, disable, tool
 from .. import http as http_mod
+
+
+@tool
+@disable("slow")
+def _test_slow_tool() -> dict:
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +89,57 @@ def test_extension_tools_appear_when_enabled():
         assert not missing, f"dbg tools in registry but hidden: {missing}"
     finally:
         MCP_SERVER._enabled_extensions.data = old_exts
+
+
+@test()
+def test_disable_group_exists_and_populated():
+    """@disable('slow') should register tools in a default-on disable group."""
+    assert "slow" in MCP_DISABLE_GROUPS, "No 'slow' disable group registered"
+    assert "_test_slow_tool" in MCP_DISABLE_GROUPS["slow"]
+
+
+@test()
+def test_disable_group_tools_visible_by_default():
+    """Disable-group tools should be listed when no ?disable is active."""
+    old_exts = getattr(MCP_SERVER._enabled_extensions, "data", set())
+    old_disabled = getattr(MCP_SERVER._disabled_groups, "data", set())
+    MCP_SERVER._enabled_extensions.data = set()
+    MCP_SERVER._disabled_groups.data = set()
+    try:
+        listed = {t["name"] for t in MCP_SERVER._mcp_tools_list()["tools"]}
+        assert "_test_slow_tool" in listed
+    finally:
+        MCP_SERVER._enabled_extensions.data = old_exts
+        MCP_SERVER._disabled_groups.data = old_disabled
+
+
+@test()
+def test_disable_group_tools_hidden_when_disabled():
+    """Disable-group tools should disappear from tools/list when ?disable is active."""
+    old_exts = getattr(MCP_SERVER._enabled_extensions, "data", set())
+    old_disabled = getattr(MCP_SERVER._disabled_groups, "data", set())
+    MCP_SERVER._enabled_extensions.data = set()
+    MCP_SERVER._disabled_groups.data = {"slow"}
+    try:
+        listed = {t["name"] for t in MCP_SERVER._mcp_tools_list()["tools"]}
+        assert "_test_slow_tool" not in listed
+    finally:
+        MCP_SERVER._enabled_extensions.data = old_exts
+        MCP_SERVER._disabled_groups.data = old_disabled
+
+
+@test()
+def test_disable_group_tool_call_rejected_when_disabled():
+    """tools/call should reject a tool hidden by ?disable."""
+    old_disabled = getattr(MCP_SERVER._disabled_groups, "data", set())
+    MCP_SERVER._disabled_groups.data = {"slow"}
+    try:
+        result = MCP_SERVER._mcp_tools_call("_test_slow_tool", {})
+        assert result.get("isError")
+        text = result["content"][0]["text"]
+        assert "disabled by group 'slow'" in text
+    finally:
+        MCP_SERVER._disabled_groups.data = old_disabled
 
 
 # ---------------------------------------------------------------------------

--- a/src/ida_pro_mcp/ida_mcp/tests/test_http.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_http.py
@@ -93,9 +93,13 @@ def test_extension_tools_appear_when_enabled():
 
 @test()
 def test_disable_group_exists_and_populated():
-    """@disable('slow') should register tools in a default-on disable group."""
+    """Disable groups should register both synthetic and real expensive tools."""
     assert "slow" in MCP_DISABLE_GROUPS, "No 'slow' disable group registered"
     assert "_test_slow_tool" in MCP_DISABLE_GROUPS["slow"]
+    assert "expensive" in MCP_DISABLE_GROUPS, "No 'expensive' disable group registered"
+    expensive = MCP_DISABLE_GROUPS["expensive"]
+    for name in ("find", "find_regex", "search_text"):
+        assert name in expensive, f"{name} missing from expensive disable group"
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -65,6 +65,7 @@ def _saved_target():
     old_port = server.IDA_PORT
     old_session = getattr(server.mcp._transport_session_id, "data", None)
     old_exts = getattr(server.mcp._enabled_extensions, "data", set())
+    old_disabled = getattr(server.mcp._disabled_groups, "data", set())
     try:
         yield
     finally:
@@ -72,6 +73,7 @@ def _saved_target():
         server.IDA_PORT = old_port
         server.mcp._transport_session_id.data = old_session
         server.mcp._enabled_extensions.data = old_exts
+        server.mcp._disabled_groups.data = old_disabled
 
 
 @test()
@@ -90,19 +92,20 @@ def test_tools_list_keeps_discovery_and_launch_tools_when_ida_unreachable():
 
 
 @test()
-def test_server_proxy_to_instance_forwards_session_and_extensions():
-    """Top-level proxy requests should preserve MCP session and enabled extensions."""
+def test_server_proxy_to_instance_forwards_session_extensions_and_disabled_groups():
+    """Top-level proxy requests should preserve MCP session, ext, and disable query params."""
     with _saved_target():
         original_conn = server.http.client.HTTPConnection
         _RecordingConnection.calls = []
         server.http.client.HTTPConnection = _RecordingConnection
         server.mcp._transport_session_id.data = "http:session-456"
         server.mcp._enabled_extensions.data = {"dbg"}
+        server.mcp._disabled_groups.data = {"slow"}
         try:
             server._proxy_to_instance("127.0.0.1", 13337, b"{}")
             assert len(_RecordingConnection.calls) == 1
             call = _RecordingConnection.calls[0]
-            assert call["path"] == "/mcp?ext=dbg"
+            assert call["path"] == "/mcp?ext=dbg&disable=slow"
             assert call["headers"].get("Mcp-Session-Id") == "session-456"
         finally:
             server.http.client.HTTPConnection = original_conn
@@ -132,29 +135,42 @@ def test_resolve_ida_rpc_preserves_multiple_ext_query_params():
 
 
 @test()
-def test_resolve_ida_rpc_no_ext_leaves_extensions_empty():
-    """--ida-rpc without ext param should not add spurious extensions."""
+def test_resolve_ida_rpc_preserves_disable_query_param():
+    """--ida-rpc http://host:port/mcp?disable=slow should seed disabled groups."""
     with _saved_target():
-        server.mcp._enabled_extensions.data = set()
-        args = argparse.Namespace(ida_rpc="http://10.0.0.1:9999")
+        args = argparse.Namespace(ida_rpc="http://10.0.0.1:9999/mcp?disable=slow")
         server._resolve_ida_rpc(args)
-        exts = getattr(server.mcp._enabled_extensions, "data", set())
-        assert len(exts) == 0, f"Expected no extensions, got: {exts}"
+        disabled = getattr(server.mcp._disabled_groups, "data", set())
+        assert "slow" in disabled, f"Expected 'slow' in disabled groups, got: {disabled}"
 
 
 @test()
-def test_ida_rpc_ext_flows_through_to_proxy_path():
-    """Extensions from --ida-rpc should appear in proxied request path."""
+def test_resolve_ida_rpc_no_ext_or_disable_leaves_filters_empty():
+    """--ida-rpc without ext/disable params should not add spurious filters."""
+    with _saved_target():
+        server.mcp._enabled_extensions.data = set()
+        server.mcp._disabled_groups.data = set()
+        args = argparse.Namespace(ida_rpc="http://10.0.0.1:9999")
+        server._resolve_ida_rpc(args)
+        exts = getattr(server.mcp._enabled_extensions, "data", set())
+        disabled = getattr(server.mcp._disabled_groups, "data", set())
+        assert len(exts) == 0, f"Expected no extensions, got: {exts}"
+        assert len(disabled) == 0, f"Expected no disabled groups, got: {disabled}"
+
+
+@test()
+def test_ida_rpc_ext_and_disable_flow_through_to_proxy_path():
+    """Filters from --ida-rpc should appear in proxied request path."""
     with _saved_target():
         original_conn = server.http.client.HTTPConnection
         _RecordingConnection.calls = []
         server.http.client.HTTPConnection = _RecordingConnection
         try:
-            args = argparse.Namespace(ida_rpc="http://10.0.0.1:9999/mcp?ext=dbg")
+            args = argparse.Namespace(ida_rpc="http://10.0.0.1:9999/mcp?ext=dbg&disable=slow")
             server._resolve_ida_rpc(args)
             server._proxy_to_instance("10.0.0.1", 9999, b"{}")
             assert len(_RecordingConnection.calls) == 1
-            assert _RecordingConnection.calls[0]["path"] == "/mcp?ext=dbg"
+            assert _RecordingConnection.calls[0]["path"] == "/mcp?ext=dbg&disable=slow"
         finally:
             server.http.client.HTTPConnection = original_conn
 

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -237,13 +237,21 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
         self.mcp_server: "McpServer" = getattr(server, "mcp_server")
         super().__init__(request, client_address, server)
 
+    def _parse_csv_query_param(self, path: str, key: str) -> set[str]:
+        """Parse a comma-separated query param into a normalized set."""
+        query = parse_qs(urlparse(path).query)
+        value = query.get(key, [""])[0]
+        if not value:
+            return set()
+        return {item.strip() for item in value.split(",") if item.strip()}
+
     def _parse_extensions(self, path: str) -> set[str]:
         """Parse ?ext=dbg,foo query param into set of enabled extensions"""
-        query = parse_qs(urlparse(path).query)
-        ext_param = query.get("ext", [""])[0]
-        if not ext_param:
-            return set()
-        return {e.strip() for e in ext_param.split(",") if e.strip()}
+        return self._parse_csv_query_param(path, "ext")
+
+    def _parse_disabled_groups(self, path: str) -> set[str]:
+        """Parse ?disable=slow,expensive query param into set of disabled groups"""
+        return self._parse_csv_query_param(path, "disable")
 
     def log_message(self, format, *args):
         """Override to suppress default logging or customize"""
@@ -440,9 +448,11 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             self.send_error(400, f"No active SSE connection found for session {session_id}")
             return
 
-        # Parse extensions from query params and store in thread-local
+        # Parse query params and store in thread-local
         extensions = self._parse_extensions(self.path)
+        disabled_groups = self._parse_disabled_groups(self.path)
         setattr(self.mcp_server._enabled_extensions, "data", extensions)
+        setattr(self.mcp_server._disabled_groups, "data", disabled_groups)
         setattr(self.mcp_server._transport_session_id, "data", f"sse:{session_id}")
         set_current_request_external_base_url(
             _derive_external_base_url(
@@ -458,6 +468,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             response = self.mcp_server.registry.dispatch(body)
         finally:
             setattr(self.mcp_server._enabled_extensions, "data", set())
+            setattr(self.mcp_server._disabled_groups, "data", set())
             setattr(self.mcp_server._protocol_version, "data", None)
             setattr(self.mcp_server._transport_session_id, "data", None)
             set_current_request_external_base_url(None)
@@ -506,9 +517,11 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
                     )
                     self.mcp_server.register_http_session(mcp_session_id)
 
-        # Parse extensions from query params and store in thread-local
+        # Parse query params and store in thread-local
         extensions = self._parse_extensions(self.path)
+        disabled_groups = self._parse_disabled_groups(self.path)
         setattr(self.mcp_server._enabled_extensions, "data", extensions)
+        setattr(self.mcp_server._disabled_groups, "data", disabled_groups)
         setattr(
             self.mcp_server._transport_session_id,
             "data",
@@ -528,6 +541,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             response = self.mcp_server.registry.dispatch(body)
         finally:
             setattr(self.mcp_server._enabled_extensions, "data", set())
+            setattr(self.mcp_server._disabled_groups, "data", set())
             setattr(self.mcp_server._protocol_version, "data", None)
             setattr(self.mcp_server._transport_session_id, "data", None)
             set_current_request_external_base_url(None)
@@ -549,7 +563,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             send_response(200, json.dumps(response).encode("utf-8"))
 
 class McpServer:
-    def __init__(self, name: str, version = "1.0.0", *, extensions: dict[str, set[str]] | None = None):
+    def __init__(self, name: str, version = "1.0.0", *, extensions: dict[str, set[str]] | None = None, disabled_groups: dict[str, set[str]] | None = None):
         self.name = name
         self.version = version
         self.cors_allowed_origins: Callable[[str], bool] | list[str] | str | None = self.cors_localhost
@@ -567,7 +581,9 @@ class McpServer:
         self._protocol_version = threading.local()
         self._transport_session_id = threading.local()
         self._enabled_extensions = threading.local()  # set[str] per request
+        self._disabled_groups = threading.local()  # set[str] per request
         self._extensions_registry = extensions if extensions is not None else {}  # group -> set of tool names
+        self._disabled_groups_registry = disabled_groups if disabled_groups is not None else {}  # group -> set of tool names
         self.require_streamable_http_session = False
 
         # Register MCP protocol methods with correct names
@@ -748,12 +764,15 @@ class McpServer:
     def _mcp_tools_list(self, _meta: dict | None = None) -> dict:
         """MCP tools/list method"""
         enabled = getattr(self._enabled_extensions, "data", set())
+        disabled = getattr(self._disabled_groups, "data", set())
         tools = []
         for func_name, func in self.tools.methods.items():
-            # Check if tool belongs to an extension group
             tool_group = self._get_tool_extension(func_name)
             if tool_group and tool_group not in enabled:
-                continue  # Skip tools from disabled extension groups
+                continue
+            disabled_group = self._get_tool_disabled_group(func_name)
+            if disabled_group and disabled_group in disabled:
+                continue
             tools.append(self._generate_tool_schema(func_name, func))
         return {"tools": tools}
 
@@ -764,14 +783,28 @@ class McpServer:
                 return group
         return None
 
+    def _get_tool_disabled_group(self, func_name: str) -> str | None:
+        """Return disable-group name if tool belongs to one, else None"""
+        for group, tools in self._disabled_groups_registry.items():
+            if func_name in tools:
+                return group
+        return None
+
     def _mcp_tools_call(self, name: str, arguments: dict | None = None, _meta: dict | None = None) -> dict:
         """MCP tools/call method"""
         # Check if tool requires an extension that isn't enabled
         enabled = getattr(self._enabled_extensions, "data", set())
+        disabled = getattr(self._disabled_groups, "data", set())
         tool_group = self._get_tool_extension(name)
         if tool_group and tool_group not in enabled:
             return {
                 "content": [{"type": "text", "text": f"Tool '{name}' requires extension '{tool_group}'. Enable with ?ext={tool_group}"}],
+                "isError": True,
+            }
+        disabled_group = self._get_tool_disabled_group(name)
+        if disabled_group and disabled_group in disabled:
+            return {
+                "content": [{"type": "text", "text": f"Tool '{name}' is disabled by group '{disabled_group}'. Remove it from ?disable={disabled_group} to call this tool"}],
                 "isError": True,
             }
 

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -138,10 +138,16 @@ def _remember_output_proxy_target_from_response(host: str, port: int, response: 
 
 
 def _get_proxy_request_path() -> str:
-    """Build the proxied MCP path, preserving enabled extensions."""
+    """Build the proxied MCP path, preserving ext/disable query params."""
     enabled = sorted(getattr(mcp._enabled_extensions, "data", set()))
+    disabled = sorted(getattr(mcp._disabled_groups, "data", set()))
+    parts = []
     if enabled:
-        return f"/mcp?ext={','.join(enabled)}"
+        parts.append(f"ext={','.join(enabled)}")
+    if disabled:
+        parts.append(f"disable={','.join(disabled)}")
+    if parts:
+        return f"/mcp?{'&'.join(parts)}"
     return "/mcp"
 
 
@@ -469,10 +475,14 @@ def _resolve_ida_rpc(args) -> None:
         IDA_HOST = ida_rpc.hostname
         IDA_PORT = ida_rpc.port
 
-        # Preserve ?ext= query param so proxy requests include the extensions
-        ext_value = parse_qs(ida_rpc.query).get("ext", [""])[0]
+        # Preserve ?ext= and ?disable= query params for proxied requests
+        query = parse_qs(ida_rpc.query)
+        ext_value = query.get("ext", [""])[0]
         if ext_value:
             mcp._enabled_extensions.data = set(ext_value.split(","))
+        disable_value = query.get("disable", [""])[0]
+        if disable_value:
+            mcp._disabled_groups.data = set(disable_value.split(","))
 
         set_ida_rpc(IDA_HOST, IDA_PORT)
         return


### PR DESCRIPTION
Certain tools, especially those that search/find text, can take a long time to complete. Not exposing them to agents can make sense, depending on the binary that's being analyzed.

Using `http://127.0.0.1:13337/mcp?disable=expensive` or `http://127.0.0.1:13337/mcp?ext=dbg&disable=expensive`, the tools `find`, `find_regex` and `search_text` can now be disabled.