### PR TITLE
Improve MCP error reporting for rename, xrefs, decompile, and set_type (fixes #52)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -154,6 +154,8 @@ class XrefsToResult(TypedDict, total=False):
     addr: str
     xrefs: list[Xref] | None
     more: bool
+    xref_count: int
+    message: str
     error: str
 
 
@@ -179,6 +181,7 @@ class XrefQueryResult(TypedDict, total=False):
     data: list[XrefQueryRow]
     next_offset: int | None
     total: int
+    message: str
     error: str | None
 
 
@@ -186,6 +189,7 @@ class StructFieldXrefsResult(TypedDict, total=False):
     struct: str
     field: str
     xrefs: list[Xref]
+    message: str
     error: str
 
 
@@ -274,6 +278,7 @@ class ExportedFunctionJson(TypedDict, total=False):
     comments: dict[str, dict[str, str]]
     asm: str
     code: str | None
+    decompile_error: str | None
     xrefs: dict[str, list[dict[str, str]]]
     error: str
 
@@ -755,9 +760,9 @@ def decompile(
     """Decompile function(s) at address(es); returns pseudocode and per-item errors."""
     try:
         start = parse_address(addr)
-        code = decompile_function_safe(start, include_addresses=include_addresses)
+        code, err = decompile_function_safe(start, include_addresses=include_addresses)
         if code is None:
-            return {"addr": addr, "code": None, "error": "Decompilation failed"}
+            return {"addr": addr, "code": None, "error": err or "Decompilation failed"}
         result: DecompileResult = {"addr": addr, "code": code}
         try:
             import ida_hexrays
@@ -1128,10 +1133,10 @@ def analyze_batch(
                 analysis["prototype"] = get_prototype(fn)
 
             if include_decompile:
-                code = decompile_function_safe(fn.start_ea)
+                code, err = decompile_function_safe(fn.start_ea)
                 analysis["decompile"] = code
                 if code is None:
-                    analysis["decompile_error"] = "Decompilation failed"
+                    analysis["decompile_error"] = err or "Decompilation failed"
 
             if include_disasm:
                 lines, disasm_truncated = _disasm_lines_limited(fn, max_disasm_insns)
@@ -1155,6 +1160,8 @@ def analyze_batch(
                     "to_count": len(xrefs.get("to", [])),
                     "from_count": len(xrefs.get("from", [])),
                 }
+                if not xrefs.get("to") and not xrefs.get("from"):
+                    analysis["xrefs"]["message"] = "No cross-references to this address"
 
             if include_callers:
                 callers = get_callers(hex(fn.start_ea), limit=max_callers)
@@ -1237,9 +1244,20 @@ def xrefs_to(
 
     for addr in addrs:
         try:
+            ea = parse_address(addr)
+            if not ida_bytes.is_mapped(ea):
+                results.append(
+                    {
+                        "addr": addr,
+                        "xrefs": None,
+                        "error": f"Address not mapped: {addr}",
+                    }
+                )
+                continue
+
             xrefs = []
             more = False
-            for xref in idautils.XrefsTo(parse_address(addr)):
+            for xref in idautils.XrefsTo(ea):
                 if len(xrefs) >= limit:
                     more = True
                     break
@@ -1250,7 +1268,15 @@ def xrefs_to(
                         fn=get_function(xref.frm, raise_error=False),
                     )
                 )
-            results.append({"addr": addr, "xrefs": xrefs, "more": more})
+            entry: XrefsToResult = {
+                "addr": addr,
+                "xrefs": xrefs,
+                "more": more,
+                "xref_count": len(xrefs),
+            }
+            if not xrefs:
+                entry["message"] = "No cross-references to this address"
+            results.append(entry)
         except Exception as e:
             results.append({"addr": addr, "xrefs": None, "error": str(e)})
 
@@ -1294,6 +1320,9 @@ def xref_query(
                 target = idaapi.get_name_ea(idaapi.BADADDR, q)
                 if target == idaapi.BADADDR:
                     raise ValueError(f"Failed to resolve address/name: {q}")
+
+            if not ida_bytes.is_mapped(target):
+                raise ValueError(f"Address not mapped: {q}")
 
             rows: list[dict] = []
             if direction in {"to", "both"}:
@@ -1348,18 +1377,19 @@ def xref_query(
                 rows.sort(key=lambda r: int(str(r["addr"]), 16), reverse=descending)
 
             page = paginate(rows, offset, count)
-            results.append(
-                {
-                    "target": q,
-                    "resolved_addr": hex(target),
-                    "direction": direction,
-                    "xref_type": xref_type,
-                    "data": page["data"],
-                    "next_offset": page["next_offset"],
-                    "total": len(rows),
-                    "error": None,
-                }
-            )
+            page_result: XrefQueryResult = {
+                "target": q,
+                "resolved_addr": hex(target),
+                "direction": direction,
+                "xref_type": xref_type,
+                "data": page["data"],
+                "next_offset": page["next_offset"],
+                "total": len(rows),
+                "error": None,
+            }
+            if len(rows) == 0:
+                page_result["message"] = "No cross-references to this address"
+            results.append(page_result)
         except Exception as e:
             results.append(
                 {
@@ -1452,7 +1482,14 @@ def xrefs_to_field(
                         fn=get_function(xref.frm, raise_error=False),
                     )
                 ]
-            results.append({"struct": struct_name, "field": field_name, "xrefs": xrefs})
+            field_result: StructFieldXrefsResult = {
+                "struct": struct_name,
+                "field": field_name,
+                "xrefs": xrefs,
+            }
+            if not xrefs:
+                field_result["message"] = "No cross-references to this struct field"
+            results.append(field_result)
         except Exception as e:
             results.append(
                 {
@@ -2249,7 +2286,10 @@ def export_funcs(
 
             if format == "json":
                 func_data["asm"] = get_assembly_lines(ea)
-                func_data["code"] = decompile_function_safe(ea)
+                code, err = decompile_function_safe(ea)
+                func_data["code"] = code
+                if code is None and err:
+                    func_data["decompile_error"] = err
                 func_data["xrefs"] = get_all_xrefs(ea)
 
             results.append(func_data)

--- a/src/ida_pro_mcp/ida_mcp/api_composite.py
+++ b/src/ida_pro_mcp/ida_mcp/api_composite.py
@@ -43,6 +43,7 @@ class AnalyzeFunctionResult(TypedDict, total=False):
     prototype: str | None
     size: int
     decompiled: str | None
+    decompile_error: str | None
     decompile_truncated: int
     assembly: str | None
     strings: list[str]
@@ -231,14 +232,16 @@ def _analyze_function_internal(
         result["size"] = func.end_ea - func.start_ea
 
         # Decompilation — capped at _DECOMPILE_LINE_CAP lines.
-        try:
-            raw_code = decompile_function_safe(ea)
+        raw_code, decompile_err = decompile_function_safe(ea)
+        if raw_code is None:
+            result["decompiled"] = None
+            if decompile_err:
+                result["decompile_error"] = decompile_err
+        else:
             code, total_lines = _cap_decompile(raw_code)
             result["decompiled"] = code
             if total_lines is not None:
                 result["decompile_truncated"] = total_lines
-        except Exception:
-            result["decompiled"] = None
 
         # Assembly — opt-in only.
         if include_asm:
@@ -477,7 +480,7 @@ def diff_before_after(
         return {"error": f"No function at {hex(ea)}"}
 
     # --- Before ---
-    before = decompile_function_safe(ea)
+    before, _ = decompile_function_safe(ea)
 
     # --- Apply action ---
     applied: str
@@ -486,9 +489,11 @@ def diff_before_after(
             name = action_args.get("name")
             if not name:
                 return {"error": "action_args must contain 'name'"}
-            ok = idaapi.set_name(ea, name, idaapi.SN_CHECK)
+            from .api_modify import rename_at_ea
+
+            ok, err = rename_at_ea(ea, name)
             if not ok:
-                return {"error": f"set_name failed for {name!r}"}
+                return {"error": err or f"set_name failed for {name!r}"}
             applied = f"Renamed to {name!r}"
 
         elif action == "set_type":
@@ -496,13 +501,20 @@ def diff_before_after(
             if not type_str:
                 return {"error": "action_args must contain 'type'"}
             from .api_types import _parse_function_tinfo
+
             try:
                 tif = _parse_function_tinfo(type_str)
-            except ValueError:
-                return {"error": f"Failed to parse type: {type_str!r}"}
+            except ValueError as exc:
+                return {"error": str(exc)}
             ok = ida_typeinf.apply_tinfo(ea, tif, ida_typeinf.TINFO_DEFINITE)
             if not ok:
-                return {"error": f"apply_tinfo failed for {type_str!r}"}
+                return {
+                    "error": (
+                        f"Failed to apply function type at {hex(ea)} for signature "
+                        f"{type_str!r}; ensure all referenced types are declared in the "
+                        "local type library"
+                    )
+                }
             applied = f"Set type to {type_str!r}"
 
         elif action == "set_comment":
@@ -519,7 +531,7 @@ def diff_before_after(
 
     # --- After (invalidate Hex-Rays cache so we see the change) ---
     ida_hexrays.mark_cfunc_dirty(ea)
-    after = decompile_function_safe(ea)
+    after, _ = decompile_function_safe(ea)
 
     return {
         "before": before,

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -18,6 +18,7 @@ from .utils import (
     parse_address,
     decompile_checked,
     refresh_decompiler_ctext,
+    hexrays_local_var_exists,
     CommentOp,
     CommentAppendOp,
     AsmPatchOp,
@@ -300,6 +301,41 @@ def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[PatchAsmResult]:
     return results
 
 
+def rename_at_ea(
+    ea: int,
+    new_name: str,
+    *,
+    allow_overwrite: bool = False,
+    dry_run: bool = False,
+) -> tuple[bool, str | None]:
+    """Rename at address with detailed error reporting."""
+    conflict_ea = idaapi.get_name_ea(idaapi.BADADDR, new_name)
+    if (
+        conflict_ea != idaapi.BADADDR
+        and conflict_ea != ea
+        and not allow_overwrite
+    ):
+        return (
+            False,
+            f"can't rename at {hex(ea)} as {new_name!r}: name already used at {hex(conflict_ea)}",
+        )
+
+    if dry_run:
+        return True, None
+
+    flags = idaapi.SN_CHECK
+    if allow_overwrite:
+        flags = idaapi.SN_CHECK | int(getattr(idaapi, "SN_FORCE", 0))
+    ok = idaapi.set_name(ea, new_name, flags)
+    if not ok:
+        return (
+            False,
+            f"Rename failed at {hex(ea)}: IDA rejected name {new_name!r} "
+            "(invalid identifier or internal conflict)",
+        )
+    return True, None
+
+
 @tool
 @idasync
 def rename(
@@ -339,24 +375,12 @@ def rename(
         return False
 
     def _set_name_checked(ea: int, new_name: str) -> tuple[bool, str | None]:
-        conflict_ea = idaapi.get_name_ea(idaapi.BADADDR, new_name)
-        if (
-            conflict_ea != idaapi.BADADDR
-            and conflict_ea != ea
-            and not allow_overwrite
-        ):
-            return False, f"Name already exists at {hex(conflict_ea)}"
-
-        if dry_run:
-            return True, None
-
-        flags = idaapi.SN_CHECK
-        if allow_overwrite:
-            flags = idaapi.SN_CHECK | int(getattr(idaapi, "SN_FORCE", 0))
-        ok = idaapi.set_name(ea, new_name, flags)
-        if not ok:
-            return False, "Rename failed"
-        return True, None
+        return rename_at_ea(
+            ea,
+            new_name,
+            allow_overwrite=allow_overwrite,
+            dry_run=dry_run,
+        )
 
     def _place_func_in_vibe_dir(ea: int) -> tuple[bool, str | None]:
         if dry_run:
@@ -563,11 +587,32 @@ def rename(
                 success = True
                 error = None
                 if not dry_run:
-                    success = ida_hexrays.rename_lvar(func.start_ea, old_name, new_name)
-                    if success:
-                        refresh_decompiler_ctext(func.start_ea)
+                    if not ida_hexrays.init_hexrays_plugin():
+                        success = False
+                        error = (
+                            "Hex-Rays decompiler is not available "
+                            "(required for local variable rename)"
+                        )
+                    else:
+                        success = ida_hexrays.rename_lvar(
+                            func.start_ea, old_name, new_name
+                        )
+                        if success:
+                            refresh_decompiler_ctext(func.start_ea)
+                        elif not hexrays_local_var_exists(func.start_ea, old_name):
+                            error = (
+                                f"Local variable {old_name!r} not found in function at "
+                                f"{hex(func.start_ea)}"
+                            )
+                        else:
+                            error = (
+                                f"Rename failed: could not rename local {old_name!r} "
+                                f"to {new_name!r}"
+                            )
                 if not success:
-                    error = "Rename failed"
+                    error = error or (
+                        f"Rename failed: could not rename local {old_name!r} to {new_name!r}"
+                    )
 
                 result = {
                     "func_addr": func_addr,
@@ -685,10 +730,24 @@ def rename(
                 success = True
                 error = None
                 if not dry_run:
-                    sval = ida_frame.soff_to_fpoff(func, offset)
-                    success = ida_frame.define_stkvar(func, new_name, sval, udm.type)
+                    _, conflict_udm = tinfo_get_udm(frame_tif, new_name)
+                    if conflict_udm and new_name != old_name:
+                        success = False
+                        error = f"Stack variable name {new_name!r} already exists"
+                    else:
+                        sval = ida_frame.soff_to_fpoff(func, offset)
+                        success = ida_frame.define_stkvar(func, new_name, sval, udm.type)
+                        if not success:
+                            error = (
+                                f"Rename failed: could not rename stack variable "
+                                f"{old_name!r} to {new_name!r} in function at "
+                                f"{hex(func.start_ea)}"
+                            )
                 if not success:
-                    error = "Rename failed"
+                    error = error or (
+                        f"Rename failed: could not rename stack variable {old_name!r} "
+                        f"to {new_name!r} in function at {hex(func.start_ea)}"
+                    )
 
                 result = {
                     "func_addr": func_addr,

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -19,6 +19,7 @@ from .utils import (
     get_type_by_name,
     parse_decls_ctypes,
     my_modifier_t,
+    hexrays_local_var_exists,
     read_bytes_bss_safe,
     read_int_bss_safe,
     StructRead,
@@ -919,7 +920,11 @@ def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
             ok = ida_typeinf.apply_tinfo(func.start_ea, tif, ida_typeinf.PT_SIL)
             result = {"edit": edit, "kind": kind, "ok": ok}
             if not ok:
-                result["error"] = "Failed to apply function type"
+                result["error"] = (
+                    f"Failed to apply function type at {hex(func.start_ea)} for signature "
+                    f"{signature!r}; ensure all referenced types are declared in the local "
+                    "type library"
+                )
             return result
 
         if kind == "global":
@@ -941,7 +946,9 @@ def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
             ok = ida_typeinf.apply_tinfo(ea, tif, ida_typeinf.PT_SIL)
             result = {"edit": edit, "kind": kind, "ok": ok}
             if not ok:
-                result["error"] = "Failed to apply global type"
+                result["error"] = (
+                    f"Failed to apply global type at {hex(ea)} for type {type_text!r}"
+                )
             return result
 
         if kind == "local":
@@ -957,11 +964,20 @@ def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
                 return {"edit": edit, "kind": kind, "error": "Function not found"}
 
             new_tif = _parse_type_tinfo(type_text)
+
             modifier = my_modifier_t(var_name, new_tif)
             ok = ida_hexrays.modify_user_lvars(func.start_ea, modifier)
             result = {"edit": edit, "kind": kind, "ok": ok}
             if not ok:
-                result["error"] = "Failed to apply local variable type"
+                if not hexrays_local_var_exists(func.start_ea, var_name):
+                    result["error"] = (
+                        f"Local variable {var_name!r} not found in function at "
+                        f"{hex(func.start_ea)}"
+                    )
+                else:
+                    result["error"] = (
+                        f"Failed to apply type {type_text!r} to local variable {var_name!r}"
+                    )
             return result
 
         if kind == "stack":
@@ -997,7 +1013,10 @@ def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
             ok = ida_frame.set_frame_member_type(func, offset, tif)
             result = {"edit": edit, "kind": kind, "ok": ok}
             if not ok:
-                result["error"] = "Failed to set stack member type"
+                result["error"] = (
+                    f"Failed to set stack member type for {stack_name!r} at offset "
+                    f"{offset} in function at {hex(func.start_ea)}"
+                )
             return result
 
         return {"edit": edit, "kind": kind, "error": f"Unknown kind: {kind}"}

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_analysis.py
@@ -69,7 +69,7 @@ def test_decompile_invalid_address():
     """decompile reports an error for an unmapped address."""
     result = decompile(get_unmapped_address())
     assert result["code"] is None
-    assert_error(result)
+    assert_error(result, contains="Decompilation failed")
 
 
 @test()
@@ -437,12 +437,47 @@ def test_xrefs_to_by_name():
 
 @test()
 def test_xrefs_to_invalid():
-    """xrefs_to reports an error or empty xrefs for an invalid address."""
+    """xrefs_to reports an error for an unmapped address."""
     result = xrefs_to(get_unmapped_address())
     assert_is_list(result, min_length=1)
     assert result[0]["addr"] == get_unmapped_address()
-    if result[0].get("xrefs") is None:
-        assert_error(result[0])
+    assert result[0].get("xrefs") is None
+    assert_error(result[0], contains="Address not mapped")
+
+
+def _find_address_without_xrefs() -> str | None:
+    """Return a mapped address with no incoming xrefs, if one exists."""
+    import ida_bytes
+    import idaapi
+    import idautils
+
+    for seg_ea in idautils.Segments():
+        seg = idaapi.getseg(seg_ea)
+        if seg is None:
+            continue
+        for head in idautils.Heads(seg.start_ea, min(seg.end_ea, seg.start_ea + 0x4000)):
+            if not ida_bytes.is_mapped(head):
+                continue
+            if not any(True for _ in idautils.XrefsTo(head)):
+                return hex(head)
+    return None
+
+
+@test()
+def test_xrefs_to_zero_xrefs_message():
+    """xrefs_to explains when a mapped address has no incoming xrefs."""
+    addr = _find_address_without_xrefs()
+    if addr is None:
+        skip_test("binary has no mapped address without incoming xrefs")
+
+    result = xrefs_to(addr)
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    assert entry["addr"] == addr
+    assert entry.get("error") in (None, "")
+    assert entry.get("xref_count") == 0
+    assert entry.get("xrefs") == []
+    assert "No cross-references" in (entry.get("message") or "")
 
 
 @test()

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_modify.py
@@ -23,6 +23,7 @@ from ..api_core import lookup_funcs
 
 
 CRACKME_MAIN = "0x123e"
+CRACKME_CHECK_PW = "0x11a9"
 CRACKME_PATCH_ASM_ADDR = "0x125e"
 CRACKME_FRAME_DUMMY = "0x11a0"
 TYPED_FIXTURE_IMMEDIATE_1234 = "0x1013e44"
@@ -209,6 +210,14 @@ def test_rename_function_roundtrip():
 
 
 @test(binary="crackme03.elf")
+def test_rename_duplicate_name():
+    """rename reports when the target name is already used elsewhere."""
+    result = rename({"func": [{"addr": CRACKME_FRAME_DUMMY, "name": "main"}]})
+    assert "func" in result
+    assert_error(result["func"][0], contains="already used")
+
+
+@test(binary="crackme03.elf")
 def test_rename_data_roundtrip():
     """rename can rename a global/data symbol and restore it."""
     import idaapi
@@ -261,12 +270,12 @@ def test_rename_stop_on_error():
     assert result["summary"]["stopped"] is True
 
 
-@test()
+@test(binary="crackme03.elf")
 def test_rename_local_error_handling():
     """rename(local=...) reports a structured error for a missing local variable."""
-    fn_addr = get_any_function()
+    fn_addr = CRACKME_CHECK_PW
     if not fn_addr:
-        skip_test("binary has no functions")
+        skip_test("check_pw not present")
 
     result = rename(
         {
@@ -281,7 +290,7 @@ def test_rename_local_error_handling():
     )
     assert "local" in result
     assert "error" in result["local"][0]
-    assert_error(result["local"][0])
+    assert_error(result["local"][0], contains="not found")
 
 
 @test(binary="typed_fixture.elf")
@@ -297,7 +306,9 @@ def test_rename_local_roundtrip():
         )
         assert (
             "error" not in result["local"][0]
-            or result["local"][0].get("error") == "Rename failed"
+            or "not found" in (result["local"][0].get("error") or "").lower()
+            or "Hex-Rays" in (result["local"][0].get("error") or "")
+            or "could not rename local" in (result["local"][0].get("error") or "").lower()
         )
     finally:
         rename(

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
@@ -29,6 +29,7 @@ from ..api_types import (
 TEST_STRUCT_NAME = "__TestStruct__"
 NAME_RESOLUTION_STRUCT = "__NameResolutionTest__"
 CRACKME_DSO_HANDLE = "0x4008"
+CRACKME_CHECK_PW = "0x11a9"
 TYPE_APPLY_SIGNATURE = "int"
 TYPED_FIXTURE_SUM_POINT = "0x1013c10"
 TYPED_FIXTURE_USE_WRAPPER = "0x1013dc0"
@@ -455,6 +456,29 @@ def test_set_type_function_not_found_branch():
 
 
 @test(binary="crackme03.elf")
+def test_set_type_function_undefined_referenced_type():
+    """set_type(kind=function) explains apply failures for undeclared referenced types."""
+    result = set_type(
+        {
+            "addr": CRACKME_CHECK_PW,
+            "kind": "function",
+            "signature": "UndefinedStruct __fastcall check_pw(const char *s)",
+        }
+    )
+    assert_is_list(result, min_length=1)
+    entry = result[0]
+    if entry.get("ok"):
+        skip_test("IDA accepted an undefined referenced type in this environment")
+    assert_error(entry)
+    assert entry["error"] != "Failed to apply function type"
+    assert (
+        "declared" in entry["error"].lower()
+        or "parse" in entry["error"].lower()
+        or "function type" in entry["error"].lower()
+    )
+
+
+@test(binary="crackme03.elf")
 def test_set_type_stack_missing_member():
     """set_type(kind=stack) reports a missing frame member explicitly."""
     fn_addr = get_named_address("main")
@@ -533,7 +557,8 @@ def test_set_type_local_branch():
     assert_is_list(result, min_length=1)
     assert (
         "error" not in result[0]
-        or result[0].get("error") == "Failed to apply local variable type"
+        or result[0].get("ok") is True
+        or "Failed to apply type" in (result[0].get("error") or "")
     )
 
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_typed_fixture.py
@@ -170,10 +170,7 @@ def test_typed_fixture_set_type_local_and_stack_paths():
     local = set_type(
         {"addr": USE_WRAPPER, "kind": "local", "variable": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
     )[0]
-    assert (
-        "error" not in local
-        or local.get("error") == "Failed to apply local variable type"
-    )
+    assert "error" not in local or local.get("ok") is True or "Failed to apply type" in (local.get("error") or "")
 
     stack = set_type(
         {"addr": USE_WRAPPER, "kind": "stack", "name": TYPED_FIXTURE_LOCAL_NAME, "ty": "int"}
@@ -194,7 +191,8 @@ def test_typed_fixture_rename_local_and_stack_paths():
         )
         assert (
             "error" not in local["local"][0]
-            or local["local"][0].get("error") == "Rename failed"
+            or "not found" in (local["local"][0].get("error") or "").lower()
+            or "Hex-Rays" in (local["local"][0].get("error") or "")
         )
         stack = rename(
             {
@@ -208,13 +206,6 @@ def test_typed_fixture_rename_local_and_stack_paths():
         names = {var["name"] for var in frame["vars"]}
         assert "rhs_stack" in names
     finally:
-        rename(
-            {
-                "local": [
-                    {"func_addr": USE_WRAPPER, "old": "rhs_value", "new": TYPED_FIXTURE_LOCAL_NAME}
-                ]
-            }
-        )
         rename(
             {
                 "stack": [

--- a/src/ida_pro_mcp/ida_mcp/tests/test_utils.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_utils.py
@@ -112,8 +112,9 @@ def test_utils_stack_frame_and_decompile_helpers():
     names = {v["name"] for v in vars_}
     assert {"rhs_handle", "lhs_handle"}.issubset(names)
 
-    code = decompile_function_safe(0x1013DC0)
+    code, err = decompile_function_safe(0x1013DC0)
     assert code is not None
+    assert err is None
     assert "sum_point" in code
     # Address annotations (/*0x....*/) are added via get_line_item; passing None
     # for the phead/ptail output params could crash IDA via null-pointer write.

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -1006,6 +1006,23 @@ class my_modifier_t(ida_hexrays.user_lvar_modifier_t):
         return False
 
 
+def hexrays_local_var_exists(func_ea: int, var_name: str) -> bool:
+    """Return True if a Hex-Rays local variable exists in the decompiled function."""
+    if not ida_hexrays.init_hexrays_plugin():
+        return False
+    try:
+        cfunc = ida_hexrays.decompile(func_ea)
+        if not cfunc:
+            return False
+        lvars = cfunc.get_lvars()
+        for i in range(lvars.size()):
+            if lvars[i].name == var_name:
+                return True
+    except Exception:
+        return False
+    return False
+
+
 def parse_decls_ctypes(decls: str, hti_flags: int) -> tuple[int, list[str]]:
     if sys.platform == "win32":
         import ctypes
@@ -1121,17 +1138,15 @@ def decompile_checked(addr: int):
     return cfunc
 
 
-def decompile_function_safe(ea: int, include_addresses: bool = True) -> Optional[str]:
-    """Safely decompile a function, returning None on failure (uses cache)"""
+def decompile_function_safe(
+    ea: int, include_addresses: bool = True
+) -> tuple[str | None, str | None]:
+    """Safely decompile a function. Returns (code, error); exactly one is non-None."""
     import ida_lines
     import ida_kernwin
 
     try:
-        if not ida_hexrays.init_hexrays_plugin():
-            return None
-        cfunc = ida_hexrays.decompile(ea)
-        if not cfunc:
-            return None
+        cfunc = decompile_checked(ea)
         sv = cfunc.get_pseudocode()
         lines = []
         for sl in sv:
@@ -1154,9 +1169,11 @@ def decompile_function_safe(ea: int, include_addresses: bool = True) -> Optional
                 lines.append(f"{text} /*{line_ea:#x}*/")
             else:
                 lines.append(text)
-        return "\n".join(lines)
-    except Exception:
-        return None
+        return "\n".join(lines), None
+    except IDAError as e:
+        return None, str(e)
+    except Exception as e:
+        return None, f"Decompilation failed at {hex(ea)}: {e}"
 
 
 def get_assembly_lines(ea: int) -> str:


### PR DESCRIPTION
## Summary
- Return actionable error details from rename, decompile, set_type, and xref APIs so MCP agents stop retrying on benign outcomes (duplicate names, zero xrefs, generic failures).
- Propagate Hex-Rays decompilation failures through `decompile_function_safe()` as `(code, error)` and surface them in analysis/export/composite tools.
- Add explicit zero-xref `message` fields for xref helpers and expand regression tests on both fixtures.

## Test plan
- [x] `uv run ida-mcp-test tests/crackme03.elf -q` (360 passed)
- [x] `uv run ida-mcp-test tests/typed_fixture.elf -q` (331 passed, 1 skipped)
- [x] Targeted checks: duplicate rename, zero-xref message, undefined referenced type in function signature

Fixes #52