### PR TITLE
fix: mark disasm as unsafe to prevent schema validation errors on large output

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -13,7 +13,10 @@ import ida_idaapi
 import ida_xref
 import ida_ua
 import ida_name
-from .rpc import tool
+from .rpc import tool, MCP_UNSAFE
+
+# Mark disasm as unsafe to prevent schema validation errors on large output
+MCP_UNSAFE.add("disasm")
 from .sync import idasync, tool_timeout, IDAError
 from .utils import (
     parse_address,


### PR DESCRIPTION
Fixes #358

Only 2 lines changed — imports MCP_UNSAFE and adds disasm to it.