### PR TITLE
Add struct_member_upsert tool for filling struct gaps by offset

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -28,6 +28,7 @@ from .utils import (
     TypeQuery,
     TypeApplyBatch,
     EnumUpsert,
+    StructMemberUpsert,
 )
 from . import compat
 from .compat import tinfo_get_udm
@@ -147,6 +148,32 @@ class InferTypeResult(TypedDict, total=False):
     inferred_type: str | None
     method: str | None
     confidence: str
+    error: str
+
+
+class StructFieldUpsertResult(TypedDict, total=False):
+    offset: str
+    name: str
+    old: str
+    ty: str
+    created: bool
+    replaced: bool
+    skipped: bool
+    error: str
+
+
+class StructMemberUpsertSummaryResult(TypedDict):
+    created: int
+    replaced: int
+    skipped: int
+    conflicts: int
+
+
+class StructMemberUpsertResult(TypedDict, total=False):
+    struct: str
+    dry_run: bool
+    members: list[StructFieldUpsertResult]
+    summary: StructMemberUpsertSummaryResult
     error: str
 
 
@@ -504,6 +531,280 @@ def search_structs(
                             "ordinal": ordinal,
                         }
                     )
+
+    return results
+
+
+_SIZE_TO_BTF = {
+    1: ida_typeinf.BTF_UINT8,
+    2: ida_typeinf.BTF_UINT16,
+    4: ida_typeinf.BTF_UINT32,
+    8: ida_typeinf.BTF_UINT64,
+}
+
+
+def _parse_offset(value) -> int:
+    if isinstance(value, int):
+        return value
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Offset is required")
+    return int(text, 0)
+
+
+def _build_member_tinfo(field: dict) -> ida_typeinf.tinfo_t:
+    """Build the new member type from `size` (int) or `type` (name/decl)."""
+    type_text = str(field.get("type") or "").strip()
+    raw_size = field.get("size")
+    has_size = raw_size not in (None, "", 0)
+
+    if type_text and has_size:
+        raise ValueError("Provide either `size` or `type`, not both")
+    if type_text:
+        return _parse_type_tinfo(type_text)
+    if not has_size:
+        raise ValueError("Provide `size` or `type` for the new member")
+
+    size = int(raw_size)
+    if size not in _SIZE_TO_BTF:
+        raise ValueError(f"`size` must be one of 1/2/4/8 (got {size})")
+    return ida_typeinf.tinfo_t(_SIZE_TO_BTF[size])
+
+
+def _find_member_overlap(tif: ida_typeinf.tinfo_t, bit_off: int, bit_end: int):
+    """Return the first real (non-gap) member overlapping [bit_off, bit_end), else None."""
+    udt = ida_typeinf.udt_type_data_t()
+    if not tif.get_udt_details(udt):
+        return None
+    for member in udt:
+        if member.is_gap():
+            continue
+        if member.offset < bit_end and member.offset + member.size > bit_off:
+            return member
+    return None
+
+
+def _upsert_struct_member(
+    tif: ida_typeinf.tinfo_t, field: dict, dry_run: bool
+) -> StructFieldUpsertResult:
+    """Replace/insert a single struct member covering `offset` (or a bare hole)."""
+    result: StructFieldUpsertResult = {}
+
+    off_bytes = _parse_offset(field.get("offset"))
+    result["offset"] = hex(off_bytes)
+
+    name = str(field.get("name", "") or "").strip()
+    if not name:
+        return {**result, "error": "Member `name` is required"}
+    result["name"] = name
+
+    new_tif = _build_member_tinfo(field)
+    new_size = new_tif.get_size()
+    if new_size in (0, ida_typeinf.BADSIZE):
+        return {**result, "error": "Could not determine size of the new member type"}
+    result["ty"] = new_tif._print()
+
+    bit_off = off_bytes * 8
+    bit_end = bit_off + new_size * 8
+    old_type = str(field.get("old_type", "") or "").strip()
+
+    idx, udm = tif.get_udm_by_offset(bit_off)
+
+    # Case 1: bare hole. Real fixed-struct gaps usually have no covering member
+    # at all (explicit `gapNN` members only appear after UI struct-editor edits),
+    # so get_udm_by_offset returns nothing. Insert straight into the hole.
+    if idx < 0 or udm is None:
+        result["old"] = f"hole at {hex(off_bytes)}"
+        overlap = _find_member_overlap(tif, bit_off, bit_end)
+        if overlap is not None:
+            return {
+                **result,
+                "error": (
+                    f"New member [{hex(off_bytes)}, {hex(off_bytes + new_size)}) overlaps "
+                    f"existing member {overlap.name!r} at {hex(overlap.offset // 8)}"
+                ),
+            }
+        if old_type and not old_type.lower().startswith("gap"):
+            return {
+                **result,
+                "error": (
+                    f"`old_type` {old_type!r} provided but offset {hex(off_bytes)} is an "
+                    "empty hole (no covering member)"
+                ),
+            }
+        if dry_run:
+            return {**result, "created": True}
+        code = tif.add_udm(name, new_tif, bit_off)
+        if code != ida_typeinf.TERR_OK:
+            return {**result, "error": f"add_udm failed (code {code})"}
+        return {**result, "created": True}
+
+    # Case 2/3: a member covers `offset`.
+    m_begin = udm.offset
+    m_end = m_begin + udm.size
+    real_is_gap = udm.is_gap()
+    cur_name = udm.name
+    cur_type_str = udm.type._print()
+    # `gapNN` placeholders (from the UI struct editor) are fillable like gaps.
+    gap_like = real_is_gap or cur_name.startswith("gap")
+    result["old"] = (
+        f"gap {cur_name or '(anon)'} ({udm.size // 8} bytes) at {hex(m_begin // 8)}"
+        if gap_like
+        else f"{cur_type_str} {cur_name} at {hex(m_begin // 8)}"
+    )
+
+    # The new member must fit entirely inside the covering member so we never
+    # spill into (and clobber) an adjacent field.
+    if bit_off < m_begin or bit_end > m_end:
+        return {
+            **result,
+            "error": (
+                f"New member [{hex(off_bytes)}, {hex(off_bytes + new_size)}) does not fit "
+                f"within covering member [{hex(m_begin // 8)}, {hex(m_end // 8)})"
+            ),
+        }
+
+    if not gap_like:
+        if not old_type:
+            return {
+                **result,
+                "error": (
+                    f"`old_type` is required to replace named member {cur_name!r} "
+                    f"(type {cur_type_str!r})"
+                ),
+            }
+        if old_type not in (cur_name, cur_type_str, str(udm.type)):
+            return {
+                **result,
+                "error": (
+                    f"`old_type` {old_type!r} does not match member {cur_name!r} of "
+                    f"type {cur_type_str!r} at {hex(off_bytes)}"
+                ),
+            }
+    elif old_type and old_type not in (cur_name, cur_type_str, str(udm.type)) and not old_type.lower().startswith("gap"):
+        return {
+            **result,
+            "error": f"`old_type` {old_type!r} provided but offset {hex(off_bytes)} is a gap",
+        }
+
+    # Idempotent: identical named member already present.
+    if (
+        not gap_like
+        and cur_name == name
+        and bit_off == m_begin
+        and udm.size == new_size * 8
+        and cur_type_str == result["ty"]
+    ):
+        return {**result, "skipped": True}
+
+    outcome_key = "created" if gap_like else "replaced"
+    if dry_run:
+        return {**result, outcome_key: True}
+
+    # In-place retype+rename when a named member exactly matches the span.
+    if not gap_like and bit_off == m_begin and udm.size == new_size * 8:
+        code = tif.set_udm_type(idx, new_tif)
+        if code != ida_typeinf.TERR_OK:
+            return {**result, "error": f"set_udm_type failed (code {code})"}
+        code = tif.rename_udm(idx, name)
+        if code != ida_typeinf.TERR_OK:
+            return {**result, "error": f"rename_udm failed (code {code})"}
+        return {**result, outcome_key: True}
+
+    # Otherwise carve the covering member to a hole (struct members are
+    # offset-addressed, so deleting one never shifts the others) and add. A real
+    # `gapNN` member must be deleted first; a synthetic gap is already empty.
+    if not real_is_gap:
+        code = tif.del_udm(idx)
+        if code != ida_typeinf.TERR_OK:
+            return {**result, "error": f"del_udm failed (code {code})"}
+    code = tif.add_udm(name, new_tif, bit_off)
+    if code != ida_typeinf.TERR_OK:
+        return {**result, "error": f"add_udm failed (code {code})"}
+    return {**result, outcome_key: True}
+
+
+@tool
+@idasync
+def struct_member_upsert(
+    queries: Annotated[
+        list[StructMemberUpsert] | StructMemberUpsert,
+        "Replace gap/placeholder or named struct members by offset without shifting layout",
+    ],
+) -> list[StructMemberUpsertResult]:
+    """Upsert struct members by offset (gap-fill, retype, rename) idempotently."""
+    queries = normalize_dict_list(queries)
+    results: list[StructMemberUpsertResult] = []
+
+    for query in queries:
+        struct_name = str(query.get("struct", "") or query.get("name", "") or "").strip()
+        members = normalize_dict_list(query.get("members"))
+        dry_run = bool(query.get("dry_run", False))
+
+        if not struct_name:
+            results.append({"struct": struct_name, "error": "Struct name is required"})
+            continue
+        if not members or members == [{}]:
+            results.append(
+                {"struct": struct_name, "error": "At least one member is required"}
+            )
+            continue
+
+        try:
+            tif = ida_typeinf.tinfo_t()
+            if not tif.get_named_type(None, struct_name) or not tif.is_udt():
+                results.append(
+                    {"struct": struct_name, "error": f"Struct not found: {struct_name}"}
+                )
+                continue
+
+            udt = ida_typeinf.udt_type_data_t()
+            if tif.get_udt_details(udt) and udt.is_union:
+                results.append(
+                    {
+                        "struct": struct_name,
+                        "error": "Unions are not supported (member offsets overlap)",
+                    }
+                )
+                continue
+
+            member_results: list[StructFieldUpsertResult] = []
+            created = replaced = skipped = conflicts = 0
+            for field in members:
+                try:
+                    res = _upsert_struct_member(tif, field, dry_run)
+                except Exception as exc:
+                    res = {
+                        "offset": str(field.get("offset", "")),
+                        "name": str(field.get("name", "")),
+                        "error": str(exc),
+                    }
+                if res.get("error"):
+                    conflicts += 1
+                elif res.get("skipped"):
+                    skipped += 1
+                elif res.get("created"):
+                    created += 1
+                elif res.get("replaced"):
+                    replaced += 1
+                member_results.append(res)
+
+            result_dict: StructMemberUpsertResult = {
+                "struct": struct_name,
+                "dry_run": dry_run,
+                "members": member_results,
+                "summary": {
+                    "created": created,
+                    "replaced": replaced,
+                    "skipped": skipped,
+                    "conflicts": conflicts,
+                },
+            }
+            if conflicts > 0:
+                result_dict["error"] = f"{conflicts} member conflict(s)"
+            results.append(result_dict)
+        except Exception as exc:
+            results.append({"struct": struct_name, "error": str(exc)})
 
     return results
 

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_types.py
@@ -23,6 +23,7 @@ from ..api_types import (
     set_type,
     type_apply_batch,
     infer_types,
+    struct_member_upsert,
 )
 
 
