### PR TITLE
Clean up newly created IDA database fragments after failed worker opens

### DIFF
--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -55,6 +55,7 @@ IDB_MANAGEMENT_TOOLS = {
 }
 WORKER_TCP_HEALTH_TIMEOUT_SEC = 0.5
 WORKER_RPC_HEALTH_TIMEOUT_SEC = 2.0
+PARTIAL_DATABASE_EXTENSIONS = (".id0", ".id1", ".id2", ".nam", ".til")
 
 # Upper bound (seconds) on how long a worker may take to open and auto-analyze a
 # binary before it is reaped and an error is returned. A malformed or hostile
@@ -289,18 +290,41 @@ class IdalibSupervisor:
             proc.wait(timeout=5)
 
     @staticmethod
-    def _cleanup_partial_database(input_path: str) -> None:
+    def _partial_database_paths(input_path: str) -> tuple[Path, ...]:
+        base = Path(input_path)
+        return tuple(
+            base.with_name(base.name + ext)
+            for ext in PARTIAL_DATABASE_EXTENSIONS
+        )
+
+    @classmethod
+    def _existing_partial_database_parts(cls, input_path: str) -> set[Path]:
+        return {
+            part
+            for part in cls._partial_database_paths(input_path)
+            if part.exists()
+        }
+
+    @classmethod
+    def _cleanup_partial_database(
+        cls,
+        input_path: str,
+        *,
+        preserve: set[Path] | None = None,
+    ) -> None:
         """Remove leftover unpacked IDA database parts after a failed/aborted open.
 
         When a worker is reaped mid-open (for example on an analysis timeout), the
         partially written .id0/.id1/.id2/.nam/.til files are left next to the input.
         IDA then rejects every subsequent open of that path with
         "database is corrupted beyond repair", turning a one-off failure into a
-        permanent one. The packed .i64/.idb (a complete saved database) is kept.
+        permanent one. The packed .i64/.idb (a complete saved database) and any
+        unpacked parts that predated this open attempt are kept.
         """
-        base = Path(input_path)
-        for ext in (".id0", ".id1", ".id2", ".nam", ".til"):
-            part = base.with_name(base.name + ext)
+        preserved = preserve or set()
+        for part in cls._partial_database_paths(input_path):
+            if part in preserved:
+                continue
             try:
                 if part.exists():
                     part.unlink()
@@ -724,6 +748,7 @@ class IdalibSupervisor:
             return self._launch_gui_and_adopt(resolved, session_id)
 
         open_timeout = (WORKER_OPEN_TIMEOUT_SEC or None) if run_auto_analysis else None
