### PR TITLE
Fix call_stack deadlock on reentrant @idasync (closes #406)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -91,7 +91,13 @@ def _sync_wrapper(ff, keep_batch=False):
 
     def runned():
         if not call_stack.empty():
-            last_func_name = call_stack.get()
+            # Non-blocking: a concurrent reentrant @idasync call from
+            # within another tool's ff() on the same main thread may
+            # have drained the queue between empty() and get().
+            try:
+                last_func_name = call_stack.get_nowait()
+            except queue.Empty:
+                last_func_name = "<empty>"
             error_str = f"Call stack is not empty while calling the function {ff.__name__} from {last_func_name}"
             raise IDASyncError(error_str)
 
@@ -110,7 +116,14 @@ def _sync_wrapper(ff, keep_batch=False):
             if not (completed and keep_batch):
                 idc.batch(old_batch)
             _sync_state.pre_call_batch = prev_pre_call
-            call_stack.get()
+            # Non-blocking: a reentrant @idasync invoked synchronously
+            # inside ff() may have already popped our entry. Default
+            # block=True would freeze the IDA main thread on an empty
+            # queue and hang every subsequent @idasync call.
+            try:
+                call_stack.get_nowait()
+            except queue.Empty:
+                pass
 
     idaapi.execute_sync(runned, idaapi.MFF_WRITE)
     res = res_container.get()


### PR DESCRIPTION
Fixes #406. See that issue for full diagnosis, trace evidence (8.7-hour freeze captured live), and reproduction conditions.

## What this changes

Two-line fix in `_sync_wrapper`: replace blocking `call_stack.get()` with `get_nowait()` + tolerate `queue.Empty` in both the pre-check and the `finally` cleanup. The debug-guard semantics ("no two tools on the main thread simultaneously") are preserved — if a reentrant entry has already drained the queue, the outer `finally` finds nothing to clean up, which is correct.

## Why it's needed

`call_stack` is a `queue.LifoQueue()` shared across the process. The blocking `get()` deadlocks the moment a `@idasync` function transitively invokes another `@idasync` function from the main thread:

1. Outer tool's `runned()` puts its name on `call_stack`.
2. Reentrant call (e.g. `trace._netnode_flush_segment` triggered by tool-call recording into the `$ ida_mcp.trace` netnode) runs **inline** on the main thread because `execute_sync` from the main thread is synchronous.
3. Reentrant pre-check sees `call_stack.empty() == False`, calls blocking `get()`, removes the outer entry, raises `IDASyncError`.
4. Outer tool finishes normally, hits `finally: call_stack.get()` — queue empty — blocks forever.
5. IDA's main thread is parked on the `LifoQueue` condition variable. Every subsequent `@idasync` request piles up in `execute_sync`.

Most reproducible on `idb_save` because the save path interacts with hooks that flush the trace netnode mid-call. Other tools can hit it under load. Default 60s timeout (`sys.setprofile`-based) doesn't apply because the wait is in C, not Python.

## Notes

- Doesn't address the deeper design issue (a shared mutable LifoQueue is the wrong primitive here — `threading.local()` would be more correct, since reentrancy is by definition same-thread). That would be a larger refactor; this PR keeps the diff to the minimum needed to unblock real-world freezes.
- 100% backward compatible: the pre-check still raises `IDASyncError` when the queue is non-empty (now with `<empty>` as the prev-name fallback, which only happens in the race window).