@@ -630,3 +631,222 @@ def test_infer_types_invalid_text_address_errors_cleanly():
     result = infer_types("InvalidAddressName123")
     assert_is_list(result, min_length=1)
     assert_error(result[0], contains="Not found")
+
+
+# ---------------------------------------------------------------------------
+# struct_member_upsert
+#
+# Binary-agnostic: every test builds its own deterministic scratch struct with
+# declare_type and removes it in a finally, so nothing leaks into the IDB.
+# ---------------------------------------------------------------------------
+
+
+def _delete_type(name: str) -> None:
+    """Best-effort removal of a local type so tests stay self-cleaning."""
+    import ida_typeinf
+
+    try:
+        ida_typeinf.del_named_type(None, name, ida_typeinf.NTF_TYPE)
+    except Exception:
+        pass
+
+
+def _reset_struct(name: str, body: str) -> None:
+    """(Re)declare a scratch struct from a fresh slate; skip if it won't parse."""
+    _delete_type(name)
+    result = declare_type(f"struct {name} {{ {body} }};")
+    if result and result[0].get("error"):
+        skip_test(f"failed to declare {name}: {result[0]['error']}")
+
+
+def _members_by_name(struct_name: str) -> dict:
+    info = type_inspect({"name": struct_name, "include_members": True})[0]
+    assert info.get("exists") is True
+    return info, {m["name"]: m for m in (info.get("members") or [])}
+
+
+@test()
+def test_struct_member_upsert_fills_bare_hole():
+    """A bare hole (no covering member) is a valid insert target, without shifting neighbors."""
+    name = "__TestUpsertHole__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; unsigned __int64 b; unsigned __int64 c;")
+
+        # Shrink b (u64 @ 0x8) -> u32, leaving a 4-byte bare hole at 0xC.
+        shrink = struct_member_upsert(
+            {
+                "struct": name,
+                "members": [
+                    {"offset": "0x8", "name": "b_lo", "old_type": "unsigned __int64", "size": 4}
+                ],
+            }
+        )
+        assert_is_list(shrink, min_length=1)
+        assert "error" not in shrink[0]
+        assert shrink[0]["summary"]["replaced"] == 1
+
+        # Fill the bare hole at 0xC (get_udm_by_offset returns nothing here).
+        fill = struct_member_upsert(
+            {"struct": name, "members": [{"offset": "0xC", "name": "b_hi", "size": 4}]}
+        )
+        assert_is_list(fill, min_length=1)
+        assert "error" not in fill[0]
+        assert fill[0]["summary"]["created"] == 1
+        assert fill[0]["members"][0].get("created") is True
+
+        info, members = _members_by_name(name)
+        assert members["b_lo"]["offset"] == "0x8" and members["b_lo"]["size"] == 4
+        assert members["b_hi"]["offset"] == "0xc" and members["b_hi"]["size"] == 4
+        # Neighbor unshifted, overall size preserved.
+        assert members["c"]["offset"] == "0x10"
+        assert info["size"] == 24
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_fills_gap_member_without_old_type():
+    """A `gapNN` placeholder member is fillable with old_type omitted."""
+    name = "__TestUpsertGap__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; _BYTE gap8[8]; unsigned __int64 c;")
+        res = struct_member_upsert(
+            {"struct": name, "members": [{"offset": "0x8", "name": "g_lo", "size": 4}]}
+        )
+        assert_is_list(res, min_length=1)
+        assert "error" not in res[0]
+        assert res[0]["summary"]["created"] == 1
+        assert res[0]["members"][0].get("created") is True
+
+        _info, members = _members_by_name(name)
+        assert members["g_lo"]["offset"] == "0x8" and members["g_lo"]["size"] == 4
+        assert members["c"]["offset"] == "0x10"
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_retypes_named_member_in_place():
+    """Same-size retype+rename of a named member keeps its offset (uses the C-decl `type` path)."""
+    name = "__TestUpsertRetype__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; unsigned __int64 b; unsigned __int64 c;")
+        res = struct_member_upsert(
+            {
+                "struct": name,
+                "members": [
+                    {"offset": "0x8", "name": "b_ptr", "old_type": "unsigned __int64", "type": "void *"}
+                ],
+            }
+        )
+        assert_is_list(res, min_length=1)
+        assert "error" not in res[0]
+        assert res[0]["summary"]["replaced"] == 1
+
+        _info, members = _members_by_name(name)
+        assert "b_ptr" in members and members["b_ptr"]["offset"] == "0x8"
+        assert members["c"]["offset"] == "0x10"
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_is_idempotent():
+    """Re-applying an identical member is reported as skipped."""
+    name = "__TestUpsertIdem__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; unsigned __int64 b;")
+        edit = {"offset": "0x8", "name": "b_ai", "old_type": "unsigned __int64", "size": 8}
+
+        first = struct_member_upsert({"struct": name, "members": [dict(edit)]})
+        assert_is_list(first, min_length=1)
+        assert first[0]["summary"]["replaced"] == 1
+
+        second = struct_member_upsert({"struct": name, "members": [dict(edit)]})
+        assert_is_list(second, min_length=1)
+        assert "error" not in second[0]
+        assert second[0]["summary"]["skipped"] == 1
+        assert second[0]["members"][0].get("skipped") is True
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_guards_named_members():
+    """Missing or mismatched old_type on a named member is a conflict, not a clobber."""
+    name = "__TestUpsertGuard__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; unsigned __int64 b; unsigned __int64 c;")
+        res = struct_member_upsert(
+            {
+                "struct": name,
+                "members": [
+                    {"offset": "0x10", "name": "c_wrong", "old_type": "uint32_t", "size": 8},
+                    {"offset": "0x10", "name": "c_missing", "size": 8},
+                ],
+            }
+        )
+        assert_is_list(res, min_length=1)
+        assert res[0]["summary"]["conflicts"] == 2
+        assert "error" in res[0]
+        errors = " ".join((m.get("error") or "") for m in res[0]["members"]).lower()
+        assert "old_type" in errors
+
+        # The named member must be untouched by the rejected edits.
+        _info, members = _members_by_name(name)
+        assert "c" in members and members["c"]["offset"] == "0x10"
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_rejects_overflow():
+    """A member that would spill past its covering member is rejected."""
+    name = "__TestUpsertOverflow__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; _BYTE gap8[8]; unsigned __int64 c;")
+        # gap8 spans [0x8, 0x10); an 8-byte member at 0xC would run to 0x14.
+        res = struct_member_upsert(
+            {"struct": name, "members": [{"offset": "0xC", "name": "toobig", "size": 8}]}
+        )
+        assert_is_list(res, min_length=1)
+        assert res[0]["summary"]["conflicts"] == 1
+        assert_error(res[0]["members"][0], contains="fit")
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_dry_run_does_not_mutate():
+    """dry_run validates (reports would-be outcome) without changing the struct."""
+    name = "__TestUpsertDryRun__"
+    try:
+        _reset_struct(name, "unsigned __int64 a; _BYTE gap8[8]; unsigned __int64 c;")
+        before, _ = _members_by_name(name)
+
+        res = struct_member_upsert(
+            {
+                "struct": name,
+                "dry_run": True,
+                "members": [{"offset": "0x8", "name": "g_lo", "size": 4}],
+            }
+        )
+        assert_is_list(res, min_length=1)
+        assert res[0]["dry_run"] is True
+        assert res[0]["summary"]["created"] == 1
+
+        after, _ = _members_by_name(name)
+        assert before["members"] == after["members"]
+        assert before["size"] == after["size"]
+    finally:
+        _delete_type(name)
+
+
+@test()
+def test_struct_member_upsert_struct_not_found():
+    """struct_member_upsert reports a missing-struct error."""
+    res = struct_member_upsert(
+        {"struct": "__NoSuchStruct12345__", "members": [{"offset": 0, "name": "x", "size": 4}]}
+    )
+    assert_is_list(res, min_length=1)
+    assert_error(res[0], contains="not found")

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -382,6 +382,43 @@ class TypeApplyBatch(TypedDict):
     stop_on_error: NotRequired[Annotated[bool, "Stop on first failure"]]
 
 
