### PR TITLE
fix: validate pattern filter types

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -925,6 +925,10 @@ def paginate(data: list[T], offset: int, count: int) -> Page[T]:
 def pattern_filter(data: list[T], pattern: str, key: str) -> list[T]:
     if not pattern:
         return data
+    if not isinstance(pattern, str):
+        raise IDAError(
+            f"Filter pattern must be a string, got {type(pattern).__name__}"
+        )
 
     regex = None
     use_glob = False

--- a/tests/test_utils_pattern_filter.py
+++ b/tests/test_utils_pattern_filter.py
@@ -1,0 +1,67 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+
+class _IdaStub(types.ModuleType):
+    def __getattr__(self, name):
+        dummy = type(name, (), {})
+        setattr(self, name, dummy)
+        return dummy
+
+
+def _load_utils_module():
+    pkg_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "ida_pro_mcp" / "ida_mcp"
+    pkg_name = "_test_stub_ida_mcp_utils"
+
+    for module_name in (
+        "ida_bytes",
+        "ida_funcs",
+        "ida_hexrays",
+        "ida_kernwin",
+        "ida_nalt",
+        "ida_typeinf",
+        "idaapi",
+        "idautils",
+        "idc",
+    ):
+        sys.modules.setdefault(module_name, _IdaStub(module_name))
+
+    package = types.ModuleType(pkg_name)
+    package.__path__ = [str(pkg_root)]
+    sys.modules[pkg_name] = package
+
+    sync_module = types.ModuleType(pkg_name + ".sync")
+
+    class IDAError(Exception):
+        pass
+
+    setattr(sync_module, "IDAError", IDAError)
+    sys.modules[pkg_name + ".sync"] = sync_module
+
+    utils_name = pkg_name + ".utils"
+    spec = importlib.util.spec_from_file_location(utils_name, pkg_root / "utils.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[utils_name] = module
+    spec.loader.exec_module(module)
+    return module, IDAError
+
+
+def test_pattern_filter_rejects_non_string_filter_before_pattern_matching():
+    utils, IDAError = _load_utils_module()
+
+    with pytest.raises(IDAError, match="Filter pattern must be a string, got dict"):
+        utils.pattern_filter([{"name": "main"}], {"contains": "main"}, "name")
+
+
+def test_pattern_filter_keeps_existing_string_matching_modes():
+    utils, _ = _load_utils_module()
+    data = [{"name": "main"}, {"name": "helper"}, {"name": "sub_1000"}]
+
+    assert utils.pattern_filter(data, "main", "name") == [{"name": "main"}]
+    assert utils.pattern_filter(data, "sub_*", "name") == [{"name": "sub_1000"}]
+    assert utils.pattern_filter(data, "/HELP/i", "name") == [{"name": "helper"}]


### PR DESCRIPTION
## Summary

- validate `pattern_filter` input before string/glob/regex matching
- return a clear IDAError for non-string filters instead of an `AttributeError` from `.startswith`
- add focused unit coverage for non-string rejection plus existing string/glob/regex behavior

## Context

This covers one of the low-risk pre-flight mitigations discussed in #235: malformed/non-string filter inputs should fail before entering pattern matching.

## Tests

- `python -m py_compile src/ida_pro_mcp/ida_mcp/utils.py tests/test_utils_pattern_filter.py`
- `uv run pytest tests/test_utils_pattern_filter.py tests/test_server_transport.py -q`

Note: I also tried `uv run pytest tests/test_utils_pattern_filter.py tests/test_worker_lifecycle.py tests/test_server_transport.py -q`; the new filter tests passed, but two pre-existing worker lifecycle timing tests failed locally on the unmodified `origin/main` timing behavior.
