### PR TITLE
fix(sync): don't hang the caller when the call-stack guard trips

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -116,8 +116,15 @@ def _sync_wrapper(ff, keep_batch=False):
                 last_func_name = call_stack.get_nowait()
             except queue.Empty:
                 last_func_name = "<empty>"
-            error_str = f"Call stack is not empty while calling the function {ff.__name__} from {last_func_name}"
-            raise IDASyncError(error_str)
+            # Hand the error back through res_container rather than raising.
+            # execute_sync() discards exceptions escaping the callback, so a
+            # raise here leaves res_container empty and the requesting thread
+            # blocked forever on the res_container.get() below (issue #217).
+            res_container.put(IDASyncError(
+                f"Call stack is not empty while calling the function "
+                f"{ff.__name__} from {last_func_name}"
+            ))
+            return
 
         call_stack.put((ff.__name__))
         # Enable batch mode for all synchronized operations


### PR DESCRIPTION
### Problem

`_sync_wrapper`'s reentrancy guard raises from inside the `execute_sync` callback:

```python
def runned():
    if not call_stack.empty():
        ...
        raise IDASyncError(error_str)   # nothing put into res_container
    ...

idaapi.execute_sync(runned, idaapi.MFF_WRITE)
res = res_container.get()               # unbounded
```

`idaapi.execute_sync` discards exceptions that escape the callback, so when the guard trips nothing is ever placed in `res_container` and the requesting thread blocks forever on the `get()` below. Since that thread is an HTTP worker, the client waits indefinitely and the request never completes.

This is one of the reachable paths into #217. Unlike the modal-dialog scenario described there, this one is entirely within the plugin's own control.

The guard is reachable whenever a `@idasync` function invokes another `@idasync` function — the same class of reentrancy that 85efdf8 addressed on the cleanup side. That commit fixed the `finally` blocking on an empty queue; the pre-check path still raises into the void.

### Fix

Put the `IDASyncError` into `res_container` and return, instead of raising.

The existing `if isinstance(res, Exception): raise res` then delivers exactly the same exception to the caller, so **error semantics are unchanged** — the caller still sees `IDASyncError` with the same message. Only the hang goes away.

One deliberate behaviour change worth flagging: this trades an IDA-console traceback for an error delivered to the MCP client. That seemed the more useful of the two, but happy to also log it if you'd prefer to keep console visibility.

### Scope

This does **not** address the other scenario in #217, where the main thread is blocked by a modal dialog and `execute_sync` itself never completes. That needs a bounded wait and a decision about what to do with a request that may still land later, so I left it alone rather than bundling a riskier change.

### Testing

`tests/` passes with the change (196 passed).

I did not add a regression test: `sync.py` imports `idaapi` at module scope, and the top-level `tests/` suite is explicitly for modules that "run outside IDA", so covering this would mean either `sys.modules` stubbing there or an in-IDA test under `ida_mcp/tests/`. Happy to add one in whichever style you prefer — I have a stubbed version that reproduces the hang (a worker thread that never returns) and passes with the fix.

For context: I maintain a fork that carries a copy of this `sync.py`, hit this while auditing it, and fixed it there too. Sending it upstream since the bug is in your tree as well.