### PR TITLE
idb_save: add pack flag to consolidate loose files into .i64

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -832,6 +832,7 @@ def imports_query(
 @idasync
 def idb_save(
     path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
+    pack: Annotated[bool, "Pack into a single compressed .i64 and delete the loose .id0/.id1/.id2/.nam/.til working files (default: False)"] = False,
 ) -> IdbSaveResult:
     """Save active IDB to disk, optionally to a provided path."""
     try:
@@ -841,7 +842,8 @@ def idb_save(
         if not save_path:
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
-        ok = bool(ida_loader.save_database(save_path, 0))
+        flags = (ida_loader.DBFL_KILL | ida_loader.DBFL_COMP) if pack else 0
+        ok = bool(ida_loader.save_database(save_path, flags))
         result: dict = {"ok": ok, "path": save_path}
         if not ok:
             result["error"] = "save_database returned false"


### PR DESCRIPTION
I will admit that is a feature that Claude said was missing.  I am not familiar with this project at all, and only verified that it worked and seemed to provide what I was wanting.  But, if you think that this is not necessary and/or available some other way, just let me know!

I would write more, but it's just 3 lines and I'm sure you'll see everything you need just from looking at the new lines :)

I won't be offended at all it's not merged.  It was just something that Claude indicated needed to be updated in order for it to programmatically close the DB and "pack" it, so I thought I'd share just in case it was something you might be interested in.