### PR TITLE
Restore open_file tool (closes #404)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/api_discovery.py
@@ -7,7 +7,11 @@ This lets a single MCP endpoint reach any running IDA instance.
 
 import http.client
 import json
+import os
+import subprocess
+import sys
 import threading
+import time
 from collections import OrderedDict
 from typing import Annotated, NotRequired, TypedDict
 
@@ -35,6 +39,17 @@ class InstanceListItem(TypedDict, total=False):
     active: bool
 
 
+class OpenFileResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    binary: str
+    pid: int
+    switched: bool
+    message: str
+    error: str
+
+
 # Track which instance this server is (filled in by the plugin loader)
 _LOCAL_PORT: int | None = None
 _LOCAL_HOST: str = "127.0.0.1"
@@ -49,7 +64,7 @@ _redirect_targets: dict[str, tuple[str, int]] = {}
 _redirect_lock = threading.Lock()
 
 # Tools that are always handled locally, never proxied
-_LOCAL_TOOL_NAMES = {"list_instances", "select_instance"}
+_LOCAL_TOOL_NAMES = {"list_instances", "select_instance", "open_file"}
 
 
 def set_local_instance(host: str, port: int):
@@ -376,4 +391,123 @@ def select_instance(
     _set_redirect_target(host, port)
     return {"success": True, "host": host, "port": port}
 
+
+def _find_existing_idb(file_path: str) -> str | None:
+    """Check if an IDB already exists for the given binary.
+
+    IDA creates .idb (32-bit) or .i64 (64-bit) files next to the binary.
+    Opening the IDB directly skips the packed/unpacked dialog.
+    """
+    base = os.path.splitext(file_path)[0]
+    for ext in (".i64", ".idb"):
+        idb_path = base + ext
+        if os.path.isfile(idb_path):
+            return idb_path
+    return None
+
+
+def _get_ida_executable() -> str:
+    """Return the executable path for the current IDA process."""
+
+    if sys.platform == "linux":
+        return os.readlink("/proc/self/exe")
+
+    return sys.executable
+
+
+@tool
+def open_file(
+    file_path: Annotated[
+        str, "Absolute path to the binary file to open in a new IDA instance"
+    ],
+    switch: Annotated[
+        bool, "Automatically switch to the new instance once it starts"
+    ] = True,
+    autonomous: Annotated[
+        bool, "Run in autonomous mode (-A flag), suppressing all dialogs"
+    ] = False,
+    new_database: Annotated[
+        bool, "Force creating a new database even if one exists"
+    ] = False,
+    timeout: Annotated[
+        int, "Seconds to wait for the new instance to register (0 = don't wait)"
+    ] = 30,
+) -> OpenFileResult:
+    """Open a file in a new IDA Pro instance.
+
+    Launches a new IDA process for the given binary. If an existing IDB/i64 database
+    is found, opens that directly (skips the packed/unpacked dialog). Use new_database=True
+    to force a fresh analysis. Use autonomous=True to suppress all IDA dialogs.
+
+    If switch=True (default), automatically routes subsequent tool calls to the new instance.
+    """
+    if not os.path.isfile(file_path):
+        return {"success": False, "error": f"File not found: {file_path}"}
+
+    ida_exe = _get_ida_executable()
+    if not os.path.isfile(ida_exe):
+        return {"success": False, "error": f"Cannot find IDA executable: {ida_exe}"}
+
+    target = file_path
+    if not new_database:
+        existing_idb = _find_existing_idb(file_path)
+        if existing_idb:
+            target = existing_idb
+
+    args = [ida_exe]
+    if autonomous:
+        args.append("-A")
+    if new_database:
+        args.append("-c")
+    args.append(target)
+
+    before = {(i["host"], i["port"]) for i in discover_instances()}
+
+    try:
+        subprocess.Popen(
+            args,
+            creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+            if sys.platform == "win32" else 0,
+        )
+    except Exception as e:
+        return {"success": False, "error": f"Failed to launch IDA: {e}"}
+
+    if timeout == 0:
+        return {"success": True, "message": "IDA launched, not waiting for registration"}
+
+    deadline = time.monotonic() + timeout
+    new_instance = None
+    while time.monotonic() < deadline:
+        time.sleep(1)
+        current = discover_instances()
+        for inst in current:
+            key = (inst["host"], inst["port"])
+            if key not in before:
+                new_instance = inst
+                break
+        if new_instance:
+            break
+
+    if not new_instance:
+        return {
+            "success": True,
+            "message": (
+                f"IDA launched but did not register within {timeout}s. "
+                "Use list_instances to check later."
+            ),
+        }
+
+    result = {
+        "success": True,
+        "host": new_instance["host"],
+        "port": new_instance["port"],
+        "binary": new_instance["binary"],
+        "pid": new_instance["pid"],
+    }
+
+    if switch:
+        _set_redirect_target(new_instance["host"], new_instance["port"])
+        result["switched"] = True
+
+    return result
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_discovery.py
@@ -348,7 +348,7 @@ def test_dispatch_tools_list_returns_local_tools_when_redirect_unreachable():
         # The local discovery tools should always be present
         assert "list_instances" in tool_names
         assert "select_instance" in tool_names
-        assert "open_file" not in tool_names
+        assert "open_file" in tool_names
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_server.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_server.py
@@ -93,7 +93,7 @@ def test_tools_list_keeps_discovery_tools_when_ida_unreachable():
         tool_names = {tool["name"] for tool in result["result"].get("tools", [])}
         assert "select_instance" in tool_names
         assert "list_instances" in tool_names
-        assert "open_file" not in tool_names
+        assert "open_file" in tool_names
 
 
 @test()

--- a/src/ida_pro_mcp/server.py
+++ b/src/ida_pro_mcp/server.py
@@ -8,7 +8,7 @@ import threading
 import time
 import traceback
 from collections import OrderedDict
-from typing import Annotated, TYPE_CHECKING, TypedDict
+from typing import Annotated, Any, TYPE_CHECKING, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 if TYPE_CHECKING:
@@ -76,6 +76,18 @@ class ProxySelectResult(TypedDict, total=False):
     error: str
 
 
+class ProxyOpenFileResult(TypedDict, total=False):
+    success: bool
+    host: str
+    port: int
+    binary: str
+    pid: int
+    switched: bool
+    message: str
+    error: str
+    result: Any
+
+
 DEFAULT_IDA_HOST = "127.0.0.1"
 DEFAULT_IDA_PORT = 13337
 IDA_HOST = DEFAULT_IDA_HOST
@@ -84,7 +96,7 @@ IDA_PORT = DEFAULT_IDA_PORT
 mcp = McpServer("ida-pro-mcp")
 dispatch_original = mcp.registry.dispatch
 
-LOCAL_TOOLS = {"list_instances", "select_instance"}
+LOCAL_TOOLS = {"list_instances", "select_instance", "open_file"}
 OUTPUT_PROXY_CACHE_MAX_SIZE = 100
 _OUTPUT_PATH_RE = re.compile(r"^/output/([a-f0-9-]+)\.(\w+)$")
 _output_proxy_targets: OrderedDict[str, tuple[str, int]] = OrderedDict()
@@ -278,6 +290,33 @@ def _proxy_to_ida(payload: bytes | str | dict) -> dict:
     return _proxy_to_instance(host, port, payload)
 
 
+def _call_ida_tool(host: str, port: int, name: str, arguments: dict[str, Any]) -> Any:
+    """Call an MCP tool on a specific IDA instance and return structured content."""
+    response = _proxy_to_instance(
+        host,
+        port,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    )
+    if "error" in response:
+        raise RuntimeError(response["error"].get("message", "Unknown error"))
+
+    result = response.get("result", {})
+    if result.get("isError"):
+        content = result.get("content", [])
+        message = (
+            content[0].get("text", "Unknown tool error")
+            if content
+            else "Unknown tool error"
+        )
+        raise RuntimeError(message)
+    return result.get("structuredContent")
+
+
 def dispatch_proxy(request: dict | str | bytes | bytearray) -> JsonRpcResponse | None:
     """Dispatch JSON-RPC requests to the MCP server registry."""
     if not isinstance(request, dict):
@@ -431,6 +470,77 @@ def select_instance(
         return {"success": False, "error": f"Instance at {host}:{port} is not reachable"}
     _set_active_ida_target(host, port)
     return {"success": True, "host": host, "port": port}
+
+
+@mcp.tool
+def open_file(
+    file_path: Annotated[
+        str, "Absolute path to the binary file to open in a new IDA instance"
+    ],
+    switch: Annotated[
+        bool, "Automatically switch to the new instance once it starts"
+    ] = True,
+    autonomous: Annotated[
+        bool, "Run in autonomous mode (-A flag), suppressing all dialogs"
+    ] = False,
+    new_database: Annotated[
+        bool, "Force creating a new database even if one exists"
+    ] = False,
+    timeout: Annotated[
+        int, "Seconds to wait for the new instance to register (0 = don't wait)"
+    ] = 30,
+) -> ProxyOpenFileResult:
+    """Open a file in a new IDA Pro instance.
+
+    This proxy-side tool delegates to any reachable IDA instance's local open_file
+    implementation so discovery/launch remains available even when the currently
+    selected instance is down.
+    """
+    target_host, target_port = _get_active_ida_target()
+    if not probe_instance(target_host, target_port):
+        target_host = ""
+        target_port = 0
+        for inst in discover_instances():
+            if probe_instance(inst["host"], inst["port"]):
+                target_host = inst["host"]
+                target_port = inst["port"]
+                break
+
+    if not target_host or target_port == 0:
+        return {
+            "success": False,
+            "error": (
+                "No running IDA instance is available to launch a new file. "
+                "Start one instance first or specify --ida-rpc explicitly."
+            ),
+        }
+
+    try:
+        result = _call_ida_tool(
+            target_host,
+            target_port,
+            "open_file",
+            {
+                "file_path": file_path,
+                "switch": switch,
+                "autonomous": autonomous,
+                "new_database": new_database,
+                "timeout": timeout,
+            },
+        )
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+    if isinstance(result, dict):
+        if (
+            switch
+            and result.get("success")
+            and result.get("host")
+            and result.get("port")
+        ):
+            _set_active_ida_target(str(result["host"]), int(result["port"]))
+        return result
+    return {"success": True, "result": result}
 
 
 # ============================================================================


### PR DESCRIPTION
Restores the `open_file` MCP tool that was removed in 8461a5f ("Clean up legacy tools"). Originally added in d941072.

Also folds in the Linux executable-path fix from fa86976 (`_get_ida_executable` uses `/proc/self/exe` instead of `sys.executable`).

