### PR TITLE
fix(api_core): include UTF-16 strings in find_regex cache

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -145,10 +145,19 @@ _server_started_at = time.time()
 
 
 def _get_strings_cache() -> list[tuple[int, str]]:
-    """Get cached strings, building cache on first access."""
+    """Get cached strings, building cache on first access.
+
+    Both ASCII (C-style) and UTF-16 (wide) strings are scanned so that
+    ``find_regex`` can locate wide-char strings, which are common in Unreal
+    Engine and Windows binaries. ``idautils.Strings()`` defaults to
+    ``strtypes=[0]`` (C strings only), missing UTF-16 content — see #263.
+    """
     global _strings_cache
     if _strings_cache is None:
-        _strings_cache = [(s.ea, str(s)) for s in idautils.Strings() if s is not None]
+        strings = idautils.Strings()
+        # strtype 0 = C (ASCII/UTF-8), strtype 1 = Unicode C-Style (UTF-16).
+        strings.setup(strtypes=[0, 1])
+        _strings_cache = [(s.ea, str(s)) for s in strings if s is not None]
     return _strings_cache
 
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
@@ -31,6 +31,7 @@ from ..api_core import (
     find_regex,
     search_text,
     idb_save,
+    invalidate_strings_cache,
 )
 
 
@@ -466,6 +467,21 @@ def test_imports_query():
 @test()
 def test_find_regex():
     """find_regex can search for patterns"""
+    result = find_regex(".*")
+    assert_has_keys(result, "matches", "cursor")
+
+
+@test()
+def test_find_regex_strings_cache_includes_wide_strings():
+    """Strings cache is built with UTF-16 (strtype 1) included (#263).
+
+    Smoke test: invalidate the cache, rebuild, and confirm find_regex still
+    returns a well-formed result. The cache setup now passes
+    ``strtypes=[0, 1]`` to ``idautils.Strings().setup()`` so wide-char strings
+    are scanned alongside ASCII. Verifying actual UTF-16 hits requires a binary
+    with known wide strings (e.g. a UE4/Windows binary).
+    """
+    invalidate_strings_cache()
     result = find_regex(".*")
     assert_has_keys(result, "matches", "cursor")
 


### PR DESCRIPTION
## Problem

`find_regex` could not locate UTF-16 (wide) strings — common in Unreal Engine 4/5 and Windows binaries (`wchar_t` / `FString` / wide string APIs). Closes #263

`_get_strings_cache` built its cache with `idautils.Strings()`, which defaults to `strtypes=[0]` (C strings only). Wide/UTF-16 strings were never scanned, so `find_regex` (which iterates the cache) silently missed them — the AI assistant couldn't locate string references autonomously.

## Solution

Pass `strtypes=[0, 1]` to `idautils.Strings().setup()` when building the cache:
- `0` = C-style (ASCII/UTF-8)
- `1` = Unicode C-Style (UTF-16)

This automates the maintainer's documented workaround (manually enabling "Unicode C-Style (16 bits)" in IDA's Strings setup — https://github.com/mrexodia/ida-pro-mcp/issues/263#issuecomment-). The cache now includes wide strings, so `find_regex` finds them without manual IDA configuration.

## Changes

- `src/ida_pro_mcp/ida_mcp/api_core.py`: `_get_strings_cache` now instantiates `idautils.Strings()`, calls `strings.setup(strtypes=[0, 1])`, then iterates. Updated the docstring.
- `src/ida_pro_mcp/ida_mcp/tests/test_api_core.py`: added `test_find_regex_strings_cache_includes_wide_strings` (invalidates the cache, rebuilds, confirms `find_regex` still returns a well-formed result) + imported `invalidate_strings_cache`.

## Testing

⚠️ **Honest limitation:** the test suite runs **inside IDA Pro** (`api_core.py` imports `idautils`/`idaapi`/`idc` at module level), which I don't have locally, so I could not execute the tests. I verified:
- `python -m py_compile` passes on both files (no syntax errors).
- `ruff check` is clean on the changed lines (the 7 pre-existing ruff errors are unrelated duplicate-test definitions, not introduced by this PR).
- The fix is a 2-line config change that mirrors the maintainer's own workaround and follows the IDA `idautils.Strings().setup(strtypes=...)` API.

The added smoke test (and a UTF-16-specific assertion against a binary with known wide strings) can be run by a maintainer in IDA.

## Notes

- Fixes #263.
- `Signed-off-by` included on the commit (DCO).