+        preexisting_parts = self._existing_partial_database_parts(resolved)
         try:
             opened = self.call_worker_tool(
                 worker,
@@ -742,7 +767,7 @@ class IdalibSupervisor:
                 raise RuntimeError(str(opened["error"]))
         except TimeoutError:
             self._terminate_worker(worker)
-            self._cleanup_partial_database(resolved)
+            self._cleanup_partial_database(resolved, preserve=preexisting_parts)
             raise RuntimeError(
                 f"idalib worker timed out after {open_timeout:.0f}s while opening and "
                 f"analyzing {resolved}. The binary may drive auto-analysis into an "
@@ -751,6 +776,7 @@ class IdalibSupervisor:
             ) from None
         except Exception:
             self._terminate_worker(worker)
+            self._cleanup_partial_database(resolved, preserve=preexisting_parts)
             raise
 
         worker_session = opened.get("session", {}) if isinstance(opened, dict) else {}
@@ -826,6 +852,7 @@ class IdalibSupervisor:
         resolved = self._resolve_gui_fallback_path(session)
         with self._lock:
             worker = self._allocate_worker_locked()
+        preexisting_parts = self._existing_partial_database_parts(resolved)
         try:
             opened = self.call_worker_tool(
                 worker,
@@ -842,6 +869,7 @@ class IdalibSupervisor:
                 raise RuntimeError(str(opened["error"]))
         except Exception:
             self._terminate_worker(worker)
+            self._cleanup_partial_database(resolved, preserve=preexisting_parts)
             raise
 
         worker_session = opened.get("session", {}) if isinstance(opened, dict) else {}

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 from ida_pro_mcp import idalib_supervisor as supmod
 
 
@@ -170,6 +172,88 @@ def test_worker_rpc_default_has_no_socket_timeout(monkeypatch):
 
     assert _FakeConnection.instances[0].timeout is None
     assert _FakeConnection.instances[1].timeout == 2.0
+
+
+def test_cleanup_partial_database_removes_only_new_parts(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"sample")
+    existing = Path(str(sample) + ".id0")
+    existing.write_bytes(b"existing database state")
+    packed = Path(str(sample) + ".i64")
+    packed.write_bytes(b"packed database")
+
+    preserved = supmod.IdalibSupervisor._existing_partial_database_parts(str(sample))
+    new_id1 = Path(str(sample) + ".id1")
+    new_id1.write_bytes(b"incomplete")
+    new_nam = Path(str(sample) + ".nam")
+    new_nam.write_bytes(b"incomplete")
+
+    supmod.IdalibSupervisor._cleanup_partial_database(
+        str(sample),
+        preserve=preserved,
+    )
+
+    assert existing.read_bytes() == b"existing database state"
+    assert not new_id1.exists()
+    assert not new_nam.exists()
+    assert packed.read_bytes() == b"packed database"
+
+
+def test_open_session_cleans_new_parts_after_worker_failure(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"sample")
+    existing = Path(str(sample) + ".id0")
+    existing.write_bytes(b"existing database state")
+    packed = Path(str(sample) + ".i64")
+    packed.write_bytes(b"packed database")
+
+    class _FailingSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None, *, timeout=None):
+            assert arguments is not None
+            Path(arguments["input_path"] + ".id1").write_bytes(b"incomplete")
+            raise ConnectionResetError(10054, "worker reset")
+
+    sup = _FailingSupervisor()
+    with pytest.raises(ConnectionResetError):
+        sup.open_session(
+            str(sample),
+            mode="force_headless",
+            run_auto_analysis=False,
+            build_caches=False,
+            init_hexrays=False,
+        )
+
+    assert existing.read_bytes() == b"existing database state"
+    assert not Path(str(sample) + ".id1").exists()
+    assert packed.read_bytes() == b"packed database"
+
+
+def test_failed_gui_fallback_cleans_new_parts_after_worker_failure(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"sample")
+    existing = Path(str(sample) + ".id0")
+    existing.write_bytes(b"existing database state")
+
+    class _FailingSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None, *, timeout=None):
+            assert arguments is not None
+            Path(arguments["input_path"] + ".id1").write_bytes(b"incomplete")
+            raise ConnectionResetError(10054, "worker reset")
+
+    gui_session = supmod.WorkerSession(
+        session_id="gui",
+        input_path=str(sample),
+        filename=sample.name,
+        backend="gui",
+        owned=False,
+    )
+    sup = _FailingSupervisor()
+    with pytest.raises(ConnectionResetError):
+        sup._reopen_gui_session_headless(gui_session)
+
+    assert existing.read_bytes() == b"existing database state"
+    assert not Path(str(sample) + ".id1").exists()
+
 
 def test_worker_tools_inject_database_and_filter_management_tools():
     sup = _FakeSupervisor()


### PR DESCRIPTION
## Summary

- snapshot existing loose IDA database parts before a headless worker opens a file
- remove only parts created by that attempt when the worker times out, crashes, or disconnects
- apply the same cleanup when a closed GUI session is reopened headlessly
- preserve packed databases and loose database parts that existed before the attempt

## Problem

An idalib worker can exit or reset its connection while opening a database, leaving partially written `.id0`, `.id1`, `.id2`, `.nam`, or `.til` files beside the input. Cleanup previously ran only for analysis timeouts, so failures such as `ConnectionResetError` / WinError 10054 could leave fragments that made subsequent opens fail as a corrupted database.

The timeout cleanup also removed every loose database part without distinguishing files created by the failed attempt from pre-existing state.

## Impact

A failed worker open no longer poisons later attempts with newly created database fragments. Existing loose database state and packed `.i64` / `.idb` databases are preserved.

## Validation

- `pytest tests/test_idalib_supervisor.py -q`: 42 passed
- `pytest tests -q`: 199 passed, 114 subtests passed
