### PR TITLE
feat: add  add_bookmark tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Worker controls:
 
 ## Modification Operations
 
+- `add_bookmark(addr, name, prefix)`: Add or replace the IDA bookmark at an address; set `prefix=""` for no prefix.
 - `set_comments(items)`: Set comments at address(es) in both disassembly and decompiler views.
 - `patch_asm(items)`: Patch assembly instructions at address(es).
 - `declare_type(decls)`: Declare C type(s) in the local type library.

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -30,6 +30,9 @@ from .utils import (
     UndefineOp,
 )
 
+MAX_BOOKMARK_SLOTS = 1024
+BOOKMARK_PREFIX = "idaMCP: "
+
 
 class CommentResult(TypedDict):
     addr: str
@@ -91,9 +94,67 @@ class DefineResult(TypedDict, total=False):
     error: str
 
 
+class BookmarkResult(TypedDict, total=False):
+    addr: str
+    ea: str
+    slot: int | None
+    title: str
+    prefix: str
+    ok: bool
+    error: str
+
+
 # ============================================================================
 # Modification Operations
 # ============================================================================
+
+
+@tool
+@idasync
+def add_bookmark(
+    addr: Annotated[str, "Address to bookmark"],
+    name: Annotated[str, "Bookmark label text after the prefix"],
+    prefix: Annotated[
+        str,
+        "Optional title prefix. Defaults to 'idaMCP: '; pass '' for no prefix.",
+    ] = BOOKMARK_PREFIX,
+) -> BookmarkResult:
+    """Add or replace the IDA bookmark at an address. Set prefix="" for no prefix."""
+    ea = parse_address(addr)
+    title = f"{prefix}{name}"
+    free_slot: int | None = None
+
+    for slot in range(MAX_BOOKMARK_SLOTS):
+        slot_ea = idc.get_bookmark(slot)
+        if slot_ea == idc.BADADDR:
+            if free_slot is None:
+                free_slot = slot
+            continue
+
+        if slot_ea == ea:
+            free_slot = slot
+            break
+
+    if free_slot is None:
+        return {
+            "addr": addr,
+            "ea": hex(ea),
+            "slot": None,
+            "title": title,
+            "prefix": prefix,
+            "ok": False,
+            "error": "No free bookmark slot",
+        }
+
+    idc.put_bookmark(ea, 0, 0, 0, free_slot, title)
+    return {
+        "addr": addr,
+        "ea": hex(ea),
+        "slot": free_slot,
+        "title": title,
+        "prefix": prefix,
+        "ok": True,
+    }
 
 
 @tool

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -1123,6 +1123,13 @@ class McpServer:
             param = sig.parameters.get(param_name)
             if not param or param.default is inspect.Parameter.empty:
                 required.append(param_name)
+            else:
+                try:
+                    json.dumps(param.default)
+                except TypeError:
+                    pass
+                else:
+                    properties[param_name]["default"] = param.default
 
         schema: dict[str, Any] = {
             "name": func_name,


### PR DESCRIPTION
- Add `add_bookmark(addr, name, prefix)` MCP tool for creating or replacing an IDA bookmark at an address.
- Default bookmark prefix remains `idaMCP: `, with `prefix=""` available for plain bookmark titles.
- Include default parameter values in generated MCP tool schemas.