### PR TITLE
Fix stale strings cache when switching binaries in idalib worker

### DIFF
--- a/src/ida_pro_mcp/idalib_session_manager.py
+++ b/src/ida_pro_mcp/idalib_session_manager.py
@@ -16,6 +16,8 @@ from datetime import datetime
 import idapro
 import ida_auto
 
+from .ida_mcp.api_core import invalidate_strings_cache
+
 logger = logging.getLogger(__name__)
 
 
@@ -115,8 +117,7 @@ class IDASessionManager:
             logger.info(f"Closing session: {session_id} ({session.input_path.name})")
 
             if self._active_session_id == session_id:
-                idapro.close_database()
-                self._active_session_id = None
+                self._close_active_database()
 
             del self._sessions[session_id]
             logger.info(f"Session closed: {session_id}")
@@ -153,9 +154,7 @@ class IDASessionManager:
         with self._lock:
             logger.info(f"Closing all {len(self._sessions)} sessions")
 
-            if self._active_session_id is not None:
-                idapro.close_database()
-                self._active_session_id = None
+            self._close_active_database()
 
             self._sessions.clear()
             logger.info("All sessions closed")
@@ -171,13 +170,20 @@ class IDASessionManager:
         logger.info("Activated session %s (%s)", session_id, session.input_path.name)
 
     def _activate_database_path(self, input_path: str, run_auto_analysis: bool) -> None:
-        if self._active_session_id is not None:
-            logger.debug("Closing active database before opening %s", input_path)
-            idapro.close_database()
-            self._active_session_id = None
+        self._close_active_database()
 
         if idapro.open_database(input_path, run_auto_analysis=run_auto_analysis):
             raise RuntimeError(f"Failed to open database: {input_path}")
+
+    def _close_active_database(self) -> None:
+        if self._active_session_id is not None:
+            logger.debug("Closing active database (session: %s)", self._active_session_id)
+            idapro.close_database()
+            self._active_session_id = None
+
+        # The strings cache is process-global, so drop it on every DB change or
+        # the next binary would serve the previous one's strings.
+        invalidate_strings_cache()
 
 
 _session_manager: Optional[IDASessionManager] = None

