### PR TITLE
fix(idalib): avoid SIGTERM/SIGINT handler deadlock in idalib_server

### DIFF
--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import signal
+import threading
 import time
 from pathlib import Path
 from typing import Annotated, Any, TypedDict
@@ -248,10 +249,19 @@ def main():
 
     def cleanup_and_exit(signum, frame):
         logger.info("Signal %s received; shutting down", signum)
-        try:
-            MCP_SERVER.stop()
-        except Exception:
-            logger.exception("MCP_SERVER.stop() failed in signal handler")
+        # MCP_SERVER.stop() blocks until serve_forever() returns, but this
+        # handler runs on the main thread — the same thread that is parked
+        # inside serve_forever() underneath this frame. Calling stop() here
+        # deadlocks the process forever (and, having flipped _running to
+        # False, turns every later stop() — watchdog TTL, repeat signals —
+        # into a no-op). Stop from a helper thread instead.
+        def _stop():
+            try:
+                MCP_SERVER.stop()
+            except Exception:
+                logger.exception("MCP_SERVER.stop() failed in signal handler")
+
+        threading.Thread(target=_stop, daemon=True, name="signal-stop").start()
 
     signal.signal(signal.SIGINT, cleanup_and_exit)
     signal.signal(signal.SIGTERM, cleanup_and_exit)


### PR DESCRIPTION
Fixes #487.

## Problem

`idalib_server` runs a single-threaded `HTTPServer` on the main thread (`MCP_SERVER.serve(..., background=False)`). Its SIGTERM/SIGINT handler called `MCP_SERVER.stop()` directly — but `stop()` blocks in `HTTPServer.shutdown()`, which waits for `serve_forever()` to return and must be called from a *different* thread than the one running it. The handler runs on the main thread, on top of the frame parked inside `serve_forever()`, so the process deadlocks forever.

Since `stop()` flips `_running = False` before blocking, every subsequent `stop()` call (the idle-TTL watchdog, repeated signals) becomes a no-op. Combined with `start_new_session=True` in the supervisor's `_spawn_worker()`, each wedged worker survives as a PPID=1 orphan that only SIGKILL can remove — leaking roughly one idalib process per supervisor lifetime (I had ~774 of them holding ~28 GB of swap). Full analysis with a stack sample of a wedged process is in #487.

## Fix

Run `MCP_SERVER.stop()` on a short-lived daemon thread from the signal handler. That is exactly the "different thread" `shutdown()` requires; the main thread then exits `serve_forever()` normally and `main()`'s `finally` block performs the usual cleanup (`_LIFECYCLE.stop()`, discovery deregistration, `close_all_sessions()`).

## Verification

On macOS 26.5 / Python 3.11 / IDA Professional 9.3 (idalib):

- **Before**: spawn a worker, wait until it answers JSON-RPC `ping` on `/mcp`, send SIGTERM → still alive 10 s later (and indefinitely; `sample` shows the handler blocked in `HTTPServer.shutdown()` under `serve_forever()`).
- **After**: same scenario → clean exit with rc=0 within milliseconds.
- Idle-TTL self-exit path still works after the change (worker with a shortened TTL and no requests exits on its own).
- `pytest tests/test_worker_lifecycle.py tests/test_idalib_supervisor.py` → 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
