### PR TITLE
idb_save: add pack flag to consolidate loose files into .i64

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -832,6 +832,7 @@ def imports_query(
 @idasync
 def idb_save(
     path: Annotated[str, "Optional destination path (default: current IDB path)"] = "",
+    pack: Annotated[bool, "Pack into a single compressed .i64 and delete the loose .id0/.id1/.id2/.nam/.til working files (default: False)"] = False,
 ) -> IdbSaveResult:
     """Save active IDB to disk, optionally to a provided path."""
     try:
@@ -841,7 +842,8 @@ def idb_save(
         if not save_path:
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
-        ok = bool(ida_loader.save_database(save_path, 0))
+        flags = (ida_loader.DBFL_KILL | ida_loader.DBFL_COMP) if pack else 0
+        ok = bool(ida_loader.save_database(save_path, flags))
         result: dict = {"ok": ok, "path": save_path}
         if not ok:
             result["error"] = "save_database returned false"


### PR DESCRIPTION
_`Note:  I don't normally do pull requests generated entirely by Claude; but, it's just 3 lines and I'm primarily a C++ developer (my python is serviceable, but not expert level.)    If Claude is wrong about any of it, or if you aren't interested in adding this feature, I won't be offended at all.  I just thought I'd share just in case it was helpful.`_

## Summary

- Adds a `pack: bool = False` parameter to `idb_save`.
- When `pack=True`, the underlying `ida_loader.save_database()` call is invoked with `DBFL_KILL | DBFL_COMP`, which consolidates the loose `.id0` / `.id1` / `.id2` /
`.nam` / `.til` working files into the packed `.i64` (equivalent to IDA GUI's *File → Close → Pack database (Compressed File)*).
- `pack=False` is the default, so existing callers get unchanged behavior.

## Why

Previously `idb_save` hardcoded `flags=0`, so MCP clients had no way to ask for the packed/cleaned-up form. The only way to get the same end-state was to call
`idalib_close` and lose the session. With `pack=True` you can checkpoint into a clean packed `.i64` mid-session while keeping the database open for continued work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)