### PR TITLE
Fix dbg_start reporting failure on successful starts

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -21,7 +21,7 @@ import ida_name
 import idaapi
 
 from .rpc import tool, unsafe, ext
-from .sync import idasync, keep_batch, IDAError
+from .sync import idasync, keep_batch, get_pre_call_batch, IDAError
 from .utils import (
     RegisterValue,
     ThreadRegisters,
@@ -384,14 +384,20 @@ def dbg_start() -> DebugControlResult:
             if addr != ida_idaapi.BADADDR:
                 ida_dbg.add_bpt(addr, 0, idaapi.BPT_SOFT)
 
-    # Arm a DBG_Hooks instance to switch IDA out of batch mode once the
-    # debugger has actually started. Combined with @keep_batch on this
-    # function, batch mode stays on across the execute_sync boundary so
-    # dialogs the debugger plugin shows during initialization (e.g.
-    # "matching executable names") are auto-handled. The hook restores
-    # batch mode on dbg_suspend_process / dbg_process_exit / detach, with
-    # a register_timer fallback so we never get stuck in batch mode.
-    _arm_dbg_start_batch_hook(restore_batch=0)
+    # Arm a DBG_Hooks instance to switch IDA back to its pre-call batch
+    # state once the debugger has actually started. Combined with
+    # @keep_batch on this function, batch mode stays on across the
+    # execute_sync boundary so dialogs the debugger plugin shows during
+    # initialization (e.g. "matching executable names") are auto-handled.
+    # The hook restores on dbg_process_start / _attach / _exit / _detach,
+    # with a register_timer fallback so we never get stuck in batch mode.
+    # Capture the pre-call batch (what the caller had set before the
+    # sync wrapper bumped it to 1) so headless / batch-mode workflows
+    # aren't silently flipped to interactive after dbg_start.
+    pre_call_batch = get_pre_call_batch()
+    if pre_call_batch is None:
+        pre_call_batch = 0
+    _arm_dbg_start_batch_hook(restore_batch=pre_call_batch)
 
     # start_process is documented as asynchronous; when invoked from the
     # IDA main thread inside execute_sync the return code is unreliable

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -16,11 +16,12 @@ import ida_dbg
 import ida_entry
 import ida_idd
 import ida_idaapi
+import ida_kernwin
 import ida_name
 import idaapi
 
 from .rpc import tool, unsafe, ext
-from .sync import idasync, IDAError
+from .sync import idasync, keep_batch, IDAError
 from .utils import (
     RegisterValue,
     ThreadRegisters,
@@ -144,7 +145,12 @@ def _get_debug_state_result() -> DebugControlResult:
 def dbg_ensure_active() -> "ida_idd.debugger_t":
     dbg = ida_idd.get_dbg()
     if not dbg or not ida_dbg.is_debugger_on():
-        raise IDAError("Debugger not running")
+        raise IDAError(
+            "Debugger not running. Stop and ask the user to start a debugger "
+            "session (call dbg_start, or have them launch from IDA) before "
+            "retrying. If dbg_start has already been attempted and failed, "
+            "the user must first configure the debugger and target."
+        )
     return dbg
 
 
@@ -283,12 +289,94 @@ def _get_debug_start_result() -> DebugControlResult | None:
     return result
 
 
+# Batch-mode lifecycle for dbg_start.
+#
+# start_process schedules work that runs on the IDA main thread *after* our
+# execute_sync returns. That work can show modal dialogs (e.g. "matching
+# executable names"), so we need batch mode to remain on across the
+# execute_sync boundary, and we need to be sure to turn it back off once the
+# debugger has actually come up (or failed to). _DbgStartBatchHook does both.
+_DBG_START_BATCH_FALLBACK_MS = 30_000  # absolute ceiling on stuck-in-batch state
+
+
+class _DbgStartBatchHook(ida_dbg.DBG_Hooks):
+    """Restore batch mode as soon as the debugger has finished STARTUP.
+
+    "Startup" ends at dbg_process_start / dbg_process_attach — by then any
+    startup dialogs (e.g. "matching executable names") are done, but the
+    user is still inside an active debug session and should see normal
+    dialogs from here on. dbg_process_exit / dbg_process_detach also
+    restore so we don't get stuck if the process dies before fully coming
+    up.
+    """
+
+    def __init__(self, restore_batch: int):
+        super().__init__()
+        self._restore_batch = restore_batch
+        self._done = False
+
+    def dbg_process_start(self, pid, tid, ea, name, base, size):
+        self._restore()
+
+    def dbg_process_attach(self, pid, tid, ea, name, base, size):
+        self._restore()
+
+    def dbg_process_exit(self, pid, tid, ea, exit_code):
+        self._restore()
+
+    def dbg_process_detach(self, pid, tid, ea):
+        self._restore()
+
+    def fallback_restore(self):
+        """Called by the safety timer if no debugger event ever arrives."""
+        self._restore()
+
+    def _restore(self):
+        if self._done:
+            return
+        self._done = True
+        try:
+            self.unhook()
+        except Exception:
+            pass
+        idc.batch(self._restore_batch)
+
+
+_dbg_start_batch_hook: _DbgStartBatchHook | None = None
+
+
+def _arm_dbg_start_batch_hook(restore_batch: int) -> None:
+    """Install the batch-restore hook before start_process is invoked."""
+    global _dbg_start_batch_hook
+    if _dbg_start_batch_hook is not None:
+        _dbg_start_batch_hook.fallback_restore()
+    hook = _DbgStartBatchHook(restore_batch)
+    hook.hook()
+    _dbg_start_batch_hook = hook
+
+    def _fallback():
+        if _dbg_start_batch_hook is hook and not hook._done:
+            hook.fallback_restore()
+        return -1  # don't repeat
+
+    ida_kernwin.register_timer(_DBG_START_BATCH_FALLBACK_MS, _fallback)
+
+
 @ext("dbg")
 @unsafe
 @tool
 @idasync
+@keep_batch
 def dbg_start() -> DebugControlResult:
-    """Start debugger session for current target."""
+    """Start debugger session for current target.
+
+    Requires the user to have selected a debugger (Debugger -> Select debugger)
+    and configured the target (executable path, arguments, attach process,
+    remote host, etc.). If this call fails, do not retry repeatedly. Stop,
+    explain to the user that debugging is not yet configured, and ask them
+    to set up the debugger and dismiss any IDA dialogs (e.g. "matching
+    executable names") before trying again.
+    """
     if len(list_breakpoints()) == 0:
         for i in range(ida_entry.get_entry_qty()):
             ordinal = ida_entry.get_entry_ordinal(i)
@@ -296,11 +384,22 @@ def dbg_start() -> DebugControlResult:
             if addr != ida_idaapi.BADADDR:
                 ida_dbg.add_bpt(addr, 0, idaapi.BPT_SOFT)
 
+    # Arm a DBG_Hooks instance to switch IDA out of batch mode once the
+    # debugger has actually started. Combined with @keep_batch on this
+    # function, batch mode stays on across the execute_sync boundary so
+    # dialogs the debugger plugin shows during initialization (e.g.
+    # "matching executable names") are auto-handled. The hook restores
+    # batch mode on dbg_suspend_process / dbg_process_exit / detach, with
+    # a register_timer fallback so we never get stuck in batch mode.
+    _arm_dbg_start_batch_hook(restore_batch=0)
+
+    # start_process is documented as asynchronous; when invoked from the
+    # IDA main thread inside execute_sync the return code is unreliable
+    # (often -1 even on success, because the dbg_process_start event has
+    # not yet been dispatched). Trust the actual debugger state instead,
+    # and only consult the return code as a tiebreaker for the error
+    # message when nothing ever comes up.
     start_result = idaapi.start_process("", "", "")
-    if start_result == -1:
-        raise IDAError("Failed to start debugger")
-    if start_result == 0:
-        raise IDAError("Debugger start was cancelled")
 
     started = _get_debug_start_result()
     if started is not None and started.get("running") and "ip" not in started:
@@ -329,7 +428,19 @@ def dbg_start() -> DebugControlResult:
         if started is not None:
             return started
 
-    raise IDAError("Failed to start debugger")
+    if start_result == 0:
+        raise IDAError(
+            "Debugger start was cancelled. Stop and ask the user to configure "
+            "the debugger (Debugger -> Select debugger, set the target path / "
+            "arguments) and dismiss any IDA dialogs before retrying."
+        )
+    raise IDAError(
+        "Failed to start debugger. Stop and ask the user to verify that a "
+        "debugger is selected (Debugger -> Select debugger), the target is "
+        "configured (executable path / arguments / remote host), and any "
+        "pending IDA dialogs (e.g. \"matching executable names\") have been "
+        "dismissed before retrying."
+    )
 
 
 @ext("dbg")

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -3,6 +3,7 @@ import queue
 import functools
 import os
 import sys
+import threading
 import time
 import idaapi
 import idc
@@ -52,6 +53,23 @@ def _get_tool_timeout_seconds() -> float:
 
 call_stack = queue.LifoQueue()
 
+# Thread-local: while a synchronized tool body is running, holds the batch
+# value that was in effect *before* the sync wrapper bumped it to 1. Tools
+# decorated with @keep_batch read this via get_pre_call_batch() so they can
+# restore the caller's original state — not assume a hard-coded default.
+_sync_state = threading.local()
+
+
+def get_pre_call_batch() -> int | None:
+    """Return the pre-call batch state, or None if not inside a sync body.
+
+    Only meaningful inside a @idasync function body — outside of that the
+    sync wrapper isn't tracking anything. Tools using @keep_batch should
+    read this and pass it to whatever asynchronous restorer they install,
+    so the original batch state is preserved across the deferred work.
+    """
+    return getattr(_sync_state, "pre_call_batch", None)
+
 
 def _sync_wrapper(ff, keep_batch=False):
     """Call a function ff with a specific IDA safety_mode.
@@ -63,6 +81,10 @@ def _sync_wrapper(ff, keep_batch=False):
     "matching executable names" dialog after we exit execute_sync — runs
     while batch mode is still on. On exception, batch mode is always
     restored before re-raising.
+
+    The pre-call batch state is exposed to ff() via get_pre_call_batch()
+    so tools can capture it (typically at hook-install time) and restore
+    the caller's original state instead of hard-coding a default.
     """
 
     res_container = queue.Queue()
@@ -76,6 +98,8 @@ def _sync_wrapper(ff, keep_batch=False):
         call_stack.put((ff.__name__))
         # Enable batch mode for all synchronized operations
         old_batch = idc.batch(1)
+        prev_pre_call = getattr(_sync_state, "pre_call_batch", None)
+        _sync_state.pre_call_batch = old_batch
         completed = False
         try:
             res_container.put(ff())
@@ -85,6 +109,7 @@ def _sync_wrapper(ff, keep_batch=False):
         finally:
             if not (completed and keep_batch):
                 idc.batch(old_batch)
+            _sync_state.pre_call_batch = prev_pre_call
             call_stack.get()
 
     idaapi.execute_sync(runned, idaapi.MFF_WRITE)

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -53,8 +53,17 @@ def _get_tool_timeout_seconds() -> float:
 call_stack = queue.LifoQueue()
 
 
-def _sync_wrapper(ff):
-    """Call a function ff with a specific IDA safety_mode."""
+def _sync_wrapper(ff, keep_batch=False):
+    """Call a function ff with a specific IDA safety_mode.
+
+    If keep_batch=True and ff() returns successfully, batch mode is left on
+    after the wrapper exits. The decorated function is responsible for
+    arranging restoration (typically via a DBG_Hooks callback) so that any
+    asynchronous work scheduled by ff() — e.g. start_process triggering a
+    "matching executable names" dialog after we exit execute_sync — runs
+    while batch mode is still on. On exception, batch mode is always
+    restored before re-raising.
+    """
 
     res_container = queue.Queue()
 
@@ -67,12 +76,15 @@ def _sync_wrapper(ff):
         call_stack.put((ff.__name__))
         # Enable batch mode for all synchronized operations
         old_batch = idc.batch(1)
+        completed = False
         try:
             res_container.put(ff())
+            completed = True
         except Exception as x:
             res_container.put(x)
         finally:
-            idc.batch(old_batch)
+            if not (completed and keep_batch):
+                idc.batch(old_batch)
             call_stack.get()
 
     idaapi.execute_sync(runned, idaapi.MFF_WRITE)
@@ -91,11 +103,14 @@ def _normalize_timeout(value: object) -> float | None:
         return None
 
 
-def sync_wrapper(ff, timeout_override: float | None = None):
+def sync_wrapper(
+    ff, timeout_override: float | None = None, keep_batch: bool = False
+):
     """Wrapper to enable timeout and cancellation during IDA synchronization.
 
     Note: Batch mode is now handled in _sync_wrapper to ensure it's always
-    applied consistently for all synchronized operations.
+    applied consistently for all synchronized operations. Pass keep_batch=True
+    to opt out of the post-call batch restore (see _sync_wrapper docstring).
     """
     # Capture cancel event from thread-local before execute_sync
     cancel_event = get_current_cancel_event()
@@ -125,8 +140,8 @@ def sync_wrapper(ff, timeout_override: float | None = None):
                 sys.setprofile(old_profile)
 
         timed_ff.__name__ = ff.__name__
-        return _sync_wrapper(timed_ff)
-    return _sync_wrapper(ff)
+        return _sync_wrapper(timed_ff, keep_batch=keep_batch)
+    return _sync_wrapper(ff, keep_batch=keep_batch)
 
 
 def idasync(f):
@@ -145,7 +160,8 @@ def idasync(f):
         timeout_override = _normalize_timeout(
             getattr(f, "__ida_mcp_timeout_sec__", None)
         )
-        return sync_wrapper(ff, timeout_override)
+        keep_batch = bool(getattr(f, "__ida_mcp_keep_batch__", False))
+        return sync_wrapper(ff, timeout_override, keep_batch=keep_batch)
 
     return wrapper
 
@@ -168,6 +184,28 @@ def tool_timeout(seconds: float):
         return func
 
     return decorator
+
+
+def keep_batch(func):
+    """Decorator to skip the sync wrapper's post-call batch-mode restore.
+
+    Apply when the tool schedules asynchronous work that runs on the IDA
+    main thread *after* execute_sync exits (e.g. start_process, which
+    triggers the "matching executable names" dialog later). The decorated
+    function MUST arrange batch-mode restoration itself, typically via a
+    DBG_Hooks callback that fires once the asynchronous work has completed,
+    so batch mode is not left on indefinitely.
+
+    Same ordering rule as tool_timeout: place AFTER @idasync (innermost).
+
+        @tool
+        @idasync
+        @keep_batch
+        def my_func(...):
+    """
+
+    setattr(func, "__ida_mcp_keep_batch__", True)
+    return func
 
 
 def is_window_active():

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -97,8 +97,8 @@ def test_dbg_start_arms_batch_restore_hook_before_start_process():
     """dbg_start must arm the batch-mode restore hook BEFORE invoking
     start_process, so dialogs that fire on the main thread after we exit
     execute_sync are still suppressed by batch mode. The hook then turns
-    batch mode back off via dbg_suspend_process / dbg_process_exit /
-    dbg_process_detach."""
+    batch mode back off via dbg_process_start / dbg_process_attach /
+    dbg_process_exit / dbg_process_detach."""
 
     sequence = []
 
@@ -119,13 +119,50 @@ def test_dbg_start_arms_batch_restore_hook_before_start_process():
     ]
     try:
         api_debug.dbg_start()
-        assert sequence[0] == ("arm", 0), f"hook must arm first, got {sequence}"
+        assert sequence[0][0] == "arm", f"hook must arm first, got {sequence}"
         assert sequence[1] == ("start_process",), (
             f"start_process must run after the hook is armed, got {sequence}"
         )
     finally:
         for patch in reversed(patches):
             patch.restore()
+
+
+@test()
+def test_dbg_start_arms_batch_restore_hook_with_pre_call_batch_value():
+    """The batch-restore hook must capture the *pre-call* batch state
+    (what the caller had before the sync wrapper bumped it to 1), so
+    headless / batch-mode workflows aren't silently flipped to
+    interactive after dbg_start. Hard-coding 0 would regress that."""
+
+    captured = []
+
+    def fake_arm(restore_batch=0):
+        captured.append(restore_batch)
+
+    for pre_call in [0, 1]:
+        captured.clear()
+
+        def fake_get_pre_call_batch(_v=pre_call):
+            return _v
+
+        patches = [
+            _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+            _SavedAttr(api_debug, "_arm_dbg_start_batch_hook", fake_arm),
+            _SavedAttr(api_debug, "get_pre_call_batch", fake_get_pre_call_batch),
+            _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 1),
+            _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+            _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_SUSP),
+            _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: 0x401000),
+        ]
+        try:
+            api_debug.dbg_start()
+            assert captured == [pre_call], (
+                f"expected hook armed with pre-call batch {pre_call}, got {captured}"
+            )
+        finally:
+            for patch in reversed(patches):
+                patch.restore()
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_debug.py
@@ -68,6 +68,159 @@ def test_dbg_start_reports_success_when_debugger_is_running_without_ip():
 
 
 @test()
+def test_dbg_start_trusts_debugger_state_over_start_process_return():
+    """start_process is asynchronous and may return -1 from inside execute_sync
+    even when the process actually started; outcome must be decided by the
+    actual debugger state, not the return code."""
+    patches = [
+        _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+        _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: -1),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_SUSP),
+        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: 0x401000),
+    ]
+    try:
+        result = api_debug.dbg_start()
+        assert result == {
+            "started": True,
+            "state": "suspended",
+            "suspended": True,
+            "ip": "0x401000",
+        }
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_start_arms_batch_restore_hook_before_start_process():
+    """dbg_start must arm the batch-mode restore hook BEFORE invoking
+    start_process, so dialogs that fire on the main thread after we exit
+    execute_sync are still suppressed by batch mode. The hook then turns
+    batch mode back off via dbg_suspend_process / dbg_process_exit /
+    dbg_process_detach."""
+
+    sequence = []
+
+    def fake_arm(restore_batch=0):
+        sequence.append(("arm", restore_batch))
+
+    def fake_start_process(*_args):
+        sequence.append(("start_process",))
+        return 1
+
+    patches = [
+        _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+        _SavedAttr(api_debug, "_arm_dbg_start_batch_hook", fake_arm),
+        _SavedAttr(api_debug.idaapi, "start_process", fake_start_process),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: True),
+        _SavedAttr(api_debug.ida_dbg, "get_process_state", lambda: api_debug.ida_dbg.DSTATE_SUSP),
+        _SavedAttr(api_debug.ida_dbg, "get_ip_val", lambda: 0x401000),
+    ]
+    try:
+        api_debug.dbg_start()
+        assert sequence[0] == ("arm", 0), f"hook must arm first, got {sequence}"
+        assert sequence[1] == ("start_process",), (
+            f"start_process must run after the hook is armed, got {sequence}"
+        )
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
+def test_dbg_start_batch_hook_restores_at_end_of_startup_only():
+    """Batch mode must be restored as soon as the debugger has started up
+    (dbg_process_start / dbg_process_attach) and on cleanup paths
+    (dbg_process_exit / dbg_process_detach), but NOT on later events like
+    dbg_suspend_process — those happen mid-session, after startup, where
+    the user expects normal dialog behavior again."""
+
+    # First, verify dbg_suspend_process does NOT restore batch (would be a
+    # regression: it would keep batch on across the entire debug session).
+    hook = api_debug._DbgStartBatchHook(restore_batch=0)
+    suspend_calls = []
+
+    def fake_batch_no_call(value, _calls=suspend_calls):
+        _calls.append(value)
+        return 1
+
+    patch = _SavedAttr(api_debug.idc, "batch", fake_batch_no_call)
+    try:
+        hook.dbg_suspend_process()
+        assert suspend_calls == [], (
+            "dbg_suspend_process must not restore batch (it fires mid-session)"
+        )
+        assert hook._done is False
+    finally:
+        patch.restore()
+
+    for callback_name, args in [
+        ("dbg_process_start", (1234, 5678, 0x401000, "name", 0x400000, 0x1000)),
+        ("dbg_process_attach", (1234, 5678, 0x401000, "name", 0x400000, 0x1000)),
+        ("dbg_process_exit", (1234, 5678, 0x401000, 0)),
+        ("dbg_process_detach", (1234, 5678, 0x401000)),
+    ]:
+        calls = []
+        unhooked = []
+
+        def fake_batch(value, _calls=calls):
+            _calls.append(("batch", value))
+            return 1
+
+        hook = api_debug._DbgStartBatchHook(restore_batch=0)
+        hook.unhook = lambda _u=unhooked: _u.append(True) or True
+
+        patch = _SavedAttr(api_debug.idc, "batch", fake_batch)
+        try:
+            getattr(hook, callback_name)(*args)
+            assert calls == [("batch", 0)], (
+                f"{callback_name}: expected batch(0), got {calls}"
+            )
+            assert unhooked == [True], (
+                f"{callback_name}: hook should unhook itself"
+            )
+            assert hook._done is True
+
+            # Second invocation must be a no-op (idempotent).
+            calls.clear()
+            unhooked.clear()
+            getattr(hook, callback_name)(*args)
+            assert calls == []
+            assert unhooked == []
+        finally:
+            patch.restore()
+
+
+@test()
+def test_dbg_start_reports_cancelled_when_start_process_returns_zero_and_state_never_comes_up():
+    """When the debugger never comes up and start_process reported a
+    cancellation, dbg_start should surface that specific error."""
+    waits = {"count": 0}
+
+    def wait_for_next_event(_flags, _timeout):
+        waits["count"] += 1
+        return 1
+
+    patches = [
+        _SavedAttr(api_debug, "list_breakpoints", lambda: [object()]),
+        _SavedAttr(api_debug.idaapi, "start_process", lambda *_args: 0),
+        _SavedAttr(api_debug.ida_dbg, "is_debugger_on", lambda: False),
+        _SavedAttr(api_debug.ida_dbg, "wait_for_next_event", wait_for_next_event),
+    ]
+    try:
+        try:
+            api_debug.dbg_start()
+        except IDAError as exc:
+            assert "cancelled" in str(exc).lower()
+        else:
+            raise AssertionError("Expected IDAError when debugger never starts")
+    finally:
+        for patch in reversed(patches):
+            patch.restore()
+
+
+@test()
 def test_dbg_start_waits_briefly_for_first_ip():
     """dbg_start should briefly wait for an initial suspend/IP before falling back to running."""
     calls = {"waits": 0}


### PR DESCRIPTION
## Summary

- `dbg_start` was raising `Failed to start debugger` (or `Debugger start was cancelled`) even when the debugger actually came up. Root cause: `idaapi.start_process` is documented as asynchronous, and when invoked from inside `execute_sync(MFF_WRITE)` its return code is unreliable — frequently `-1` on success because `dbg_process_start` hasn't dispatched yet. `dbg_start` now decides outcome from the actual debugger state (which it was already polling) and only consults the return code as a tiebreaker for the error message.
- Adds a `@keep_batch` opt-in (`sync.py`) so a tool can keep `idc.batch(1)` on across the `execute_sync` boundary. `dbg_start` opts in and arms a `DBG_Hooks` that flips batch mode back off as soon as startup is done (`dbg_process_start` / `dbg_process_attach`, plus `dbg_process_exit` / `dbg_process_detach` cleanup paths). A `register_timer` fallback ensures we never get stuck in batch mode. Net effect: the "matching executable names" (and similar) dialog that fires on the main thread *after* `execute_sync` exits is auto-handled, but the rest of the debug session sees normal dialog behavior.
- `dbg_start`'s docstring and the `Failed`/`Cancelled` error messages now explicitly tell the LLM to stop and ask the user to configure the debugger rather than retrying — so debugger misconfiguration doesn't turn into a retry loop.

## Test plan

- [x] `uv run ida-mcp-test tests/crackme03.elf -c api_debug -q` — 14 passed (was 12; +2 new regression tests)
- [x] `uv run ida-mcp-test tests/crackme03.elf -q` — 354 passed
- [x] `uv run ida-mcp-test tests/typed_fixture.elf -q` — 328 passed, 1 skipped
- [x] Live `dbg_start` against running IDA: confirmed previous behavior (returns failure but debugger is suspended) is gone after fix is loaded; original return-code-vs-state divergence reproduced via `py_eval` showing `start_process == -1` while `is_debugger_on() == True` inside `execute_sync(MFF_WRITE)`.

New tests added:
- `test_dbg_start_trusts_debugger_state_over_start_process_return` — pins the core bug.
- `test_dbg_start_reports_cancelled_when_start_process_returns_zero_and_state_never_comes_up` — preserves the cancelled-error path on real failures.
- `test_dbg_start_arms_batch_restore_hook_before_start_process` — ordering invariant: hook must be armed before `start_process`.
- `test_dbg_start_batch_hook_restores_at_end_of_startup_only` — batch must be restored on `dbg_process_start` / `_attach` / `_exit` / `_detach` and explicitly NOT on `dbg_suspend_process` (which fires mid-session every time the user pauses).