### PR TITLE
fix: avoid trace flush during idb save to prevent freeze

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_trace.py
@@ -197,6 +197,38 @@ def test_trace_idb_shutdown_flushes_pending_buffer():
 
 
 @test()
+def test_trace_idb_savebase_does_not_flush_pending_buffer():
+    """savebase must not write trace records while IDA is saving the database."""
+    _reset_trace(batch_records=100)
+    try:
+        _call_through_registry("server_health", {})
+        backend = trace._state["idb_backend"]
+        hook = trace._state["idb_hook"]
+        assert backend is not None
+        assert hook is not None
+        assert _read_stats()["segments"] == 0
+
+        flush_calls = []
+        original_flush = backend.flush
+
+        def counted_flush():
+            flush_calls.append(True)
+            return original_flush()
+
+        backend.flush = counted_flush
+        hook.savebase()
+
+        assert flush_calls == []
+        assert _read_stats()["segments"] == 0
+
+        backend.flush = original_flush
+        trace.shutdown()
+        assert _read_stats()["segments"] == 1
+    finally:
+        _teardown_trace()
+
+
+@test()
 def test_trace_idb_records_duration_and_timestamp_shape():
     """Each record has numeric duration_ms and ISO-8601 UTC timestamp."""
     _reset_trace(batch_records=1)

--- a/src/ida_pro_mcp/ida_mcp/trace.py
+++ b/src/ida_pro_mcp/ida_mcp/trace.py
@@ -176,7 +176,7 @@ def _ensure_atexit() -> None:
 
 
 def _install_idb_hook() -> None:
-    """Flush pending records when the IDB is saved or closed."""
+    """Install IDB lifecycle hooks for trace cleanup."""
     with _state_lock:
         if _state["idb_hook"] is not None:
             return
@@ -189,12 +189,10 @@ def _install_idb_hook() -> None:
 
     class _TraceFlushHook(ida_idp.IDB_Hooks):
         def savebase(self, *args):
-            b = backend_ref.get("idb_backend")
-            if b is not None:
-                try:
-                    b.flush()
-                except Exception:
-                    pass
+            # Do not write trace netnodes while IDA is saving the database.
+            # Reentrant IDB mutation from this hook can destabilize GUI saves;
+            # buffered records still flush on threshold, iteration, shutdown,
+            # or close.
             return 0
 
         def closebase(self, *args):


### PR DESCRIPTION
## Summary

Prevents the trace `savebase` hook from flushing buffered trace records while IDA is saving the database.

## Root Cause

`idb_save` enters IDA's save path, which triggers `IDB_Hooks.savebase`. The trace hook previously called `flush()` there, causing reentrant netnode writes during database save. In GUI IDA this can destabilize the save path and crash.

## Impact

Trace records still flush through normal thresholds, trace iteration, shutdown, and close. They are no longer written from inside the save hook.

## Validation

- Regression failed before the fix
- `uv run ida-mcp-test tests/crackme03.elf -p "*savebase_does_not_flush*" -q` -> 1 passed
- `uv run ida-mcp-test tests/crackme03.elf -c trace -q` -> 12 passed
- Manual test in IDA confirmed `idb_save` no longer crashes.