--- a/tests/test_idalib_session_manager.py
+++ b/tests/test_idalib_session_manager.py
@@ -1,0 +1,146 @@
+"""Tests for IDASessionManager, run without IDA by stubbing idapro/ida_auto.
+
+Regression coverage for #476: the process-global strings cache must be dropped
+whenever the active database is torn down or replaced, otherwise a switched-to
+binary serves the previous one's strings.
+"""
+
+import sys
+import types
+import importlib
+
+import pytest
+
+
+class _FakeIdapro(types.ModuleType):
+    """Records open/close_database calls in order."""
+
+    def __init__(self):
+        super().__init__("idapro")
+        self.events: list[tuple] = []
+
+    def open_database(self, path, run_auto_analysis=False):
+        self.events.append(("open", path))
+        return 0  # 0 == success; the manager treats a truthy return as failure
+
+    def close_database(self, *args, **kwargs):
+        self.events.append(("close",))
+
+
+class _FakeIdaAuto(types.ModuleType):
+    def __init__(self):
+        super().__init__("ida_auto")
+
+    def auto_wait(self):
+        return True
+
+
+class _CacheSpy:
+    def __init__(self):
+        self.invalidations = 0
+
+    def invalidate_strings_cache(self):
+        self.invalidations += 1
+
+
+@pytest.fixture
+def session_env(monkeypatch):
+    """Import a fresh IDASessionManager wired to fake IDA dependencies."""
+    fake_idapro = _FakeIdapro()
+    fake_ida_auto = _FakeIdaAuto()
+    spy = _CacheSpy()
+
+    fake_api_core = types.ModuleType("ida_pro_mcp.ida_mcp.api_core")
+    fake_api_core.invalidate_strings_cache = spy.invalidate_strings_cache
+    fake_ida_mcp = types.ModuleType("ida_pro_mcp.ida_mcp")
+    fake_ida_mcp.api_core = fake_api_core
+
+    monkeypatch.setitem(sys.modules, "idapro", fake_idapro)
+    monkeypatch.setitem(sys.modules, "ida_auto", fake_ida_auto)
+    monkeypatch.setitem(sys.modules, "ida_pro_mcp.ida_mcp", fake_ida_mcp)
+    monkeypatch.setitem(sys.modules, "ida_pro_mcp.ida_mcp.api_core", fake_api_core)
+    # Re-import against the stubs, not any real copy left by another test.
+    monkeypatch.delitem(sys.modules, "ida_pro_mcp.idalib_session_manager", raising=False)
+
+    module = importlib.import_module("ida_pro_mcp.idalib_session_manager")
+    manager = module.IDASessionManager()
+
+    yield types.SimpleNamespace(manager=manager, idapro=fake_idapro, spy=spy)
+
+    sys.modules.pop("ida_pro_mcp.idalib_session_manager", None)
+
+
+def _make_binary(tmp_path, name):
+    path = tmp_path / name
+    path.write_bytes(b"\x7fELF" + name.encode())
+    return path
+
+
+def test_switching_binaries_invalidates_strings_cache(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    b = _make_binary(tmp_path, "b.bin")
+
+    session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.spy.invalidations = 0
+    session_env.idapro.events.clear()
+
+    session_env.manager.open_binary(b, run_auto_analysis=False)
+
+    assert session_env.spy.invalidations >= 1, "cache not invalidated on binary switch"
+    # The previous database is closed before the new one is opened.
+    assert session_env.idapro.events == [("close",), ("open", str(b))]
+
+
+def test_activate_session_invalidates_strings_cache(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    b = _make_binary(tmp_path, "b.bin")
+
+    sid_a = session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.manager.open_binary(b, run_auto_analysis=False)  # b is now active
+    session_env.spy.invalidations = 0
+
+    session_env.manager.activate_session(sid_a)
+
+    assert session_env.spy.invalidations >= 1, "cache not invalidated on re-activation"
+
+
+def test_reactivating_already_active_session_does_not_invalidate(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    sid_a = session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.spy.invalidations = 0
+
+    session_env.manager.activate_session(sid_a)  # already active: no DB change
+
+    assert session_env.spy.invalidations == 0
+
+
+def test_closing_active_session_invalidates_strings_cache(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    sid_a = session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.spy.invalidations = 0
+
+    session_env.manager.close_session(sid_a)
+
+    assert session_env.spy.invalidations >= 1, "cache not invalidated when active DB closed"
+
+
+def test_closing_inactive_session_preserves_active_cache(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    b = _make_binary(tmp_path, "b.bin")
+    sid_a = session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.manager.open_binary(b, run_auto_analysis=False)  # b is now active
+    session_env.spy.invalidations = 0
+
+    session_env.manager.close_session(sid_a)  # a is not active; b stays loaded
+
+    assert session_env.spy.invalidations == 0, "must not clear cache for the still-active DB"
+
+
+def test_close_all_sessions_invalidates_strings_cache(session_env, tmp_path):
+    a = _make_binary(tmp_path, "a.bin")
+    session_env.manager.open_binary(a, run_auto_analysis=False)
+    session_env.spy.invalidations = 0
+
+    session_env.manager.close_all_sessions()
+
+    assert session_env.spy.invalidations >= 1


### PR DESCRIPTION
Fixes #476

`_strings_cache` in `api_core.py` is process-global and was built once, then never refreshed. After the idalib worker switched databases, strings queries kept returning the previous binary's strings.

Added a `_close_active_database()` helper in `IDASessionManager` that drops the cache on every DB teardown/switch (`open_binary`, `activate_session`, `close_session`, `close_all_sessions`). Closing an inactive session leaves the active binary's cache intact.

**Why not the per-session dict:** `api_core` is session-agnostic. Its tools run against whatever DB idalib currently has open and never receive a `session_id`. Keying the cache by session would force `api_core` to ask the session manager
which session is active, inverting the dependency. Invalidating on switch keeps the coupling one-way (manager -> api_core).
The only cost is a lazy rebuild on switch-back, cheap next to the reopen + auto-analysis a switch already does.