### PR TITLE
Remove unnecessary API version check for IDA 9.0

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/compat.py
+++ b/src/ida_pro_mcp/ida_mcp/compat.py
@@ -84,7 +84,8 @@ if TYPE_CHECKING:
     IDA_VERSION: tuple[int, int, int] = cast(tuple[int, int, int], (9, 2, 0))
 else:
     IDA_VERSION = _parse_kernel_version(idaapi.get_kernel_version())
-    _check_required_apis(IDA_VERSION)
+    
+    #_check_required_apis(IDA_VERSION)
 
 IDA_GE_90 = IDA_VERSION >= (9, 0, 0)
 IDA_GE_85 = IDA_VERSION >= (8, 5, 0)

--- a/src/ida_pro_mcp/ida_mcp/compat.py
+++ b/src/ida_pro_mcp/ida_mcp/compat.py
@@ -84,7 +84,6 @@ if TYPE_CHECKING:
     IDA_VERSION: tuple[int, int, int] = cast(tuple[int, int, int], (9, 2, 0))
 else:
     IDA_VERSION = _parse_kernel_version(idaapi.get_kernel_version())
-    
 
 IDA_GE_90 = IDA_VERSION >= (9, 0, 0)
 IDA_GE_85 = IDA_VERSION >= (8, 5, 0)

--- a/src/ida_pro_mcp/ida_mcp/compat.py
+++ b/src/ida_pro_mcp/ida_mcp/compat.py
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
 else:
     IDA_VERSION = _parse_kernel_version(idaapi.get_kernel_version())
     
-    #_check_required_apis(IDA_VERSION)
 
 IDA_GE_90 = IDA_VERSION >= (9, 0, 0)
 IDA_GE_85 = IDA_VERSION >= (8, 5, 0)


### PR DESCRIPTION
The _check_required_apis() function blocks IDA 9.0

 but the code already provides complete fallbacks via
hasattr() checks in get_func_name(), get_func_prototype(), and
tinfo_get_udm(). Remove the hard check to allow it to work.
