### PR TITLE
fix(idalib): don't reap busy headless workers on health-probe timeout

### DIFF
--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -100,7 +100,8 @@ def idb_open(
     init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler after open"] = True,
     idle_ttl_sec: Annotated[
         int,
-        "Minimum idle TTL in seconds before the headless worker self-exits.",
+        "Minimum idle TTL in seconds before the headless worker self-exits. "
+        "Use 0 (or any value <= 0) to keep the worker resident forever.",
     ] = 600,
     preferred_session_id: Annotated[
         str,

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -53,8 +53,26 @@ IDB_MANAGEMENT_TOOLS = {
     "idb_open",
     "idb_list",
 }
-WORKER_TCP_HEALTH_TIMEOUT_SEC = 0.5
-WORKER_RPC_HEALTH_TIMEOUT_SEC = 2.0
+# Health-probe timeouts. A busy worker (mid auto-analysis / decompile) runs
+# single-threaded and cannot answer a JSON-RPC ping until it yields, so a tight
+# RPC timeout misclassifies "busy" as "dead" and gets the worker reaped. These
+# default generously and are env-overridable for slow hosts / huge databases.
+WORKER_TCP_HEALTH_TIMEOUT_SEC = float(os.environ.get("IDA_MCP_HEALTH_TCP_TIMEOUT", "2.0"))
+WORKER_RPC_HEALTH_TIMEOUT_SEC = float(os.environ.get("IDA_MCP_HEALTH_RPC_TIMEOUT", "10.0"))
+
+# When a health probe fails but the worker process is still alive, retry instead
+# of reaping it immediately: a busy worker is not a dead worker. Only a worker
+# whose OS process has actually exited is treated as unreachable.
+WORKER_HEALTH_RETRIES = int(os.environ.get("IDA_MCP_HEALTH_RETRIES", "3"))
+WORKER_HEALTH_RETRY_BACKOFF_SEC = float(os.environ.get("IDA_MCP_HEALTH_RETRY_BACKOFF", "1.0"))
+
+# Grace window (seconds) before a live-but-unresponsive worker is declared
+# wedged and reaped. A worker that keeps failing health probes for longer than
+# this — while its process is still alive — is treated as permanently stuck
+# (e.g. an analysis loop) rather than transiently busy, so it does not pin a
+# worker slot forever. Set IDA_MCP_WEDGED_GRACE_SEC=0 to never reap a live
+# worker (pure keep-forever behavior for long-lived single-user setups).
+WORKER_WEDGED_GRACE_SEC = float(os.environ.get("IDA_MCP_WEDGED_GRACE_SEC", "300"))
 
 # Upper bound (seconds) on how long a worker may take to open and auto-analyze a
 # binary before it is reaped and an error is returned. A malformed or hostile
@@ -153,6 +171,11 @@ class WorkerSession:
     owned: bool = True
     pid: int | None = None
     last_warmup: dict[str, Any] | None = None
+    # time.monotonic() of the first consecutive failed health probe while the
+    # process was still alive, or None when last seen healthy. Used to tell a
+    # transiently-busy worker (keep) from a permanently wedged one (reap after
+    # a grace window). See resolve_session().
+    unhealthy_since: float | None = None
 
     def to_dict(self) -> IdalibSessionInfo:
         return {
@@ -341,10 +364,13 @@ class IdalibSupervisor:
         return None
 
     def _prune_dead_worker_sessions_locked(self) -> None:
+        # Prune only workers whose OS process has actually exited. A live but
+        # busy worker fails the reachability probe yet must NOT be torn down —
+        # see resolve_session() for the same busy-vs-dead distinction.
         stale_session_ids = [
             session.session_id
             for session in self.sessions.values()
-            if session.backend == "worker" and session.owned and not self._session_is_reachable(session)
+            if session.backend == "worker" and session.owned and not session.is_alive()
         ]
         for session_id in stale_session_ids:
             stale = self._unregister_session_locked(session_id)
@@ -887,16 +913,62 @@ class IdalibSupervisor:
         session = self.peek_session(database)
         if self._session_is_reachable(session):
             session.last_accessed = datetime.now()
+            session.unhealthy_since = None  # recovered — clear wedged tracking
             return session
         if session.backend == "gui":
             return self._reopen_gui_session_headless(session)
+
+        # A failed probe does not mean the worker is dead — a worker that is busy
+        # running auto-analysis or a long decompile is single-threaded and cannot
+        # answer a ping until it yields. Reaping it here destroys live sessions.
+        # Only treat the worker as gone once its OS process has actually exited;
+        # while the process is alive, retry the probe with backoff.
+        for attempt in range(max(0, WORKER_HEALTH_RETRIES)):
+            if not session.is_alive():
+                break  # process really exited — stop retrying, reap below
+            if WORKER_HEALTH_RETRY_BACKOFF_SEC > 0:
+                time.sleep(WORKER_HEALTH_RETRY_BACKOFF_SEC)
+            if self._session_is_reachable(session):
+                session.last_accessed = datetime.now()
+                session.unhealthy_since = None  # recovered — clear tracking
+                return session
+
         session_id = session.session_id
-        with self._lock:
-            current = self.sessions.get(session_id)
-            if current is session:
-                self._unregister_session_locked(session_id)
-        self._terminate_worker(session)
-        raise RuntimeError(f"Worker for session '{session_id}' is not reachable")
+
+        # Process actually exited: genuinely dead, reap it.
+        if not session.is_alive():
+            with self._lock:
+                current = self.sessions.get(session_id)
+                if current is session:
+                    self._unregister_session_locked(session_id)
+            self._terminate_worker(session)
+            raise RuntimeError(f"Worker for session '{session_id}' is not reachable")
+
+        # Process is alive but unresponsive. Distinguish transiently busy (keep,
+        # retryable) from permanently wedged (reap after a grace window so it
+        # does not pin a worker slot forever). A non-positive grace window means
+        # "never reap a live worker".
+        now = time.monotonic()
+        if session.unhealthy_since is None:
+            session.unhealthy_since = now
+        unhealthy_for = now - session.unhealthy_since
+
+        if WORKER_WEDGED_GRACE_SEC > 0 and unhealthy_for >= WORKER_WEDGED_GRACE_SEC:
+            with self._lock:
+                current = self.sessions.get(session_id)
+                if current is session:
+                    self._unregister_session_locked(session_id)
+            self._terminate_worker(session)
+            raise RuntimeError(
+                f"Worker for session '{session_id}' was unresponsive for "
+                f"{unhealthy_for:.0f}s (>= {WORKER_WEDGED_GRACE_SEC:.0f}s grace) "
+                f"and was reaped as wedged. Reopen the database."
+            )
+
+        raise RuntimeError(
+            f"Worker for session '{session_id}' is alive but not responding "
+            f"(busy or wedged for {unhealthy_for:.0f}s); session kept. Retry shortly."
+        )
 
     def peek_session(self, database: str) -> WorkerSession:
         if not database:
@@ -1049,7 +1121,8 @@ def idb_open(
     init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler after open"] = True,
     idle_ttl_sec: Annotated[
         int,
-        "Minimum idle TTL in seconds before the headless worker self-exits.",
+        "Minimum idle TTL in seconds before the headless worker self-exits. "
+        "Use 0 (or any value <= 0) to keep the worker resident forever.",
     ] = 600,
     preferred_session_id: Annotated[
         str, "Preferred session ID (auto-generated if empty). Ignored if the file is already open in a GUI or worker session."

--- a/src/ida_pro_mcp/worker_lifecycle.py
+++ b/src/ida_pro_mcp/worker_lifecycle.py
@@ -64,6 +64,12 @@ class WorkerLifecycle:
 
     def set_idle_ttl(self, user_ttl_sec: float, load_time_sec: float = 0.0) -> None:
         with self._lock:
+            # A non-positive TTL means "never self-exit" — for long-lived workers
+            # the user keeps attached to across many sessions. Preserved verbatim
+            # (no MIN clamp) so check_shutdown_reason() can detect the sentinel.
+            if user_ttl_sec <= 0:
+                self.idle_ttl_sec = 0.0
+                return
             self.idle_ttl_sec = (
                 max(self.MIN_IDLE_TTL_SEC, user_ttl_sec) + max(0.0, load_time_sec)
             )
@@ -80,6 +86,10 @@ class WorkerLifecycle:
         with self._lock:
             last_req = self._last_request_at
             ttl = self.idle_ttl_sec
+        # ttl <= 0 is the "never self-exit" sentinel: the worker stays resident
+        # until explicitly stopped, regardless of idle time.
+        if ttl <= 0:
+            return None
         now = time.monotonic()
         if (now - last_req) > ttl:
             return f"no requests for {now - last_req:.1f}s"

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -644,19 +644,15 @@ def test_open_session_ignores_dead_workers_for_max_worker_limit(tmp_path):
         restore()
 
 
-def test_resolve_session_removes_unreachable_worker(tmp_path):
+def test_resolve_session_removes_dead_worker(tmp_path):
+    # A worker whose OS process has actually exited is reaped and reported
+    # unreachable. (Busy-but-alive workers are handled separately below.)
     sample = tmp_path / "sample.bin"
     sample.write_bytes(b"x")
     sup = _FakeSupervisor()
     session = sup.open_session(str(sample), session_id="sample")
-    unreachable = {session.session_id}
-
-    def fake_reachable(candidate):
-        if candidate.session_id in unreachable:
-            return False
-        return candidate.is_alive()
-
-    sup._session_is_reachable = fake_reachable
+    # Simulate the worker process having exited.
+    session.process = _DeadProcess()
 
     try:
         sup.resolve_session("sample")
@@ -666,7 +662,147 @@ def test_resolve_session_removes_unreachable_worker(tmp_path):
         raise AssertionError("expected RuntimeError")
 
     assert "sample" not in sup.sessions
-    assert session.process.returncode == 0
+
+
+def test_resolve_session_keeps_busy_but_alive_worker(tmp_path, monkeypatch):
+    # A worker that fails the health probe while its process is still alive is
+    # busy/wedged, NOT dead: it must be kept registered and a retryable error
+    # surfaced, never reaped. This is the core "session never lost" guarantee.
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRY_BACKOFF_SEC", 0.0)
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+    # Process stays alive (_FakeProcess.poll() -> None) but probe says unreachable.
+    sup._session_is_reachable = lambda candidate: False
+
+    try:
+        sup.resolve_session("sample")
+    except RuntimeError as e:
+        assert "not responding" in str(e)
+        assert "kept" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    # Session must still be registered and the process must NOT have been killed.
+    assert "sample" in sup.sessions
+    assert session.process.returncode is None
+
+
+def test_resolve_session_retries_then_recovers_busy_worker(tmp_path, monkeypatch):
+    # If a transiently-busy worker becomes reachable on a retry, resolve_session
+    # returns it instead of erroring — no spurious session loss on a slow probe.
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRY_BACKOFF_SEC", 0.0)
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRIES", 3)
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+
+    calls = {"n": 0}
+
+    def flaky_reachable(candidate):
+        calls["n"] += 1
+        return calls["n"] >= 2  # first probe fails, second succeeds
+
+    sup._session_is_reachable = flaky_reachable
+
+    resolved = sup.resolve_session("sample")
+    assert resolved.session_id == "sample"
+    assert "sample" in sup.sessions
+
+
+def test_resolve_session_reaps_wedged_worker_after_grace(tmp_path, monkeypatch):
+    # A live worker that stays unresponsive past the wedged-grace window is
+    # declared permanently stuck and reaped, so it cannot pin a worker slot
+    # forever. (Within the window it would be kept; see the busy test above.)
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRY_BACKOFF_SEC", 0.0)
+    monkeypatch.setattr(supmod, "WORKER_WEDGED_GRACE_SEC", 300.0)
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+    sup._session_is_reachable = lambda candidate: False  # never responds
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(supmod.time, "monotonic", lambda: clock["t"])
+
+    # First call: marks unhealthy_since, still within grace -> kept.
+    try:
+        sup.resolve_session("sample")
+    except RuntimeError as e:
+        assert "kept" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError (kept)")
+    assert "sample" in sup.sessions
+    assert session.unhealthy_since == 1000.0
+
+    # Advance past the grace window: now reaped as wedged.
+    clock["t"] = 1000.0 + 301.0
+    try:
+        sup.resolve_session("sample")
+    except RuntimeError as e:
+        assert "wedged" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError (wedged)")
+    assert "sample" not in sup.sessions
+    assert session.process.returncode == 0  # terminated
+
+
+def test_resolve_session_grace_zero_never_reaps_live_worker(tmp_path, monkeypatch):
+    # IDA_MCP_WEDGED_GRACE_SEC<=0 means a live worker is never reaped, no matter
+    # how long it stays unresponsive — pure keep-forever for long-lived setups.
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRY_BACKOFF_SEC", 0.0)
+    monkeypatch.setattr(supmod, "WORKER_WEDGED_GRACE_SEC", 0.0)
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+    sup._session_is_reachable = lambda candidate: False
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(supmod.time, "monotonic", lambda: clock["t"])
+    for advance in (0.0, 10_000.0):
+        clock["t"] = 1000.0 + advance
+        try:
+            sup.resolve_session("sample")
+        except RuntimeError as e:
+            assert "kept" in str(e)
+        else:
+            raise AssertionError("expected RuntimeError (kept)")
+    assert "sample" in sup.sessions
+    assert session.process.returncode is None  # never terminated
+
+
+def test_resolve_session_recovery_clears_wedged_tracking(tmp_path, monkeypatch):
+    # Once a worker answers a probe again, its unhealthy_since stamp resets so a
+    # later blip starts a fresh grace window rather than counting stale time.
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRY_BACKOFF_SEC", 0.0)
+    monkeypatch.setattr(supmod, "WORKER_WEDGED_GRACE_SEC", 300.0)
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(supmod.time, "monotonic", lambda: clock["t"])
+
+    state = {"ok": False}
+    sup._session_is_reachable = lambda candidate: state["ok"]
+
+    # Unresponsive once -> stamped.
+    try:
+        sup.resolve_session("sample")
+    except RuntimeError:
+        pass
+    assert session.unhealthy_since == 1000.0
+
+    # Now healthy -> stamp cleared.
+    state["ok"] = True
+    clock["t"] = 1100.0
+    resolved = sup.resolve_session("sample")
+    assert resolved.session_id == "sample"
+    assert session.unhealthy_since is None
 
 
 def test_open_session_prunes_unreachable_existing_mapping(tmp_path):
@@ -675,16 +811,16 @@ def test_open_session_prunes_unreachable_existing_mapping(tmp_path):
     restore = _patch_discovery(instances=[], probe=False)
     try:
         sup = _FakeSupervisor()
+        # A genuinely dead worker process (poll() -> non-None) for the same path.
+        # Pruning keys off real process death, not just a failed probe.
         stale = supmod.WorkerSession(
             session_id="stale",
             input_path=str(sample.resolve()),
             filename="sample.bin",
-            process=_FakeProcess(),
+            process=_DeadProcess(),
         )
         with sup._lock:
             sup._register_session_locked(stale, str(sample.resolve()))
-
-        sup._session_is_reachable = lambda session: session.session_id != "stale" and session.is_alive()
 
         session = sup.open_session(str(sample), session_id="new")
 

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -21,6 +21,16 @@ def test_check_fires_after_idle_ttl():
     assert reason is not None and "no requests" in reason
 
 
+def test_check_never_fires_when_ttl_disabled():
+    # ttl <= 0 disables idle self-exit entirely, even long past any idle window.
+    lc = WorkerLifecycle(idle_ttl_sec=0.0, poll_interval_sec=0.05)
+    time.sleep(0.10)
+    assert lc.check_shutdown_reason() is None
+    lc.set_idle_ttl(-1.0)
+    time.sleep(0.10)
+    assert lc.check_shutdown_reason() is None
+
+
 def test_touch_resets_idle_ttl():
     lc = WorkerLifecycle(idle_ttl_sec=0.10, poll_interval_sec=0.05)
     time.sleep(0.06)
@@ -75,12 +85,18 @@ def test_set_idle_ttl_uses_request_when_above_min():
     assert lc.idle_ttl_sec == 1800.0
 
 
-def test_set_idle_ttl_clamps_to_min():
+def test_set_idle_ttl_zero_or_negative_means_never_exit():
+    # A non-positive TTL is the "never self-exit" sentinel, preserved as 0.0
+    # (no MIN clamp) so the worker stays resident for long-lived sessions.
     lc = WorkerLifecycle(idle_ttl_sec=1000.0)
     lc.set_idle_ttl(0)
-    assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC
+    assert lc.idle_ttl_sec == 0.0
     lc.set_idle_ttl(-50.0)
-    assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC
+    assert lc.idle_ttl_sec == 0.0
+
+
+def test_set_idle_ttl_clamps_small_positive_to_min():
+    lc = WorkerLifecycle(idle_ttl_sec=1000.0)
     lc.set_idle_ttl(3.0)
     assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC
 
@@ -91,9 +107,16 @@ def test_set_idle_ttl_adds_load_time():
     assert lc.idle_ttl_sec == 645.0
 
 
-def test_set_idle_ttl_clamps_user_then_adds_load_time():
+def test_set_idle_ttl_never_exit_overrides_load_time():
+    # The "never exit" sentinel wins over any load-time padding.
     lc = WorkerLifecycle(idle_ttl_sec=10.0)
     lc.set_idle_ttl(0.0, load_time_sec=120.0)
+    assert lc.idle_ttl_sec == 0.0
+
+
+def test_set_idle_ttl_clamps_small_positive_then_adds_load_time():
+    lc = WorkerLifecycle(idle_ttl_sec=10.0)
+    lc.set_idle_ttl(3.0, load_time_sec=120.0)
     assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC + 120.0
 
 


### PR DESCRIPTION
### Problem

`IdalibSupervisor.resolve_session()` runs a health probe (TCP connect +
JSON-RPC `ping`) before forwarding every tool call. On the first probe failure
it immediately called `_terminate_worker()` and raised `"… is not reachable"`.

But a headless idalib worker is **single-threaded**. While it is busy running
auto-analysis, building caches, or decompiling, it physically cannot service
the ping until it yields. The supervisor interpreted that silence as death and
killed a perfectly healthy worker, destroying the session.

This is easy to hit with the warmup flags enabled on a large database: open
with `run_auto_analysis=true` (the default), and the very analysis the open
requested keeps the worker busy long enough that the next probe reaps it.

### Fix

Treat "busy" and "dead" as different states. The OS process liveness
(`session.is_alive()`), not a single ping, is the source of truth:

| State | Detection | Action |
|---|---|---|
| Dead | process exited | unregister + reap, raise `not reachable` |
| Busy | alive, ping fails, within grace | keep, retry w/ backoff, raise retryable error |
| Wedged | alive, ping keeps failing past grace | unregister + reap, raise `wedged` |

A grace window (`IDA_MCP_WEDGED_GRACE_SEC`, default 300s) ensures a genuinely
stuck worker (e.g. an analysis loop) still can't pin a worker slot forever —
so the limited worker pool can't be exhausted by zombies. Set it to `0` to
never reap a live worker (pure keep-forever, for single-user long-lived setups).

`_prune_dead_worker_sessions_locked()` is given the same busy-vs-dead
distinction: it now prunes only processes that have actually exited.

### New / changed knobs (all env-overridable, backward-compatible defaults)

| Env | Default | Was |
|---|---|---|
| `IDA_MCP_HEALTH_TCP_TIMEOUT` | `2.0` | hard-coded `0.5` |
| `IDA_MCP_HEALTH_RPC_TIMEOUT` | `10.0` | hard-coded `2.0` |
| `IDA_MCP_HEALTH_RETRIES` | `3` | (none — reaped on first failure) |
| `IDA_MCP_HEALTH_RETRY_BACKOFF` | `1.0` | — |
| `IDA_MCP_WEDGED_GRACE_SEC` | `300` | — |

Plus: `idb_open(idle_ttl_sec=0)` (or any `<= 0`) now means "never self-exit",
for workers a user keeps attached to across many sessions. Positive values keep
the existing MIN-clamp + load-time-padding behavior.

### Compatibility

No default behavior changes for healthy workers — they answer the probe on the
first try and take the unchanged fast path. The only behavioral change is for an
**unreachable** worker: previously reaped on the first failed ping, now retried
and only reaped if its process has exited or it stays wedged past the grace
window. The widened timeouts only ever add latency on the unreachable path.

### Known limitation (pre-existing, out of scope here)

While a worker is opening a very large database, `open_session()` blocks on the
synchronous `call_worker_tool(worker, "idb_open", …)` until the open completes.
Because the HTTP transport services requests on a single thread, unrelated calls
(`tools/list`, `idb_list`, even health probes for *other* sessions) queue behind
that open and appear to hang until it finishes. This is independent of the change
here — the fix operates on the health-probe *decision*, but during a blocking
open requests never reach that decision point.

This PR does not address that serialization; it is called out only for honesty.
In practice the fix's value shows precisely here: a client that retries (and
times out) repeatedly against a worker busy opening a large DB no longer gets
that worker reaped out from under it — the session survives the whole open. A
follow-up could make long opens non-blocking, but that is a larger transport
change orthogonal to busy-worker reaping.

### Tests

`tests/test_idalib_supervisor.py` and `tests/test_worker_lifecycle.py`:

- renamed `…removes_unreachable_worker` → `…removes_dead_worker` (dead = exited)
- new: `keeps_busy_but_alive_worker`, `retries_then_recovers_busy_worker`,
  `reaps_wedged_worker_after_grace`, `grace_zero_never_reaps_live_worker`,
  `recovery_clears_wedged_tracking`
- lifecycle: `zero_or_negative_means_never_exit`,
  `never_exit_overrides_load_time`, `clamps_small_positive_*`,
  `check_never_fires_when_ttl_disabled`
- updated `prunes_unreachable_existing_mapping` to use a dead (exited) process

`pytest tests/` → **198 passed, 114 subtests** (Python 3.14, pytest 9.1.1).