+class StructFieldUpsert(TypedDict):
+    """Single struct member replace/insert operation.
+
+    Targets the member currently covering `offset` (a gap or a named field) and
+    replaces it with a new member. Provide exactly one of `size` or `type`.
+    """
+
+    offset: Annotated[str | int, "Byte offset of the member within the struct (hex or int)"]
+    name: Annotated[str, "New member name"]
+    old_type: NotRequired[
+        Annotated[
+            str,
+            "Type or member name that must currently cover the offset. Required when "
+            "the target is a named member (guards against clobbering); optional when "
+            "the target is a gap.",
+        ]
+    ]
+    size: NotRequired[
+        Annotated[int, "Integer member size: 1/2/4/8 -> uint8/16/32/64 (use size OR type)"]
+    ]
+    type: NotRequired[
+        Annotated[str, "C type name or declaration for the new member (use size OR type)"]
+    ]
+
+
+class StructMemberUpsert(TypedDict):
+    """Upsert struct members by offset without shifting existing fields."""
+
+    struct: Annotated[str, "Struct type name"]
+    members: Annotated[
+        list[StructFieldUpsert] | StructFieldUpsert, "Members to upsert"
+    ]
+    dry_run: NotRequired[
+        Annotated[bool, "Validate only (check offsets/old_type/new type); no changes"]
+    ]
+
+
 class StackVarDecl(TypedDict):
     """Stack variable declaration"""
 


### PR DESCRIPTION
Replaces a gap, `gapNN` placeholder, or named member at a given offset with a sized (1/2/4/8) or C-typed member, without shifting the rest of the layout. Batch input, dry_run, and idempotent summary mirror enum_upsert; `old_type` guards against clobbering named members.

Adds StructFieldUpsert/StructMemberUpsert input types and 8 tests.