### PR TITLE
fix(idalib): forward warmup to GUI sessions, then make HTTP layer threaded so it doesn't starve health checks

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -21,7 +21,7 @@ import ida_typeinf
 import idc
 
 from .rpc import tool
-from .sync import idasync, get_tool_deadline, tool_timeout
+from .sync import busy, idasync, is_busy, get_tool_deadline, tool_timeout
 from .utils import (
     ConvertedNumber,
     EntityQuery,
@@ -45,8 +45,9 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-class ServerHealthResult(TypedDict):
+class ServerHealthResult(TypedDict, total=False):
     status: str
+    busy_reason: str
     uptime_sec: float
     idb_path: str | None
     module: str
@@ -374,15 +375,26 @@ def _build_health_payload() -> dict:
 
 
 @tool
-@idasync
 def server_health() -> ServerHealthResult:
-    """Health/ready probe for MCP server and current IDB state."""
+    """Health/ready probe for MCP server and current IDB state.
+
+    Returns immediately with {"status": "busy", "busy_reason": ...} while a
+    long operation (idb_open / server_warmup: auto-analysis, cache builds,
+    Hex-Rays init) is in progress, instead of queuing behind it on the IDA
+    main thread — that queue won't drain until the long operation yields, so
+    waiting for it defeats the point of a health probe."""
+    busy_reason = is_busy()
+    if busy_reason is not None:
+        return {"status": "busy", "busy_reason": busy_reason}
+    return _server_health_sync()
+
+
+@idasync
+def _server_health_sync() -> ServerHealthResult:
     return _build_health_payload()
 
 
 @tool
-@idasync
-@tool_timeout(600.0)
 def server_warmup(
     wait_auto_analysis: Annotated[bool, "Wait for auto-analysis to finish before returning"] = True,
     build_caches: Annotated[bool, "Build core caches (e.g. strings) now instead of on first use"] = True,
@@ -394,6 +406,19 @@ def server_warmup(
     via mode="prefer_gui"/"force_gui". Safe to call again manually (e.g. after
     invalidating a cache, or on a session opened before this behavior existed)
     - each step is a cheap no-op if already warmed."""
+    # Set the busy flag before submitting to execute_sync (not inside the
+    # @idasync body) so server_health can see "busy" for the entire time
+    # this call is queued on the IDA main thread, not just while it's
+    # actually executing.
+    with busy("server_warmup"):
+        return _server_warmup_sync(wait_auto_analysis, build_caches, init_hexrays)
+
+
+@idasync
+@tool_timeout(600.0)
+def _server_warmup_sync(
+    wait_auto_analysis: bool, build_caches: bool, init_hexrays: bool
+) -> ServerWarmupResult:
     steps = []
 
     if wait_auto_analysis:

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -21,7 +21,7 @@ import ida_typeinf
 import idc
 
 from .rpc import tool
-from .sync import idasync, get_tool_deadline
+from .sync import idasync, get_tool_deadline, tool_timeout
 from .utils import (
     ConvertedNumber,
     EntityQuery,
@@ -382,6 +382,7 @@ def server_health() -> ServerHealthResult:
 
 @tool
 @idasync
+@tool_timeout(600.0)
 def server_warmup(
     wait_auto_analysis: Annotated[bool, "Wait for auto-analysis to finish before returning"] = True,
     build_caches: Annotated[bool, "Build core caches (e.g. strings) now instead of on first use"] = True,

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -380,13 +380,19 @@ def server_health() -> ServerHealthResult:
     return _build_health_payload()
 
 
+@tool
 @idasync
 def server_warmup(
-    wait_auto_analysis: bool = True,
-    build_caches: bool = True,
-    init_hexrays: bool = True,
+    wait_auto_analysis: Annotated[bool, "Wait for auto-analysis to finish before returning"] = True,
+    build_caches: Annotated[bool, "Build core caches (e.g. strings) now instead of on first use"] = True,
+    init_hexrays: Annotated[bool, "Initialize the Hex-Rays decompiler"] = True,
 ) -> ServerWarmupResult:
-    """Warm up IDA subsystems. Called by idb_open; no longer exposed as an MCP tool."""
+    """Warm up IDA subsystems (auto-analysis wait, caches, Hex-Rays).
+
+    idb_open calls this automatically, including for GUI instances it adopts
+    via mode="prefer_gui"/"force_gui". Safe to call again manually (e.g. after
+    invalidating a cache, or on a session opened before this behavior existed)
+    - each step is a cheap no-op if already warmed."""
     steps = []
 
     if wait_auto_analysis:

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -69,6 +69,50 @@ def _get_tool_timeout_seconds() -> float:
         return _DEFAULT_TOOL_TIMEOUT_SEC
 
 
+# Process-wide "long operation in progress" flag. Set around idb_open /
+# server_warmup (auto-analysis, cache builds, Hex-Rays init) so callers like
+# server_health can report "busy" immediately instead of queuing behind
+# execute_sync on the IDA main thread — which won't run until the long
+# operation yields. A plain str under a Lock is enough: writers only flip it
+# at the start/end of a long op, readers just need the current value.
+_busy_lock = threading.Lock()
+_busy_reason: str | None = None
+
+
+def is_busy() -> str | None:
+    """Return the current busy reason, or None if no long operation is running."""
+    with _busy_lock:
+        return _busy_reason
+
+
+class busy:
+    """Context manager marking a process-wide long-running IDA operation.
+
+    Nests safely: only the outermost `with busy(...)` clears the flag on
+    exit, so server_warmup running inside idb_open's `with busy("idb_open")`
+    doesn't prematurely report "not busy" when its own block exits.
+    """
+
+    def __init__(self, reason: str):
+        self._reason = reason
+        self._is_outermost = False
+
+    def __enter__(self):
+        global _busy_reason
+        with _busy_lock:
+            if _busy_reason is None:
+                _busy_reason = self._reason
+                self._is_outermost = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        global _busy_reason
+        if self._is_outermost:
+            with _busy_lock:
+                _busy_reason = None
+        return False
+
+
 call_stack = queue.LifoQueue()
 
 # Thread-local: while a synchronized tool body is running, holds the batch

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -18,6 +18,7 @@ from ida_pro_mcp.ida_mcp.discovery import register_instance, unregister_instance
 from ida_pro_mcp.ida_mcp.http import IdaMcpHttpRequestHandler
 from ida_pro_mcp.ida_mcp.profile import apply_profile, load_profile
 from ida_pro_mcp.ida_mcp.rpc import set_download_base_url, tool
+from ida_pro_mcp.ida_mcp.sync import busy
 from ida_pro_mcp.idalib_session_manager import get_session_manager
 from ida_pro_mcp.worker_lifecycle import WorkerLifecycle
 
@@ -113,19 +114,20 @@ def idb_open(
         manager = get_session_manager()
         resolved_path = Path(input_path).resolve()
         load_started_at = time.monotonic()
-        opened_session_id = manager.open_binary(
-            resolved_path,
-            run_auto_analysis=run_auto_analysis,
-            session_id=preferred_session_id or None,
-        )
-        session = manager.activate_session(opened_session_id)
-        warmup: ServerWarmupResult | None = None
-        if build_caches or init_hexrays:
-            warmup = server_warmup(
-                wait_auto_analysis=False,
-                build_caches=build_caches,
-                init_hexrays=init_hexrays,
+        with busy("idb_open"):
+            opened_session_id = manager.open_binary(
+                resolved_path,
+                run_auto_analysis=run_auto_analysis,
+                session_id=preferred_session_id or None,
             )
+            session = manager.activate_session(opened_session_id)
+            warmup: ServerWarmupResult | None = None
+            if build_caches or init_hexrays:
+                warmup = server_warmup(
+                    wait_auto_analysis=False,
+                    build_caches=build_caches,
+                    init_hexrays=init_hexrays,
+                )
         _LIFECYCLE.set_idle_ttl(float(idle_ttl_sec), time.monotonic() - load_started_at)
         if _REGISTERED_PORT is None and _BOUND_HOST and _BOUND_PORT:
             _register_in_discovery(_BOUND_HOST, _BOUND_PORT, session.input_path)

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -623,7 +623,52 @@ class IdalibSupervisor:
         )
         return worker_stub
 
-    def _launch_gui_and_adopt(self, resolved_path: str, session_id: str) -> WorkerSession:
+    def _warmup_gui_session(
+        self,
+        session: WorkerSession,
+        *,
+        wait_auto_analysis: bool,
+        build_caches: bool,
+        init_hexrays: bool,
+    ) -> None:
+        """Best-effort warmup RPC into a GUI-backed session.
+
+        GUI instances are adopted rather than launched by idb_open, so unlike
+        headless workers they never got build_caches/run_auto_analysis/init_hexrays
+        forwarded to them - callers saw those flags silently do nothing. This
+        can genuinely take a long time on a huge binary (e.g. building the
+        strings cache cold), so failures here must not fail session creation;
+        the session is already valid and usable without a warm cache.
+        """
+        try:
+            self.call_worker_tool(
+                session,
+                "server_warmup",
+                {
+                    "wait_auto_analysis": wait_auto_analysis,
+                    "build_caches": build_caches,
+                    "init_hexrays": init_hexrays,
+                },
+                timeout=WORKER_OPEN_TIMEOUT_SEC or None,
+            )
+        except Exception as e:
+            logger.warning(
+                "Warmup failed for GUI session %s:%s (%s): %s",
+                session.host,
+                session.port,
+                session.input_path,
+                e,
+            )
+
+    def _launch_gui_and_adopt(
+        self,
+        resolved_path: str,
+        session_id: str,
+        *,
+        run_auto_analysis: bool = True,
+        build_caches: bool = True,
+        init_hexrays: bool = True,
+    ) -> WorkerSession:
         launched = _discovery.launch_gui_instance(resolved_path)
         if not launched.get("success"):
             raise RuntimeError(launched.get("error") or "Failed to launch GUI IDA process")
@@ -656,7 +701,15 @@ class IdalibSupervisor:
                 session.port,
                 resolved_path,
             )
-            return session
+
+        if build_caches or run_auto_analysis or init_hexrays:
+            self._warmup_gui_session(
+                session,
+                wait_auto_analysis=run_auto_analysis,
+                build_caches=build_caches,
+                init_hexrays=init_hexrays,
+            )
+        return session
 
     def open_session(
         self,
@@ -688,6 +741,7 @@ class IdalibSupervisor:
             elif session_id in self.sessions:
                 raise ValueError(f"Session already exists: {session_id}")
 
+            adopted_gui_session: WorkerSession | None = None
             if mode in ("prefer_gui", "force_gui"):
                 gui_instance = self._find_instance_for_path(resolved, backend="gui")
                 if gui_instance is not None:
@@ -699,8 +753,12 @@ class IdalibSupervisor:
                         session.port,
                         resolved,
                     )
-                    return session
-                if mode == "force_gui":
+                    # Defer warmup until the lock is released below - it RPCs
+                    # into the GUI instance and can run long (e.g. building
+                    # the strings cache cold on a huge binary).
+                    adopted_gui_session = session
+                    break_for_launch = False
+                elif mode == "force_gui":
                     # Drop the lock so the long-running subprocess launch + poll
                     # doesn't block other supervisor operations.
                     break_for_launch = True
@@ -717,11 +775,27 @@ class IdalibSupervisor:
                     if adopted is not None:
                         return adopted
 
-            if not break_for_launch:
+            if not break_for_launch and adopted_gui_session is None:
                 worker = self._allocate_worker_locked()
 
+        if adopted_gui_session is not None:
+            if build_caches or run_auto_analysis or init_hexrays:
+                self._warmup_gui_session(
+                    adopted_gui_session,
+                    wait_auto_analysis=run_auto_analysis,
+                    build_caches=build_caches,
+                    init_hexrays=init_hexrays,
+                )
+            return adopted_gui_session
+
         if break_for_launch:
-            return self._launch_gui_and_adopt(resolved, session_id)
+            return self._launch_gui_and_adopt(
+                resolved,
+                session_id,
+                run_auto_analysis=run_auto_analysis,
+                build_caches=build_caches,
+                init_hexrays=init_hexrays,
+            )
 
         open_timeout = (WORKER_OPEN_TIMEOUT_SEC or None) if run_auto_analysis else None
         try:


### PR DESCRIPTION
## Context

Three commits that build on each other around `idb_open`/`server_warmup` on
large binaries:

1. **Forward `build_caches`/`run_auto_analysis`/`init_hexrays` to adopted GUI
   sessions.** `idb_open` warms up a freshly-spawned headless worker
   automatically, but a GUI instance adopted via `mode="prefer_gui"`/
   `"force_gui"` never got the same treatment — re-exposes `server_warmup`
   as an MCP tool and forwards it to the adopted session.
2. **Give `server_warmup` a 600s timeout.** Cold cache builds
   (`run_auto_analysis`/`build_caches`/`init_hexrays`) on huge binaries
   routinely exceed the previous default 60s tool timeout.
3. **Make the idalib HTTP layer threaded.** Testing (2) surfaced the real
   problem: `idalib_server.py` started its HTTP server with
   `background=False`, which also forced the stdlib's non-threaded
   `HTTPServer` (the two were tied to the same flag). A worker running
   `idb_open`/`server_warmup` on a large binary occupies its single HTTP
   thread inside `execute_sync` for however long analysis takes (now up to
   600s per #2) — so the process can't accept *any* new connection,
   including `server_health`/`ping` probes, until the long call returns.
   The supervisor's own gateway had the same issue: forwarding `tools/call`
   to a busy worker blocked the gateway thread, so an analysis on one worker
   could starve requests meant for an unrelated, idle worker.

   Fix: decouple `serve()`'s new `threaded` param (HTTP concurrency) from
   `background` (whether `serve_forever` blocks the caller), and turn
   `threaded=True` on for both the worker and the supervisor gateway.
   `execute_sync` on the IDA main thread still serializes actual IDA SDK
   work per process — this only fixes the network layer's ability to
   accept and queue requests, not IDA's single-threaded execution model.

   Also gives `server_health` a fast path: a process-wide busy flag
   (`sync.busy`/`is_busy`), set *before* `idb_open`/`server_warmup` submit
   to `execute_sync` (not inside the `@idasync` body — that window still
   counts as busy while queued), lets `server_health` return
   `{"status": "busy", "busy_reason": ...}` immediately instead of queuing
   behind a call that won't drain until the long operation yields.

## Test plan

- [x] `tests/test_idalib_supervisor.py`, `tests/test_worker_lifecycle.py`
- [x] Full non-IDA test suite (`tests/`, 190 tests + 114 subtests)
- [x] `busy`/`is_busy` nesting and concurrent-read behavior verified with a
  standalone stub-module script (no IDA env available in this sandbox)
- [x] `server_health`/`server_warmup` behavior against a real IDA kernel
  (`ida-mcp-test tests/crackme03.elf -c api_core`) 