### PR TITLE
Support the debugger extension headless (idalib) and over stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,27 @@ Worker controls:
 
 ## Debugger Operations (Extension)
 
-Debugger tools are hidden by default. Enable with `?ext=dbg` query parameter:
+Debugger tools are hidden by default (they are also `unsafe`). Enable them per transport:
 
-```
-http://127.0.0.1:13337/mcp?ext=dbg
-```
+- **HTTP** — add the `?ext=dbg` query parameter (and start the server with `--unsafe`):
+  ```
+  http://127.0.0.1:13337/mcp?ext=dbg
+  ```
+- **stdio** — pass `--unsafe --ext dbg` (stdio has no URL to carry `?ext=`):
+  ```
+  uv run idalib-mcp --stdio --unsafe --ext dbg
+  ```
+  `--ext` also reads the `IDA_MCP_EXT` environment variable.
+
+### Headless debugging (idalib)
+
+The debugger works fully headless via `idalib-mcp` — no IDA GUI required. `dbg_start()`
+selects the platform debugger and launches the database's own input file, blocking until
+it suspends at the entry breakpoint; `dbg_continue` / `dbg_step_*` / `dbg_run_to` likewise
+block until the debuggee next suspends (breakpoint or exit), since idalib has no UI event
+loop to drive it. Pass command-line arguments to the debuggee via the `IDA_MCP_DBG_ARGS`
+environment variable. (Attaching to an already-running process is not supported headless;
+`dbg_start` launches the input file.)
 
 **Control:**
 - `dbg_start()`: Start debugger process.

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -9,6 +9,7 @@ This module provides comprehensive debugging functionality including:
 """
 
 import os
+import sys
 from typing import Annotated, NotRequired, TypedDict
 
 import idc
@@ -18,6 +19,7 @@ import ida_idd
 import ida_idaapi
 import ida_kernwin
 import ida_name
+import ida_nalt
 import idaapi
 
 from .rpc import tool, unsafe, ext
@@ -140,6 +142,28 @@ def _get_debug_state_result() -> DebugControlResult:
         if ip is not None:
             result["ip"] = hex(ip)
     return result
+
+
+def _running_headless() -> bool:
+    """True when running under idalib (no IDA GUI): ``is_idaq()`` is False there."""
+    try:
+        return not ida_kernwin.is_idaq()
+    except Exception:
+        return True
+
+
+def _wait_headless_suspend(timeout_ms: int = 15000) -> None:
+    """Pump debug events until the debuggee suspends (breakpoint / exit).
+
+    idalib has no UI event loop, so after start/step/continue nothing advances the
+    debugger state on its own and registers stay unreadable. Block on WFNE_SUSP so
+    the caller sees a suspended process. No-op in the GUI, where the UI drives it.
+    """
+    if _running_headless():
+        try:
+            ida_dbg.wait_for_next_event(ida_dbg.WFNE_SUSP, timeout_ms)
+        except Exception:
+            pass
 
 
 def dbg_ensure_active() -> "ida_idd.debugger_t":
@@ -408,7 +432,23 @@ def dbg_start() -> DebugControlResult:
     # not yet been dispatched). Trust the actual debugger state instead,
     # and only consult the return code as a tiebreaker for the error
     # message when nothing ever comes up.
-    start_result = idaapi.start_process("", "", "")
+    # In the GUI the user selects a debugger + target via the Debugger menu; headless
+    # (idalib) there is no such UI, so pick the platform debugger and launch this
+    # database's own input file. Optional launch args via env IDA_MCP_DBG_ARGS. Then
+    # block until the process suspends at the entry breakpoint added above.
+    if _running_headless():
+        _dbg = "win32" if sys.platform == "win32" else ("mac" if sys.platform == "darwin" else "linux")
+        try:
+            ida_dbg.load_debugger(_dbg, 0)
+        except Exception:
+            pass
+        _path = ida_nalt.get_input_file_path() or ""
+        start_result = idaapi.start_process(
+            _path, os.environ.get("IDA_MCP_DBG_ARGS", ""), os.path.dirname(_path)
+        )
+        _wait_headless_suspend()
+    else:
+        start_result = idaapi.start_process("", "", "")
 
     started = _get_debug_start_result()
     if started is not None:
@@ -479,6 +519,7 @@ def dbg_continue() -> DebugControlResult:
     """Resume execution in active debugger session."""
     dbg_ensure_suspended()
     if idaapi.continue_process():
+        _wait_headless_suspend()
         result = _get_debug_state_result()
         result["continued"] = True
         return result
@@ -496,6 +537,7 @@ def dbg_run_to(
     dbg_ensure_suspended()
     ea = parse_address(addr)
     if idaapi.run_to(ea):
+        _wait_headless_suspend()
         result = _get_debug_state_result()
         result["continued"] = True
         return result
@@ -510,6 +552,7 @@ def dbg_step_into() -> DebugControlResult:
     """Execute one instruction, stepping into calls."""
     dbg_ensure_suspended()
     if idaapi.step_into():
+        _wait_headless_suspend()
         result = _get_debug_state_result()
         result["continued"] = True
         return result
@@ -524,6 +567,7 @@ def dbg_step_over() -> DebugControlResult:
     """Execute one instruction, stepping over calls."""
     dbg_ensure_suspended()
     if idaapi.step_over():
+        _wait_headless_suspend()
         result = _get_debug_state_result()
         result["continued"] = True
         return result

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -1194,6 +1194,15 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=8745, help="HTTP port, default: 8745")
     parser.add_argument("--unsafe", action="store_true", help="Enable unsafe worker tools (DANGEROUS)")
     parser.add_argument(
+        "--ext",
+        type=str,
+        default=os.environ.get("IDA_MCP_EXT", ""),
+        metavar="GROUPS",
+        help="Comma-separated extension groups to enable over stdio (e.g. 'dbg'). "
+        "HTTP transports enable these via the ?ext= query param; stdio has no URL, "
+        "so use this flag. Gated tools may also require --unsafe.",
+    )
+    parser.add_argument(
         "--profile",
         type=Path,
         default=None,
@@ -1244,6 +1253,11 @@ def main() -> None:
 
     try:
         if args.stdio:
+            if args.ext:
+                # stdio has no ?ext= query param, so enable the requested extension
+                # groups here for the (single-threaded) stdio dispatch loop. The
+                # supervisor forwards them to workers via the ?ext= URL it builds.
+                mcp._enabled_extensions.data = {g.strip() for g in args.ext.split(",") if g.strip()}
             mcp.stdio()
         else:
             mcp.serve(host=args.host, port=args.port, background=False)


### PR DESCRIPTION
## Summary

The `dbg_*` debugger tools previously only worked in the IDA GUI. This makes the debugger extension usable **headless via `idalib-mcp`** (no GUI), including over the **stdio** transport.

Three fixes:

1. **`dbg_start` headless** — it called `start_process("", "", "")`, relying on the user having selected a debugger and configured the target through the Debugger menu. Headless there is no such UI, so it failed with *"verify that a debugger is selected…"*. It now, when running headless (`is_idaq()` is `False`), selects the platform debugger (`win32`/`mac`/`linux`) and launches the database's own input file. Optional launch args via the `IDA_MCP_DBG_ARGS` env var.

2. **Blocking until suspend** — idalib has no UI event loop, so `dbg_start` / `dbg_continue` / `dbg_step_*` / `dbg_run_to` returned before the debuggee actually suspended, leaving process state and registers unreadable. They now block on `WFNE_SUSP` (headless only) until the process suspends at a breakpoint or exits.

3. **Enabling the `dbg` extension over stdio** — the extension could only be turned on over HTTP via `?ext=dbg`; stdio has no URL. Added a `--ext GROUPS` flag (and `IDA_MCP_EXT` env var) to `idalib-mcp`. The supervisor forwards the enabled extensions to workers as before.

GUI behaviour is unchanged — every headless path is guarded by `is_idaq()`.

## Usage

```
idalib-mcp --stdio --unsafe --ext dbg
```

## Testing

Verified end-to-end over stdio against a headless idalib worker (Windows, IDA 9.1, Python 3.14) driving `ping.exe`:

- `dbg_start` → launches the EXE and suspends at the entry breakpoint (`ip` returned)
- `dbg_add_bp` + `dbg_continue` → stops at the breakpoint
- `dbg_regs` → live registers for the running thread
- `dbg_stacktrace` → resolved frames (`module!symbol`)
- `dbg_step_into` / `dbg_step_over` → RIP advances correctly
- `dbg_exit` → terminates the debuggee

## Notes / limitations

- Headless `dbg_start` *launches* the input file; attaching to an already-running process is out of scope for this PR.
- The blocking waits are capped (15s) so a `continue` into a target that never breaks returns rather than hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
