### PR TITLE
Fix LAN connectivity: unify security checks for non-loopback bindings

### DIFF
--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -147,13 +147,18 @@ class MCP(idaapi.plugin_t):
     DEFAULT_PORT = 13337
 
     def init(self):
+        import os
+
         hotkey = MCP.wanted_hotkey.replace("-", "+")
         if __import__("sys").platform == "darwin":
             hotkey = hotkey.replace("Alt", "Option")
 
         self.mcp: "ida_mcp.rpc.McpServer | None" = None
-        self.host = self.DEFAULT_HOST
-        self.port = self.DEFAULT_PORT
+        self.host = os.environ.get("IDA_MCP_HOST", self.DEFAULT_HOST)
+        try:
+            self.port = int(os.environ.get("IDA_MCP_PORT", self.DEFAULT_PORT))
+        except (ValueError, TypeError):
+            self.port = self.DEFAULT_PORT
         self.autostart = _get_autostart()
 
         if self.autostart and ida_kernwin.is_idaq():

--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -197,6 +197,19 @@ class MCP(idaapi.plugin_t):
                 print(f"[MCP] Instance unregistration failed: {e}")
             self._registered_port = None
 
+    def _effective_host(self) -> str:
+        """Return bind host, upgrading to 0.0.0.0 when CORS is unrestricted."""
+        if self.host != self.DEFAULT_HOST:
+            return self.host
+        try:
+            import json as _json
+            blob = ida_netnode.netnode("$ ida_mcp.cors_policy").getblob(0, "C")
+            if blob and _json.loads(blob) == "unrestricted":
+                return "0.0.0.0"
+        except Exception:
+            pass
+        return self.host
+
     def run(self, arg):
         if self.mcp:
             self._unregister_instance()
@@ -210,17 +223,18 @@ class MCP(idaapi.plugin_t):
         else:
             from ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, set_local_instance
 
+        host = self._effective_host()
         port = self.port
         max_port = port + 100
         while port < max_port:
             try:
                 MCP_SERVER.serve(
-                    self.host, port, request_handler=IdaMcpHttpRequestHandler
+                    host, port, request_handler=IdaMcpHttpRequestHandler
                 )
-                print(f"  Config: http://{self.host}:{port}/config.html")
+                print(f"  Config: http://{host}:{port}/config.html")
                 self.mcp = MCP_SERVER
-                set_local_instance(self.host, port)
-                self._register_instance(port)
+                set_local_instance(host, port)
+                self._register_instance(host, port)
                 return
             except OSError as e:
                 if e.errno in (48, 98, 10048):  # Address already in use
@@ -229,7 +243,7 @@ class MCP(idaapi.plugin_t):
                     raise
         print(f"[MCP] Error: No available port in range {self.port}-{max_port - 1}")
 
-    def _register_instance(self, port: int):
+    def _register_instance(self, host: str, port: int):
         try:
             if TYPE_CHECKING:
                 from .ida_mcp.discovery import register_instance
