### PR TITLE
Fix open_file ida executable path on linux

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -407,6 +407,15 @@ def _find_existing_idb(file_path: str) -> str | None:
     return None
 
 
+def _get_ida_executable() -> str:
+    """Return the executable path for the current IDA process."""
+
+    if sys.platform == "linux":
+        return os.readlink("/proc/self/exe")
+
+    return sys.executable
+
+
 @tool
 def open_file(
     file_path: Annotated[
@@ -437,7 +446,7 @@ def open_file(
         return {"success": False, "error": f"File not found: {file_path}"}
 
     # Get the IDA executable from the currently running instance
-    ida_exe = sys.executable
+    ida_exe = _get_ida_executable()
     if not os.path.isfile(ida_exe):
         return {"success": False, "error": f"Cannot find IDA executable: {ida_exe}"}
 


### PR DESCRIPTION
Found that in IDA Python `sys.executable` returns the Python executable on Linux, while on other OSes it works correctly. This behaviour breaks the `open_file` tool. In this PR, it now reads the IDA path from `/proc/self/cmdline` on Linux.

On linux:
<img width="325" height="69" alt="image" src="https://github.com/user-attachments/assets/44576ac8-1ce0-4629-b7ec-2320975c83ae" />

On OSX:
<img width="438" height="34" alt="image" src="https://github.com/user-attachments/assets/4ace5211-75e1-4bf9-ad0b-34de8deca8e5" />

On Windows:
<img width="418" height="37" alt="image" src="https://github.com/user-attachments/assets/869711cc-816b-4c28-b95a-08b84c56cdb8" />
