### PR TITLE
feat(installer): add Kimi Code plugin

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "ida-pro-mcp",
+  "version": "0.1.0",
+  "description": "AI-powered reverse engineering assistant that bridges IDA Pro with language models through MCP.",
+  "author": {
+    "name": "mrexodia",
+    "url": "https://github.com/mrexodia/ida-pro-mcp"
+  },
+  "homepage": "https://github.com/mrexodia/ida-pro-mcp",
+  "license": "MIT",
+  "keywords": [
+    "ida",
+    "ida-pro",
+    "reverse-engineering",
+    "mcp"
+  ],
+  "interface": {
+    "displayName": "IDA Pro MCP",
+    "shortDescription": "AI-powered reverse engineering assistant that bridges IDA Pro with language models through MCP.",
+    "longDescription": "AI-powered reverse engineering assistant that bridges IDA Pro with language models through MCP.",
+    "developerName": "mrexodia",
+    "websiteURL": "https://github.com/mrexodia/ida-pro-mcp"
+  },
+  "skills": "./skills/",
+  "mcpServers": {
+    "idalib": {
+      "command": "uv",
+      "args": [
+        "run",
+        "idalib-mcp",
+        "--stdio"
+      ],
+      "cwd": "./"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ codex plugin remove ida-pro-mcp@mrexodia
 codex plugin add ida-pro-mcp@mrexodia
 ```
 
+## Installation (Kimi Code)
+
+To install the latest IDA Pro MCP in Kimi Code, run this slash command in the chat:
+
+```
+/plugins install https://github.com/mrexodia/ida-pro-mcp
+/reload
+```
+
+This installs the `idalib` MCP server and the `idapython` skill. Plugins are copied to
+`$KIMI_CODE_HOME/plugins/managed/`, so `uv` must be on your `PATH`. The first session after
+installing is slower, because `uv` resolves the dependencies before the server responds.
+
 ## Installation (GUI)
 
 **Note**: the MCP plugin is no longer recommended and will eventually be deprecated. Use `idalib-mcp` instead.

--- a/src/ida_pro_mcp/installer_data.py
+++ b/src/ida_pro_mcp/installer_data.py
@@ -28,6 +28,8 @@ CLIENT_ALIASES: dict[str, str] = {
     "antigravity": "Antigravity IDE",
     "boltai": "BoltAI",
     "bolt": "BoltAI",
+    "kimi": "Kimi Code",
+    "kimi-code": "Kimi Code",
 }
 
 # Project-level config definitions: name -> (subdirectory, config_file)
@@ -39,6 +41,7 @@ PROJECT_LEVEL_CONFIGS: dict[str, tuple[str, str]] = {
     "VS Code Insiders": (".vscode", "mcp.json"),
     "Windsurf": (".windsurf", "mcp.json"),
     "Zed": (".zed", "settings.json"),
+    "Kimi Code": (".kimi-code", "mcp.json"),
 }
 
 # Special JSON structures for project-level configs
@@ -55,6 +58,13 @@ GLOBAL_SPECIAL_JSON_STRUCTURES: dict[str, tuple[str | None, str]] = {
     "Visual Studio 2022": (None, "servers"),
     "Opencode": (None, "mcp"),
 }
+
+
+def kimi_code_home() -> str:
+    # Kimi Code resolves its data root from KIMI_CODE_HOME, falling back to ~/.kimi-code
+    return os.getenv("KIMI_CODE_HOME") or os.path.join(
+        os.path.expanduser("~"), ".kimi-code"
+    )
 
 
 def get_global_configs() -> dict[str, tuple[str, str]]:
@@ -108,6 +118,7 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp.json",
             ),
             "Codex": (os.path.join(os.path.expanduser("~"), ".codex"), "config.toml"),
+            "Kimi Code": (kimi_code_home(), "mcp.json"),
             "Zed": (
                 os.path.join(os.getenv("APPDATA", ""), "Zed"),
                 "settings.json",
@@ -243,6 +254,7 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp.json",
             ),
             "Codex": (os.path.join(os.path.expanduser("~"), ".codex"), "config.toml"),
+            "Kimi Code": (kimi_code_home(), "mcp.json"),
             "Antigravity IDE": (
                 os.path.join(os.path.expanduser("~"), ".gemini", "config"),
                 "mcp_config.json",
@@ -397,6 +409,7 @@ def get_global_configs() -> dict[str, tuple[str, str]]:
                 "mcp.json",
             ),
             "Codex": (os.path.join(os.path.expanduser("~"), ".codex"), "config.toml"),
+            "Kimi Code": (kimi_code_home(), "mcp.json"),
             "Antigravity IDE": (
                 os.path.join(os.path.expanduser("~"), ".gemini", "config"),
                 "mcp_config.json",


### PR DESCRIPTION
Kimi Code reads MCP servers from `<KIMI_CODE_HOME>/mcp.json`, falling back
to `~/.kimi-code/mcp.json`, and from `.kimi-code/mcp.json` for project scope.
Both use the standard `{"mcpServers": {...}}` shape, so no special JSON
structure is needed.