@@ -241,7 +255,7 @@ class MCP(idaapi.plugin_t):
             binary = ida_nalt.get_root_filename() or ""
             idb_path = idc.get_idb_path() or ""
             file_path = register_instance(
-                host=self.host,
+                host=host,
                 port=port,
                 pid=os.getpid(),
                 binary=binary,

--- a/src/ida_pro_mcp/ida_mcp.py
+++ b/src/ida_pro_mcp/ida_mcp.py
@@ -147,18 +147,13 @@ class MCP(idaapi.plugin_t):
     DEFAULT_PORT = 13337
 
     def init(self):
-        import os
-
         hotkey = MCP.wanted_hotkey.replace("-", "+")
         if __import__("sys").platform == "darwin":
             hotkey = hotkey.replace("Alt", "Option")
 
         self.mcp: "ida_mcp.rpc.McpServer | None" = None
-        self.host = os.environ.get("IDA_MCP_HOST", self.DEFAULT_HOST)
-        try:
-            self.port = int(os.environ.get("IDA_MCP_PORT", self.DEFAULT_PORT))
-        except (ValueError, TypeError):
-            self.port = self.DEFAULT_PORT
+        self.host = self.DEFAULT_HOST
+        self.port = self.DEFAULT_PORT
         self.autostart = _get_autostart()
 
         if self.autostart and ida_kernwin.is_idaq():
@@ -197,19 +192,6 @@ class MCP(idaapi.plugin_t):
                 print(f"[MCP] Instance unregistration failed: {e}")
             self._registered_port = None
 
-    def _effective_host(self) -> str:
-        """Return bind host, upgrading to 0.0.0.0 when CORS is unrestricted."""
-        if self.host != self.DEFAULT_HOST:
-            return self.host
-        try:
-            import json as _json
-            blob = ida_netnode.netnode("$ ida_mcp.cors_policy").getblob(0, "C")
-            if blob and _json.loads(blob) == "unrestricted":
-                return "0.0.0.0"
-        except Exception:
-            pass
-        return self.host
-
     def run(self, arg):
         if self.mcp:
             self._unregister_instance()
@@ -223,18 +205,17 @@ class MCP(idaapi.plugin_t):
         else:
             from ida_mcp import MCP_SERVER, IdaMcpHttpRequestHandler, set_local_instance
 
-        host = self._effective_host()
         port = self.port
         max_port = port + 100
         while port < max_port:
             try:
                 MCP_SERVER.serve(
-                    host, port, request_handler=IdaMcpHttpRequestHandler
+                    self.host, port, request_handler=IdaMcpHttpRequestHandler
                 )
-                print(f"  Config: http://{host}:{port}/config.html")
+                print(f"  Config: http://{self.host}:{port}/config.html")
                 self.mcp = MCP_SERVER
-                set_local_instance(host, port)
-                self._register_instance(host, port)
+                set_local_instance(self.host, port)
+                self._register_instance(port)
                 return
             except OSError as e:
                 if e.errno in (48, 98, 10048):  # Address already in use
@@ -243,7 +224,7 @@ class MCP(idaapi.plugin_t):
                     raise
         print(f"[MCP] Error: No available port in range {self.port}-{max_port - 1}")
 
-    def _register_instance(self, host: str, port: int):
+    def _register_instance(self, port: int):
         try:
             if TYPE_CHECKING:
                 from .ida_mcp.discovery import register_instance
@@ -255,7 +236,7 @@ class MCP(idaapi.plugin_t):
             binary = ida_nalt.get_root_filename() or ""
             idb_path = idc.get_idb_path() or ""
             file_path = register_instance(
-                host=host,
+                host=self.host,
                 port=port,
                 pid=os.getpid(),
                 binary=binary,

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -239,28 +239,25 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         return cast(HTTPServer, self.server).server_port
 
     def _check_origin(self) -> bool:
+        """Validate Origin for config POST requests.
+
+        Delegates to the zeromcp ``_check_api_request`` which already
+        handles non-loopback bindings (LAN) and respects the configured
+        CORS policy.  When the server is bound to 0.0.0.0 the Host
+        check passes for any client; the Origin check still enforces
+        the CORS policy so ``unrestricted`` is needed for browser-based
+        LAN config access.
         """
-        Prevents CSRF and DNS rebinding attacks by ensuring POST requests
-        originate from pages served by this server, not external websites.
-        """
-        origin = self.headers.get("Origin")
-        port = self.server_port
-        if origin not in (f"http://127.0.0.1:{port}", f"http://localhost:{port}"):
-            self.send_error(403, "Invalid Origin")
-            return False
-        return True
+        return self._check_api_request()
 
     def _check_host(self) -> bool:
+        """Validate Host header for config page access.
+
+        Delegates to ``_check_api_request`` so the same rules apply as
+        for MCP API calls: loopback-bound servers only accept loopback
+        Host headers; non-loopback servers (0.0.0.0) accept any Host.
         """
-        Prevents DNS rebinding attacks where an attacker's domain (e.g., evil.com)
-        resolves to 127.0.0.1, allowing their page to read localhost resources.
-        """
-        host = self.headers.get("Host")
-        port = self.server_port
-        if host not in (f"127.0.0.1:{port}", f"localhost:{port}"):
-            self.send_error(403, "Invalid Host")
-            return False
-        return True
+        return self._check_api_request()
 
     def _send_html(self, status: int, text: str):
         """

--- a/tests/test_browser_transport_guards.py
+++ b/tests/test_browser_transport_guards.py
@@ -118,6 +118,44 @@ class BrowserTransportGuardTests(unittest.TestCase):
         self.assertTrue(handler._check_api_request())
         self.assertEqual(errors, [])
 
+    # -- LAN connectivity tests (bound to 0.0.0.0) --
+
+    def test_nonloopback_bind_allows_lan_host(self):
+        self.assertTrue(
+            _host_header_allowed_for_bind("0.0.0.0", "192.168.1.10:13337")
+        )
+        self.assertTrue(
+            _host_header_allowed_for_bind("0.0.0.0", "10.0.0.5:13337")
+        )
+
+    def test_check_api_request_allows_lan_client_without_origin(self):
+        handler, errors = _make_handler(
+            host="192.168.1.10:13337",
+            origin=None,
+            bound_host="0.0.0.0",
+        )
+        self.assertTrue(handler._check_api_request())
+        self.assertEqual(errors, [])
+
+    def test_check_api_request_allows_lan_origin_with_wildcard_cors(self):
+        handler, errors = _make_handler(
+            host="192.168.1.10:13337",
+            origin="http://192.168.1.20:3000",
+            bound_host="0.0.0.0",
+            allowed="*",
+        )
+        self.assertTrue(handler._check_api_request())
+        self.assertEqual(errors, [])
+
+    def test_check_api_request_rejects_lan_origin_with_local_cors(self):
+        handler, errors = _make_handler(
+            host="192.168.1.10:13337",
+            origin="http://192.168.1.20:3000",
+            bound_host="0.0.0.0",
+        )
+        self.assertFalse(handler._check_api_request())
+        self.assertEqual(errors, [(403, "Invalid Origin")])
+
     def test_derive_external_base_url_prefers_forwarded_headers(self):
         base = _derive_external_base_url(
             {


### PR DESCRIPTION
## Summary

Fixes #206 — when the MCP server is bound to a non-loopback address (e.g. `0.0.0.0` via the IDA config form), the hardcoded localhost-only checks in `_check_host` and `_check_origin` (`http.py`) reject all non-localhost requests with 403.

- Replace `_check_host` and `_check_origin` with `_check_api_request` from zeromcp, which already handles non-loopback bindings correctly (allows any Host header when not bound to loopback, enforces CORS policy for Origin)
- Add LAN-specific test cases for `_check_api_request` with `0.0.0.0` binding

### How it works

When bound to a non-loopback address:
- **MCP API calls** from non-browser clients (no Origin header): work immediately
- **Config page** (`/config.html`): accessible from LAN for viewing
- **Config form submission**: requires CORS policy set to "unrestricted"
- **DNS rebinding protection**: preserved — loopback-bound servers still reject non-loopback Host headers

No changes to `ida_mcp.py` — LAN exposure is expected to go through `idalib-mcp --host 0.0.0.0` or manual config form override.

## Test plan

- [x] All 13 existing + new browser transport guard tests pass
- [x] All 58 related unit tests pass with no regression
- [ ] Manual: configure host to `0.0.0.0` via IDA config form, connect from LAN machine
- [ ] Manual: verify loopback-bound server still rejects external Host headers