### PR TITLE
fix(idalib): bound worker open/analysis with a timeout and reap hung workers

### DIFF
--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -55,6 +55,14 @@ IDALIB_HIDDEN_PLUGIN_TOOLS = {"list_instances", "select_instance"}
 STDIO_PROXY_START_TIMEOUT_SEC = 120.0
 STDIO_PROXY_PROBE_SESSION_ID = "idalib-stdio-proxy-probe"
 
+# Upper bound (seconds) on how long a worker may take to open and auto-analyze a
+# binary before it is reaped and an error is returned. A malformed or hostile
+# binary can drive IDA's auto-analysis into an effectively unbounded loop; with
+# no limit this silently wedges the worker process (and the blocking supervisor
+# RPC waiting on it) forever, with no progress feedback and no recovery.
+# Set IDA_MCP_OPEN_TIMEOUT=0 to wait indefinitely (previous behavior).
+WORKER_OPEN_TIMEOUT_SEC = float(os.environ.get("IDA_MCP_OPEN_TIMEOUT", "1800"))
+
 
 def _import_zeromcp():
     """Import vendored zeromcp without importing ida_mcp/__init__.py."""
@@ -348,6 +356,25 @@ class IdalibSupervisor:
             proc.kill()
             proc.wait(timeout=5)
 
+    @staticmethod
+    def _cleanup_partial_database(input_path: str) -> None:
+        """Remove leftover unpacked IDA database parts after a failed/aborted open.
+
+        When a worker is reaped mid-open (for example on an analysis timeout), the
+        partially written .id0/.id1/.id2/.nam/.til files are left next to the input.
+        IDA then rejects every subsequent open of that path with
+        "database is corrupted beyond repair", turning a one-off failure into a
+        permanent one. The packed .i64/.idb (a complete saved database) is kept.
+        """
+        base = Path(input_path)
+        for ext in (".id0", ".id1", ".id2", ".nam", ".til"):
+            part = base.with_name(base.name + ext)
+            try:
+                if part.exists():
+                    part.unlink()
+            except OSError:
+                pass
+
     def shutdown(self) -> None:
         with self._lock:
             workers = list(self.sessions.values())
@@ -447,7 +474,12 @@ class IdalibSupervisor:
         return self._worker_rpc(worker, request_obj)
 
     def call_worker_tool(
-        self, worker: WorkerSession, name: str, arguments: dict[str, Any] | None = None
+        self,
+        worker: WorkerSession,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
     ) -> Any:
         response = self._worker_rpc(
             worker,
@@ -457,6 +489,7 @@ class IdalibSupervisor:
                 "method": "tools/call",
                 "params": {"name": name, "arguments": arguments or {}},
             },
+            timeout=timeout,
         )
         if "error" in response:
             raise RuntimeError(response["error"].get("message", "Unknown worker error"))
@@ -607,6 +640,7 @@ class IdalibSupervisor:
 
             worker = self._allocate_worker_locked()
 
+        open_timeout = (WORKER_OPEN_TIMEOUT_SEC or None) if run_auto_analysis else None
         try:
             opened = self.call_worker_tool(
                 worker,
@@ -616,9 +650,19 @@ class IdalibSupervisor:
                     "run_auto_analysis": run_auto_analysis,
                     "session_id": session_id,
                 },
+                timeout=open_timeout,
             )
             if isinstance(opened, dict) and opened.get("error"):
                 raise RuntimeError(str(opened["error"]))
+        except TimeoutError:
+            self._terminate_worker(worker)
+            self._cleanup_partial_database(resolved)
+            raise RuntimeError(
+                f"idalib worker timed out after {open_timeout:.0f}s while opening and "
+                f"analyzing {resolved}. The binary may drive auto-analysis into an "
+                f"unbounded loop. Retry with run_auto_analysis=false (open without "
+                f"analysis and decompile on demand), or raise IDA_MCP_OPEN_TIMEOUT."
+            ) from None
         except Exception:
             self._terminate_worker(worker)
             raise


### PR DESCRIPTION
# fix(idalib): bound worker open/analysis with a timeout and reap hung workers

## Problem

Opening a binary through the idalib (headless) MCP server can hang the server
indefinitely, with no progress feedback and no way to recover short of killing
the process.

Two things combine to cause it:

1. `IDASessionManager.open_binary` calls `ida_auto.auto_wait()` with no time
   limit when `run_auto_analysis=True` (the default), and the supervisor's RPC
   to the worker (`call_worker_tool` → `_worker_rpc`) is issued with
   `timeout=None`. If a binary drives IDA's auto-analysis into an effectively
   unbounded loop, the worker never returns and the blocking supervisor call
   waits on it forever.

2. When such an open is aborted (or the worker is killed), the partially written
   database parts (`.id0` / `.id1` / `.id2` / `.nam` / `.til`) are left next to
   the input file. IDA then rejects *every* subsequent open of that path with
   `Read error. The database is corrupted beyond repair`, so a one-off failure
   becomes a permanent one.

## Reproduction

A statically linked Go binary whose embedded type information IDA cannot fully
validate (the analysis log fills with `golang: failed to validate layout of ...`)
reliably triggers it:

- `idapro.open_database(binary, run_auto_analysis=False)` returns in ~90s with
  all functions recognized.
- `ida_auto.auto_wait()` on the same database never returns (observed: 85% CPU,
  zero database writes for ~1h). A `faulthandler` dump shows the process parked
  in `ida_auto.py` → `auto_wait`.

Through the MCP this surfaces as `idalib_open` (which defaults to
`run_auto_analysis=True`) hanging forever.

## Fix

- Add `WORKER_OPEN_TIMEOUT_SEC` (env `IDA_MCP_OPEN_TIMEOUT`, default `1800`s;
  `0` = wait indefinitely, the previous behavior) and pass it as the socket
  timeout for the open/analyze RPC. `call_worker_tool` gains an optional
  `timeout` argument.
- On timeout, reap the worker (as already done for other open failures) and
  return a clear, actionable error suggesting `run_auto_analysis=false` or a
  higher `IDA_MCP_OPEN_TIMEOUT`.
- Add `_cleanup_partial_database` to delete the leftover unpacked
  `.id0/.id1/.id2/.nam/.til` parts after a failed open, so the next open is not
  permanently poisoned. The complete packed `.i64`/`.idb` is kept.

The change is limited to the headless supervisor path. Default behavior is
unchanged except that an open which would previously hang forever now fails
after the (configurable) timeout with a useful message. `run_auto_analysis=false`
is unaffected — the bound only guards the analyze path, which is the one that
can stall.
