### PR TITLE
Improve client scope error message

### DIFF
--- a/src/ida_pro_mcp/installer.py
+++ b/src/ida_pro_mcp/installer.py
@@ -269,19 +269,36 @@ def _get_mcp_servers_view(
 
 
 def _resolve_client_targets(
-    configs: dict[str, tuple[str, str]], only: list[str] | None
+    configs: dict[str, tuple[str, str]],
+    only: list[str] | None,
+    *,
+    project: bool,
 ) -> dict[str, tuple[str, str]]:
     if only is None:
         return configs
 
     available = list(configs.keys())
+    other_scope_configs = (
+        get_global_configs() if project else get_project_configs(os.getcwd())
+    )
+    other_scope_name = "global" if project else "project"
     filtered: dict[str, tuple[str, str]] = {}
     for target_name in only:
         resolved = resolve_client_name(target_name, available)
         if resolved is None:
-            print(
-                f"Unknown client: '{target_name}'. Use --list-clients to see available targets."
+            other_scope_match = resolve_client_name(
+                target_name, list(other_scope_configs.keys())
             )
+            if other_scope_match is not None:
+                print(
+                    f"Client '{other_scope_match}' is not supported for "
+                    f"--scope {'project' if project else 'global'}. "
+                    f"Use --scope {other_scope_name} for this target."
+                )
+            else:
+                print(
+                    f"Unknown client: '{target_name}'. Use --list-clients to see available targets."
+                )
         elif resolved not in filtered:
             filtered[resolved] = configs[resolved]
     return filtered
@@ -345,7 +362,7 @@ def install_mcp_servers(
         print(f"Unsupported platform: {sys.platform}")
         return
 
-    configs = _resolve_client_targets(configs, only)
+    configs = _resolve_client_targets(configs, only, project=project)
     if not configs:
         return
 

--- a/tests/test_installer_scope_messages.py
+++ b/tests/test_installer_scope_messages.py
@@ -1,0 +1,38 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from ida_pro_mcp.installer import install_mcp_servers
+
+
+class InstallerScopeMessageTests(unittest.TestCase):
+    def test_project_scope_client_available_globally_has_scope_hint(self):
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            install_mcp_servers(
+                transport="streamable-http",
+                only=["codex"],
+                project=True,
+            )
+
+        message = output.getvalue()
+        self.assertIn("Client 'Codex' is not supported for --scope project", message)
+        self.assertIn("Use --scope global for this target", message)
+        self.assertNotIn("Unknown client", message)
+
+    def test_unknown_client_still_reports_unknown(self):
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            install_mcp_servers(
+                transport="streamable-http",
+                only=["definitely-not-a-client"],
+                project=True,
+            )
+
+        self.assertIn("Unknown client: 'definitely-not-a-client'", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect when a requested client exists only in the other install scope
- print a scope-specific hint instead of reporting the client as unknown
- add tests for the Codex project-scope case and truly unknown clients

## Tests
- `uv run python -m unittest tests.test_installer_scope_messages`
- `uv run python -m compileall -q src/ida_pro_mcp/installer.py tests/test_installer_scope_messages.py`
- `nix run . -- --install codex`