### PR TITLE
fix(idb_save): native save in GUI to avoid corrupting the open database (#446)

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -835,8 +835,16 @@ def idb_save(
 ) -> IdbSaveResult:
     """Save active IDB to disk, optionally to a provided path.
 
-    Always packs into a single compressed .i64/.idb, removing the loose
-    .id0/.id1/.id2/.nam/.til working files.
+    In the GUI (idaq) the open database is backed by loose working files
+    (.id0/.id1/.id2/.nam/.til) that IDA actively manages; packing+killing them
+    out from under the running GUI corrupts the database on the next reopen
+    (issue #446). So in GUI mode this uses IDA's native in-place save
+    (equivalent to Ctrl+W / save_database(None, 0)), and for an explicit
+    different destination writes a compressed copy WITHOUT killing the live
+    working files.
+
+    Only headless idalib — which has no live loose files to clobber — packs into
+    a single compressed .i64/.idb, removing the loose working files.
     """
     try:
         save_path = path.strip() if path else ""
@@ -845,8 +853,26 @@ def idb_save(
         if not save_path:
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
-        flags = ida_loader.DBFL_KILL | ida_loader.DBFL_COMP
-        ok = bool(ida_loader.save_database(save_path, flags))
+        try:
+            is_gui = bool(ida_kernwin.is_idaq())
+        except Exception:
+            is_gui = False
+
+        if is_gui:
+            # GUI: never DBFL_KILL the loose files of the open database.
+            current = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+            if path and save_path != current:
+                # Save-as a compressed snapshot to a new path; leaves the live
+                # working files intact.
+                ok = bool(ida_loader.save_database(save_path, ida_loader.DBFL_COMP))
+            else:
+                # Native in-place save (Ctrl+W).
+                ok = bool(ida_loader.save_database(None, 0))
+        else:
+            # Headless idalib: safe to pack into a single compressed file.
+            flags = ida_loader.DBFL_KILL | ida_loader.DBFL_COMP
+            ok = bool(ida_loader.save_database(save_path, flags))
+
         result: dict = {"ok": ok, "path": save_path}
         if not ok:
             result["error"] = "save_database returned false"


### PR DESCRIPTION
Fixes #446.

`idb_save` packed the database with `DBFL_KILL | DBFL_COMP`, deleting the loose working files (`.id0/.id1/.id2/.nam/.til`) while the IDA GUI is actively using them, which corrupts the database on the next reopen.

This detects the GUI via `ida_kernwin.is_idaq()` and uses IDA's native save instead — `save_database(None, 0)` (Ctrl+W equivalent). An explicit different destination writes a compressed copy without `DBFL_KILL`, leaving the live working files intact. Headless idalib (no live loose files to clobber) keeps packing into a single compressed `.i64/.idb` as before — matching the issue's note that the current behaviour is correct for idalib.