### PR TITLE
reuse segment buffer and stop early in signature uniqueness checks

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/_sigmaker.py
@@ -755,6 +755,14 @@ class UniqueSignatureGenerator:
         start_fn = idaapi.get_func(ea)
         bytes_since_last_check = 0
 
+        # reuse a single segment buffer across every uniqueness check below
+        # rebuilding it for each instruction dominates signature generation time
+        search_buffer = (
+            InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+            if SIMD_SPEEDUP_AVAILABLE
+            else None
+        )
+
         for cur_ea, ins, ins_len in InstructionWalker(ea):
             if bytes_since_last_check > cfg.max_single_signature_length:
                 if not cfg.ask_longer_signature:
@@ -773,7 +781,7 @@ class UniqueSignatureGenerator:
             )
             bytes_since_last_check += ins_len
 
-            if SignatureSearcher.is_unique(f"{sig:ida}"):
+            if SignatureSearcher.is_unique(f"{sig:ida}", buffer=search_buffer):
                 sig.trim_signature()
                 return sig
 
@@ -994,11 +1002,14 @@ class SignatureSearcher:
 
     @staticmethod
     def _find_all_simd(
-        ida_signature: str, skip_more_than_one: bool = False
+        ida_signature: str,
+        skip_more_than_one: bool = False,
+        buffer: InMemoryBuffer | None = None,
     ) -> list[Match]:
         simd_signature, _ = SigText.normalize(ida_signature)
-        buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
-        data_mv = buf.data()
+        if buffer is None:
+            buffer = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+        data_mv = buffer.data()
 
         sig = _SimdSignature(simd_signature)
         results: list[Match] = []
@@ -1020,9 +1031,15 @@ class SignatureSearcher:
         return results
 
     @staticmethod
-    def find_all(ida_signature: str) -> list[Match]:
+    def find_all(
+        ida_signature: str,
+        skip_more_than_one: bool = False,
+        buffer: InMemoryBuffer | None = None,
+    ) -> list[Match]:
         if SIMD_SPEEDUP_AVAILABLE:
-            return SignatureSearcher._find_all_simd(ida_signature)
+            return SignatureSearcher._find_all_simd(
+                ida_signature, skip_more_than_one, buffer
+            )
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
         out: list[Match] = []
@@ -1040,9 +1057,14 @@ class SignatureSearcher:
             if hit == idaapi.BADADDR:
                 break
             out.append(Match(hit))
+            if skip_more_than_one and len(out) > 1:
+                break
             ea = hit + 1
         return out
 
     @classmethod
-    def is_unique(cls, ida_signature: str) -> bool:
-        return len(cls.find_all(ida_signature)) == 1
+    def is_unique(
+        cls, ida_signature: str, buffer: InMemoryBuffer | None = None
+    ) -> bool:
+        matches = cls.find_all(ida_signature, skip_more_than_one=True, buffer=buffer)
+        return len(matches) == 1

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_sigmaker.py
@@ -94,6 +94,57 @@ def test_make_signature_by_name():
     assert entry["unique"] is True
 
 
+@test()
+def test_is_unique_accepts_preloaded_buffer():
+    """is_unique must return the same verdict whether it loads the segment
+    buffer itself or is handed a preloaded one signature generation reuses one
+    buffer across every uniqueness check so the injected buffer path must not
+    change the result"""
+    from .._sigmaker import SignatureSearcher, InMemoryBuffer, SIMD_SPEEDUP_AVAILABLE
+
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    entry = make_signature(fn_addr)[0]
+    if entry.get("signature") is None:
+        skip_test("could not generate a signature for this function")
+    sig = entry["signature"]
+    assert entry["unique"] is True
+
+    assert SignatureSearcher.is_unique(sig) is True
+    if SIMD_SPEEDUP_AVAILABLE:
+        buffer = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+        # the same buffer must stay valid and reusable across repeated checks
+        assert SignatureSearcher.is_unique(sig, buffer=buffer) is True
+        assert SignatureSearcher.is_unique(sig, buffer=buffer) is True
+
+
+@test()
+def test_find_all_skip_more_than_one_caps_at_two():
+    """a uniqueness check only needs to know whether a second match exists so
+    find_all with skip_more_than_one set stops at two matches instead of
+    scanning to the end of the image while still agreeing with a full scan"""
+    import idaapi
+
+    from .._sigmaker import SignatureSearcher
+
+    fn_addr = get_any_function()
+    if not fn_addr:
+        skip_test("binary has no functions")
+
+    # a single byte is short enough to be ambiguous on any real binary
+    sig = f"{idaapi.get_byte(int(fn_addr, 16)):02X}"
+    full = SignatureSearcher.find_all(sig)
+    if len(full) < 2:
+        skip_test("first function byte is unique in this image")
+
+    capped = SignatureSearcher.find_all(sig, skip_more_than_one=True)
+    assert len(capped) == 2, f"expected 2 capped matches, got {len(capped)}"
+    assert [m.address for m in capped] == [m.address for m in full[:2]]
+    assert SignatureSearcher.is_unique(sig) is False
+
+
 # ============================================================================
 # make_signature_for_function
 # ============================================================================


### PR DESCRIPTION
UniqueSignatureGenerator grows a signature one instruction at a time and calls SignatureSearcher.is_unique after every instruction, each call went through find_all which rebuilt the entire segment buffer and scanned it to the very end of the image

this change:
- loads the segment buffer once per generate() call and threads it through is_unique / find_all / _find_all_simd so it is reused across every check
- passes skip_more_than_one through is_unique so a uniqueness check stops as soon as a second match is found, in both the SIMD and bin_search paths

closes #398