### PR TITLE
Add Python 3.8 / IDA 7.7 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ida-pro-mcp"
 version = "2.0.0"
 description = "Vibe reversing with IDA Pro"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 authors = [
     { name = "mrexodia" },
     { name = "can1357" },
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-    "idapro>=0.0.9",
+    
     "tomli-w>=1.0.0",
 ]
 

--- a/src/ida_pro_mcp/ida_mcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """IDA Pro MCP Plugin - Modular Package Version
 
 This package provides MCP (Model Context Protocol) integration for IDA Pro,

--- a/src/ida_pro_mcp/ida_mcp/_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/_sigmaker.py
@@ -69,6 +69,7 @@ import pathlib
 import re
 import string
 import typing
+from typing import Dict, FrozenSet, List, Optional, Tuple
 
 import idaapi
 import idc
@@ -194,7 +195,7 @@ class IDAVersionInfo:
         return NotImplemented
 
     @staticmethod
-    @functools.cache
+    @functools.lru_cache(maxsize=None)
     def ida_version():
         version_str: str = idaapi.get_kernel_version()
         sdk_version: int = idaapi.IDA_SDK_VERSION
@@ -209,7 +210,7 @@ def is_address_marked_as_code(ea: int) -> bool:
     return idaapi.is_code(idaapi.get_flags(ea))
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class InMemoryBuffer:
     class LoadMode(enum.Enum):
         SEGMENTS = "segments"
@@ -305,7 +306,7 @@ class SigMakerConfig:
     max_xref_signature_length: int = 250
 
 
-@dataclasses.dataclass(slots=True, frozen=True, repr=False)
+@dataclasses.dataclass(frozen=True, repr=False)
 class Match:
     address: int
 
@@ -344,7 +345,7 @@ class SignatureByte(typing.NamedTuple):
     is_wildcard: bool
 
 
-class Signature(list[SignatureByte]):
+class Signature(List[SignatureByte]):
     def add_byte_to_signature(self, address: int, is_wildcard: bool) -> None:
         byte_value = idaapi.get_byte(address)
         self.append(SignatureByte(byte_value, is_wildcard))
@@ -380,7 +381,7 @@ class SignatureFormatter(typing.Protocol):
     def format(self, signature: "Signature") -> str: ...
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class IdaFormatter:
     wildcard_byte: str = "?"
 
@@ -394,12 +395,12 @@ class IdaFormatter:
         return " ".join(parts)
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class X64DbgFormatter(IdaFormatter):
     wildcard_byte: str = "??"
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class MaskedBytesFormatter:
     wildcard_byte: str = "\\x00"
     mask: str = "x"
@@ -412,7 +413,7 @@ class MaskedBytesFormatter:
         wildcard_byte: str,
         mask_char: str,
         wildcard_mask_char: str,
-    ) -> tuple[list[str], list[str]]:
+    ) -> Tuple[List[str], List[str]]:
         pattern_parts = []
         mask_parts = []
         for byte in signature:
@@ -435,7 +436,7 @@ class MaskedBytesFormatter:
         return "".join(pattern_parts) + " " + "".join(mask_parts)
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class ByteArrayBitmaskFormatter:
     wildcard_byte: str = "0x00"
     mask: str = "1"
@@ -462,9 +463,9 @@ FORMATTER_MAP: typing.Dict[SignatureType, SignatureFormatter] = {
 }
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
+@dataclasses.dataclass(frozen=True)
 class WildcardPolicy:
-    allowed_types: frozenset[int]
+    allowed_types: FrozenSet[int]
     _ctx = WILDCARD_POLICY_CTX
 
     class RarelyWildcardable(enum.IntEnum):
@@ -509,7 +510,7 @@ class WildcardPolicy:
         CRB = idaapi.o_idpspec4
         DCR = idaapi.o_idpspec5
 
-    @dataclasses.dataclass(slots=True)
+    @dataclasses.dataclass()
     class _Use:
         policy: "WildcardPolicy"
         policy_class: type["WildcardPolicy"]
@@ -593,7 +594,7 @@ class WildcardPolicy:
         return cls._Use(policy, cls)
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
+@dataclasses.dataclass(frozen=True)
 class GeneratedSignature:
     """Result container for signature generation operations."""
 
@@ -617,9 +618,9 @@ class GeneratedSignature:
         )
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class XrefGeneratedSignature:
-    signatures: list[GeneratedSignature]
+    signatures: List[GeneratedSignature]
 
 
 class SigText:
@@ -644,16 +645,16 @@ class SigText:
         return len(s) > 0 and all(c in SigText._HEX_SET for c in s)
 
     @staticmethod
-    def _split_hex_pairs(s: str) -> list[str]:
+    def _split_hex_pairs(s: str) -> List[str]:
         return [s[i : i + 2].upper() for i in range(0, len(s), 2)]
 
     @staticmethod
-    def normalize(sig_str: str) -> tuple[str, list[tuple[int, bool]]]:
+    def normalize(sig_str: str) -> Tuple[str, List[Tuple[int, bool]]]:
         if not sig_str:
             return "", []
         s = sig_str.translate(SigText._TRANS)
         raw = [t for t in s.split() if t]
-        toks: list[str] = []
+        toks: List[str] = []
         for t in raw:
             t = t.strip()
             if t.startswith(("0x", "0X")):
@@ -662,7 +663,7 @@ class SigText:
                 continue
             toks.append(t)
 
-        out: list[str] = []
+        out: List[str] = []
         i = 0
         while i < len(toks):
             t = toks[i]
@@ -712,7 +713,7 @@ class SigText:
 
             raise ValueError(f"invalid signature token: {t!r}")
 
-        pattern: list[tuple[int, bool]] = []
+        pattern: List[Tuple[int, bool]] = []
         for tok in out:
             hi, lo = tok[0], tok[1]
             wild = (hi == "?") or (lo == "?")
@@ -801,7 +802,7 @@ class InstructionProcessor:
             )
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class InstructionWalker:
     start_ea: int
     end_ea: int = idaapi.BADADDR
@@ -820,7 +821,7 @@ class InstructionWalker:
         self.cursor = self.start_ea
         return self
 
-    def __next__(self) -> tuple[int, idaapi.insn_t, int]:
+    def __next__(self) -> Tuple[int, idaapi.insn_t, int]:
         if self.end_ea != idaapi.BADADDR and self.cursor >= self.end_ea:
             raise StopIteration
 
@@ -854,7 +855,7 @@ class UniqueSignatureGenerator:
         # to idaapi.bin_search, which never materializes a buffer (is_unique
         # bails at the second match). The seed is built at most once per
         # generate().
-        offsets: typing.Optional[list[int]] = None  # SIMD list candidates
+        offsets: typing.Optional[List[int]] = None  # SIMD list candidates
         buf: typing.Optional["InMemoryBuffer"] = None
 
         for cur_ea, ins, ins_len in InstructionWalker(ea):
@@ -906,7 +907,7 @@ class UniqueSignatureGenerator:
 # ---------------------------------------------------------------------------
 
 
-@dataclasses.dataclass(slots=True, frozen=True)
+@dataclasses.dataclass(frozen=True)
 class _DecodedInstruction:
     """Pre-decoded instruction data; produced once per function and reused
     across anchor growth loops in MinimalFunctionSignatureGenerator.
@@ -926,11 +927,11 @@ class _DecodedInstruction:
 
 def _refine_offsets(
     data_mv: memoryview,
-    offsets: list[int],
+    offsets: List[int],
     j: int,
     value: int,
     mask: int,
-) -> list[int]:
+) -> List[int]:
     """Keep offsets c where (data_mv[c + j] & mask) == (value & mask).
 
     j is the pattern-relative index of the byte being checked; c is a match
@@ -968,7 +969,7 @@ def _refine_offsets_into(
     return w
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class _ByteIndex:
     """A 2-byte bucket position index over the segment buffer.
 
@@ -1007,13 +1008,13 @@ class _ByteIndex:
 
 def _select_seed_run(
     sig: "Signature", index: "_ByteIndex"
-) -> typing.Optional[tuple[int, int, int]]:
+) -> typing.Optional[Tuple[int, int, int]]:
     """Pick the unmasked run (2-byte or single byte) with the smallest index
     bucket (Dynamic Seed Selection), returning (offset, width, key).
 
     Returns None only when sig has no exact byte at all.
     """
-    best: typing.Optional[tuple[int, int, int, int]] = None  # (size, offset, width, key)
+    best: typing.Optional[Tuple[int, int, int, int]] = None  # (size, offset, width, key)
     m = len(sig)
     for j in range(m - 1):
         a = sig[j]
@@ -1040,7 +1041,7 @@ def _seed_via_index(
     sig: "Signature",
     index: typing.Optional["_ByteIndex"],
     buf: "InMemoryBuffer",
-) -> typing.Optional[tuple["array.array", int]]:
+) -> typing.Optional[Tuple["array.array", int]]:
     """Seed the candidate set from the byte index instead of scanning.
 
     Picks the most selective unmasked run via Dynamic Seed Selection, maps its
@@ -1082,7 +1083,7 @@ def _decode_function_for_anchors(
     pfn: "idaapi.func_t",
     processor: "InstructionProcessor",
     cfg: "SigMakerConfig",
-) -> list[_DecodedInstruction]:
+) -> List[_DecodedInstruction]:
     """Decode a function's instructions once and capture per-instruction data
     for use across all anchor growth loops.
 
@@ -1098,7 +1099,7 @@ def _decode_function_for_anchors(
     if not func_bytes:
         return []
 
-    decoded: list[_DecodedInstruction] = []
+    decoded: List[_DecodedInstruction] = []
     for ea, ins, ins_len in InstructionWalker(pfn.start_ea, pfn.end_ea):
         offset = ea - pfn.start_ea
         if offset < 0 or offset + ins_len > len(func_bytes):
@@ -1160,7 +1161,7 @@ class MinimalFunctionSignatureGenerator:
         if no start point produces a unique signature within the length budget
         (or all candidates are degenerate, < MIN_USEFUL_SIG_BYTES bytes).
         """
-        candidates: list[GeneratedSignature] = []
+        candidates: List[GeneratedSignature] = []
 
         decoded = _decode_function_for_anchors(pfn, self.processor, cfg)
         if not decoded:
@@ -1205,7 +1206,7 @@ class MinimalFunctionSignatureGenerator:
 
     def _grow_unique_from_decoded(
         self,
-        decoded: list[_DecodedInstruction],
+        decoded: List[_DecodedInstruction],
         anchor_idx: int,
         max_len: int,
         cfg: SigMakerConfig,
@@ -1322,7 +1323,7 @@ class RangeSignatureGenerator:
         return sig
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class SignatureMaker:
     _operand_processor: OperandProcessor = dataclasses.field(
         default_factory=OperandProcessor
@@ -1397,7 +1398,7 @@ class XrefFinder:
         return sum(1 for _ in cls.iter_code_xrefs_to(ea))
 
     def find_xrefs(self, ea: int, cfg: SigMakerConfig) -> XrefGeneratedSignature:
-        xref_signatures: list[GeneratedSignature] = []
+        xref_signatures: List[GeneratedSignature] = []
 
         total = self.count_code_xrefs_to(ea)
         if total == 0:
@@ -1425,9 +1426,9 @@ class XrefFinder:
         return XrefGeneratedSignature(xref_signatures)
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class SearchResults:
-    matches: list[Match]
+    matches: List[Match]
     signature_str: str
 
 
@@ -1444,7 +1445,7 @@ class SignatureParser:
         mask = cls._extract_mask(input_str)
         parsed = ""
         if mask:
-            bytestr: list[str] = []
+            bytestr: List[str] = []
             if (bytestr := cls._ESCAPED_HEX.findall(input_str)) and len(bytestr) == len(
                 mask
             ):
@@ -1476,7 +1477,7 @@ class SignatureParser:
 
     @staticmethod
     def _masked_bytes_to_ida(
-        byte_tokens: list[str], mask: str, *, slice_from: int
+        byte_tokens: List[str], mask: str, *, slice_from: int
     ) -> str:
         sig = Signature(
             [
@@ -1496,7 +1497,7 @@ class SignatureParser:
         s = re.sub(r"\s+", " ", s)
 
         tokens = [t.strip() for t in s.split() if t.strip()]
-        out: list[str] = []
+        out: List[str] = []
         for t in tokens:
             if t == "?" or t == "??":
                 out.append("?")
@@ -1511,7 +1512,7 @@ class SignatureParser:
         return (" ".join(out) + " ") if out else ""
 
 
-@dataclasses.dataclass(slots=True)
+@dataclasses.dataclass()
 class SignatureSearcher:
     input_signature: str = ""
 
@@ -1531,14 +1532,14 @@ class SignatureSearcher:
         ida_signature: str,
         skip_more_than_one: bool = False,
         buf: typing.Optional["InMemoryBuffer"] = None,
-    ) -> list[Match]:
+    ) -> List[Match]:
         simd_signature, _ = SigText.normalize(ida_signature)
         if buf is None:
             buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
         data_mv = buf.data()
 
         sig = _SimdSignature(simd_signature)
-        results: list[Match] = []
+        results: List[Match] = []
         base = idaapi.inf_get_min_ea()
         if (k := sig.size_bytes) == 0:
             return [Match(base)]
@@ -1569,7 +1570,7 @@ class SignatureSearcher:
     def find_all_offsets(
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
-    ) -> tuple[list[int], "InMemoryBuffer"]:
+    ) -> Tuple[List[int], "InMemoryBuffer"]:
         """Return (offsets, buf): every match as a 0-based offset into
         buf.data(), plus the buffer used. The offsets seed an in-memory
         refinement; reusing the returned buf keeps subsequent refinement on
@@ -1580,7 +1581,7 @@ class SignatureSearcher:
             buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
         data_mv = buf.data()
         sig = _SimdSignature(simd_signature)
-        offsets: list[int] = []
+        offsets: List[int] = []
         k = sig.size_bytes
         if k == 0:
             return [0], buf
@@ -1605,14 +1606,14 @@ class SignatureSearcher:
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
         skip_more_than_one: bool = False,
-    ) -> list[Match]:
+    ) -> List[Match]:
         if SIMD_SPEEDUP_AVAILABLE:
             return SignatureSearcher._find_all_simd(
                 ida_signature, skip_more_than_one=skip_more_than_one, buf=buf
             )
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
-        out: list[Match] = []
+        out: List[Match] = []
         ea = idaapi.inf_get_min_ea()
         max_ea = idaapi.inf_get_max_ea()
         _bin_search = getattr(idaapi, "bin_search", None) or getattr(

--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
 from itertools import islice
 import struct
-from typing import Annotated, Any, NotRequired, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict, Union
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 import ida_lines
 import ida_funcs
 import idaapi
@@ -52,7 +55,7 @@ from . import compat
 class DecompileResult(TypedDict):
     addr: str
     code: str | None
-    refs: NotRequired[list[Ref]]
+    refs: NotRequired[List[Ref]]
     error: NotRequired[str]
 
 
@@ -83,26 +86,26 @@ class FuncProfileItem(TypedDict, total=False):
     constant_count: int
     has_type: bool
     prototype: str | None
-    callers: list[dict[str, Any]]
+    callers: List[Dict[str, Any]]
     callers_truncated: bool
-    callees: list[dict[str, Any]]
+    callees: List[Dict[str, Any]]
     callees_truncated: bool
-    strings: list[dict[str, Any]]
+    strings: List[Dict[str, Any]]
     strings_truncated: bool
-    constants: list[dict[str, Any]]
+    constants: List[Dict[str, Any]]
     constants_truncated: bool
     error: str | None
 
 
 class FuncProfileResult(TypedDict, total=False):
     target: str
-    data: list[FuncProfileItem]
+    data: List[FuncProfileItem]
     next_offset: int | None
     error: str | None
 
 
 class AnalyzeBatchDisasm(TypedDict):
-    lines: list[str]
+    lines: List[str]
     instruction_count: int
     truncated: bool
 
@@ -110,8 +113,8 @@ class AnalyzeBatchDisasm(TypedDict):
 AnalyzeBatchXrefs = TypedDict(
     "AnalyzeBatchXrefs",
     {
-        "to": list[dict[str, str]],
-        "from": list[dict[str, str]],
+        "to": List[Dict[str, str]],
+        "from": List[Dict[str, str]],
         "to_truncated": bool,
         "from_truncated": bool,
         "to_count": int,
@@ -127,19 +130,19 @@ class AnalyzeBatchDetails(TypedDict, total=False):
     decompile_error: str | None
     disasm: AnalyzeBatchDisasm | None
     xrefs: AnalyzeBatchXrefs | None
-    callers: list[dict[str, Any]] | None
+    callers: List[Dict[str, Any]] | None
     caller_count: int
     callers_truncated: bool
-    callees: list[dict[str, Any]] | None
+    callees: List[Dict[str, Any]] | None
     callee_count: int
     callees_truncated: bool
-    strings: list[dict[str, Any]] | None
+    strings: List[Dict[str, Any]] | None
     string_ref_count: int
     strings_truncated: bool
-    constants: list[dict[str, Any]] | None
+    constants: List[Dict[str, Any]] | None
     constant_count: int
     constants_truncated: bool
-    basic_blocks: list[BasicBlock] | None
+    basic_blocks: List[BasicBlock] | None
     basic_block_count: int
     basic_blocks_truncated: bool
 
@@ -154,7 +157,7 @@ class AnalyzeBatchResult(TypedDict, total=False):
 
 class XrefsToResult(TypedDict, total=False):
     addr: str
-    xrefs: list[Xref] | None
+    xrefs: List[Xref] | None
     more: bool
     xref_count: int
     message: str
@@ -169,7 +172,7 @@ XrefQueryRow = TypedDict(
         "from": str,
         "to": str,
         "type": str,
-        "fn": Function | None,
+        "fn": Union[Function, None],
     },
     total=False,
 )
@@ -180,7 +183,7 @@ class XrefQueryResult(TypedDict, total=False):
     resolved_addr: str | None
     direction: str
     xref_type: str
-    data: list[XrefQueryRow]
+    data: List[XrefQueryRow]
     next_offset: int | None
     total: int
     message: str
@@ -190,7 +193,7 @@ class XrefQueryResult(TypedDict, total=False):
 class StructFieldXrefsResult(TypedDict, total=False):
     struct: str
     field: str
-    xrefs: list[Xref]
+    xrefs: List[Xref]
     message: str
     error: str
 
@@ -203,14 +206,14 @@ class CalleeResultItem(TypedDict):
 
 class CalleesResult(TypedDict, total=False):
     addr: str
-    callees: list[CalleeResultItem] | None
+    callees: List[CalleeResultItem] | None
     more: bool
     error: str
 
 
 class FindBytesResult(TypedDict, total=False):
     pattern: str
-    matches: list[str]
+    matches: List[str]
     n: int
     cursor: ResultCursor
     error: str
@@ -219,7 +222,7 @@ class FindBytesResult(TypedDict, total=False):
 class BasicBlocksResult(TypedDict, total=False):
     addr: str
     error: str
-    blocks: list[BasicBlock]
+    blocks: List[BasicBlock]
     count: int
     total_blocks: int
     cursor: ResultCursor
@@ -227,7 +230,7 @@ class BasicBlocksResult(TypedDict, total=False):
 
 class FindResult(TypedDict, total=False):
     query: str | int | None
-    matches: list[str]
+    matches: List[str]
     count: int
     cursor: ResultCursor
     error: str | None
@@ -262,8 +265,8 @@ class InsnQueryMatch(TypedDict, total=False):
 
 class InsnQueryResult(TypedDict, total=False):
     query: InsnQuerySummary
-    ranges: list[InsnScanRange]
-    matches: list[InsnQueryMatch]
+    ranges: List[InsnScanRange]
+    matches: List[InsnQueryMatch]
     count: int
     cursor: ResultCursor
     scanned: int
@@ -277,11 +280,11 @@ class ExportedFunctionJson(TypedDict, total=False):
     name: str | None
     prototype: str | None
     size: str
-    comments: dict[str, dict[str, str]]
+    comments: Dict[str, Dict[str, str]]
     asm: str
     code: str | None
     decompile_error: str | None
-    xrefs: dict[str, list[dict[str, str]]]
+    xrefs: Dict[str, List[Dict[str, str]]]
     error: str
 
 
@@ -292,7 +295,7 @@ class ExportedPrototype(TypedDict, total=False):
 
 class ExportFuncsJsonResult(TypedDict):
     format: str
-    functions: list[ExportedFunctionJson]
+    functions: List[ExportedFunctionJson]
 
 
 class ExportFuncsHeaderResult(TypedDict):
@@ -302,7 +305,7 @@ class ExportFuncsHeaderResult(TypedDict):
 
 class ExportFuncsPrototypesResult(TypedDict):
     format: str
-    functions: list[ExportedPrototype]
+    functions: List[ExportedPrototype]
 
 
 class CallGraphNode(TypedDict):
@@ -319,8 +322,8 @@ CallGraphEdge = TypedDict(
 
 class CallGraphResult(TypedDict, total=False):
     root: str
-    nodes: list[CallGraphNode]
-    edges: list[CallGraphEdge]
+    nodes: List[CallGraphNode]
+    edges: List[CallGraphEdge]
     max_depth: int
     truncated: bool
     limit_reason: str | None
@@ -380,7 +383,7 @@ def _insn_mnem(insn: ida_ua.insn_t) -> str:
         return ""
 
 
-def _value_to_le_bytes(value: int) -> tuple[bytes, int, int] | None:
+def _value_to_le_bytes(value: int) -> Tuple[bytes, int, int] | None:
     if value < 0:
         if value >= -0x80000000:
             size = 4
@@ -402,8 +405,8 @@ def _value_to_le_bytes(value: int) -> tuple[bytes, int, int] | None:
     return struct.pack(fmt, value), size, value
 
 
-def _value_candidates_for_immediate(value: int) -> list[tuple[int, int, bytes]]:
-    candidates: list[tuple[int, int, bytes]] = []
+def _value_candidates_for_immediate(value: int) -> List[Tuple[int, int, bytes]]:
+    candidates: List[Tuple[int, int, bytes]] = []
 
     def add(size: int, signed_val: int):
         if size == 4:
@@ -483,7 +486,7 @@ def _parse_optional_int(value: object, field: str) -> int | None:
         raise ValueError(f"{field} must be an integer") from e
 
 
-def _resolve_function_start(query: object) -> tuple[int | None, str | None]:
+def _resolve_function_start(query: object) -> Tuple[int | None, str | None]:
     q = str(query or "").strip()
     if not q:
         return None, "Function query is required"
@@ -503,8 +506,8 @@ def _resolve_function_start(query: object) -> tuple[int | None, str | None]:
     return func.start_ea, None
 
 
-def _collect_line_comments(ea: int) -> list[str]:
-    out: list[str] = []
+def _collect_line_comments(ea: int) -> List[str]:
+    out: List[str] = []
     i = 0
     while True:
         line = ida_lines.get_extra_cmt(ea, ida_lines.E_PREV + i)
@@ -561,11 +564,11 @@ def _resolve_ref(ea: int) -> dict | None:
     return info
 
 
-def _collect_decompile_refs(cfunc) -> list[dict]:
+def _collect_decompile_refs(cfunc) -> List[dict]:
     import ida_hexrays
 
-    seen: set[int] = set()
-    refs: list[dict] = []
+    seen: Set[int] = set()
+    refs: List[dict] = []
 
     class _Visitor(ida_hexrays.ctree_visitor_t):
         def __init__(self):
@@ -585,9 +588,9 @@ def _collect_decompile_refs(cfunc) -> list[dict]:
     return refs
 
 
-def _collect_line_refs(ea: int) -> list[dict]:
-    seen: set[int] = set()
-    refs: list[dict] = []
+def _collect_line_refs(ea: int) -> List[dict]:
+    seen: Set[int] = set()
+    refs: List[dict] = []
     for ref_ea in idautils.CodeRefsFrom(ea, False):
         if ref_ea == idaapi.BADADDR or ref_ea in seen:
             continue
@@ -605,7 +608,7 @@ def _collect_line_refs(ea: int) -> list[dict]:
     return refs
 
 
-def _limit_items(items: list, limit: int) -> tuple[list, bool]:
+def _limit_items(items: list, limit: int) -> Tuple[list, bool]:
     if limit < 0:
         limit = 0
     if len(items) <= limit:
@@ -613,8 +616,8 @@ def _limit_items(items: list, limit: int) -> tuple[list, bool]:
     return items[:limit], True
 
 
-def _disasm_lines_limited(func: ida_funcs.func_t, max_insns: int) -> tuple[list[str], bool]:
-    lines: list[str] = []
+def _disasm_lines_limited(func: ida_funcs.func_t, max_insns: int) -> Tuple[List[str], bool]:
+    lines: List[str] = []
     truncated = False
     for item_ea in idautils.FuncItems(func.start_ea):
         if len(lines) >= max_insns:
@@ -628,8 +631,8 @@ def _disasm_lines_limited(func: ida_funcs.func_t, max_insns: int) -> tuple[list[
 
 def _collect_basic_blocks_limited(
     func: ida_funcs.func_t, max_blocks: int
-) -> tuple[list[BasicBlock], bool]:
-    blocks: list[BasicBlock] = []
+) -> Tuple[List[BasicBlock], bool]:
+    blocks: List[BasicBlock] = []
     truncated = False
     for block in idaapi.FlowChart(func):
         if len(blocks) >= max_blocks:
@@ -648,8 +651,8 @@ def _collect_basic_blocks_limited(
     return blocks, truncated
 
 
-def _collect_callees_for_function(func: ida_funcs.func_t) -> list[dict]:
-    callees: dict[int, dict] = {}
+def _collect_callees_for_function(func: ida_funcs.func_t) -> List[dict]:
+    callees: Dict[int, dict] = {}
     for item_ea in idautils.FuncItems(func.start_ea):
         for target in idautils.CodeRefsFrom(item_ea, 0):
             callee = idaapi.get_func(target)
@@ -665,8 +668,8 @@ def _collect_callees_for_function(func: ida_funcs.func_t) -> list[dict]:
     return list(callees.values())
 
 
-def _collect_callers_for_function(func: ida_funcs.func_t) -> list[dict]:
-    callers: dict[int, dict] = {}
+def _collect_callers_for_function(func: ida_funcs.func_t) -> List[dict]:
+    callers: Dict[int, dict] = {}
     for caller_site in idautils.CodeRefsTo(func.start_ea, 0):
         caller = idaapi.get_func(caller_site)
         if not caller:
@@ -828,7 +831,7 @@ def disasm(
             func_name = "<no function>"
             header_addr = start
 
-        lines: list[dict] = []
+        lines: List[dict] = []
         seen = 0
         total_count = 0
         more = False
@@ -888,7 +891,7 @@ def disasm(
             more = total_count > offset + max_instructions
 
         rettype = None
-        args: Optional[list[Argument]] = None
+        args: Optional[List[Argument]] = None
         stack_frame = None
 
         if func:
@@ -942,14 +945,14 @@ def disasm(
 @tool_timeout(120.0)
 def func_profile(
     queries: Annotated[
-        list[FuncProfileQuery] | FuncProfileQuery,
+        List[FuncProfileQuery] | FuncProfileQuery,
         "Function profiling query (supports name/address filters + pagination)",
     ],
-) -> list[FuncProfileResult]:
+) -> List[FuncProfileResult]:
     """Profile functions with summary metrics and optional sampled details."""
     queries = normalize_dict_list(queries)
 
-    results: list[dict] = []
+    results: List[dict] = []
     for query in queries:
         q = str(query.get("addr", "*") or "*").strip()
         filter_pattern = str(query.get("filter", "") or "")
@@ -962,7 +965,7 @@ def func_profile(
         include_prototype = bool(query.get("include_prototype", False))
 
         # Resolve candidate function starts.
-        candidates: list[dict] = []
+        candidates: List[dict] = []
         if q not in ("", "*"):
             start_ea, err = _resolve_function_start(q)
             if err is not None or start_ea is None:
@@ -1012,7 +1015,7 @@ def func_profile(
             candidates.sort(key=lambda f: f["start_ea"], reverse=descending)
 
         page = paginate(candidates, offset, count)
-        profiled: list[dict] = []
+        profiled: List[dict] = []
         for item in page["data"]:
             profiled.append(
                 _profile_function(
@@ -1043,14 +1046,14 @@ def func_profile(
 @tool_timeout(120.0)
 def analyze_batch(
     queries: Annotated[
-        list[AnalyzeBatchQuery] | AnalyzeBatchQuery,
+        List[AnalyzeBatchQuery] | AnalyzeBatchQuery,
         "Comprehensive per-function analysis with selectable sections",
     ],
-) -> list[AnalyzeBatchResult]:
+) -> List[AnalyzeBatchResult]:
     """Run comprehensive analysis over one or more target functions."""
     queries = normalize_dict_list(queries)
 
-    results: list[dict] = []
+    results: List[dict] = []
     for query in queries:
         q = str(query.get("addr", "") or "").strip()
         if not q:
@@ -1233,9 +1236,9 @@ def analyze_batch(
 @tool
 @idasync
 def xrefs_to(
-    addrs: Annotated[list[str] | str, "Addresses or function names to find cross-references to (e.g. '0x11a9', 'check_pw', 'main')"],
+    addrs: Annotated[List[str] | str, "Addresses or function names to find cross-references to (e.g. '0x11a9', 'check_pw', 'main')"],
     limit: Annotated[int, "Max xrefs per address (default: 100, max: 1000)"] = 100,
-) -> list[XrefsToResult]:
+) -> List[XrefsToResult]:
     """Return xrefs to address(es) or named symbols, capped per target with truncation flag."""
     addrs = normalize_list_input(addrs)
 
@@ -1289,14 +1292,14 @@ def xrefs_to(
 @idasync
 def xref_query(
     queries: Annotated[
-        list[XrefQuery] | XrefQuery,
+        List[XrefQuery] | XrefQuery,
         "Generic xref query with direction/type filters and pagination",
     ],
-) -> list[XrefQueryResult]:
+) -> List[XrefQueryResult]:
     """Query xrefs with direction/type filters and pagination."""
     queries = normalize_dict_list(queries)
 
-    results: list[dict] = []
+    results: List[dict] = []
     for query in queries:
         q = str(query.get("addr", "")).strip()
         direction = str(query.get("direction", "both") or "both").lower()
@@ -1326,7 +1329,7 @@ def xref_query(
             if not ida_bytes.is_mapped(target):
                 raise ValueError(f"Address not mapped: {q}")
 
-            rows: list[dict] = []
+            rows: List[dict] = []
             if direction in {"to", "both"}:
                 for xr in idautils.XrefsTo(target, 0):
                     kind = "code" if xr.iscode else "data"
@@ -1412,8 +1415,8 @@ def xref_query(
 @tool
 @idasync
 def xrefs_to_field(
-    queries: list[StructFieldQuery] | StructFieldQuery,
-) -> list[StructFieldXrefsResult]:
+    queries: List[StructFieldQuery] | StructFieldQuery,
+) -> List[StructFieldXrefsResult]:
     """Get cross-references to structure fields"""
     if isinstance(queries, dict):
         queries = [queries]
@@ -1513,9 +1516,9 @@ def xrefs_to_field(
 @tool
 @idasync
 def callees(
-    addrs: Annotated[list[str] | str, "Function addresses or names to get callees for (e.g. '0x123e', 'main')"],
+    addrs: Annotated[List[str] | str, "Function addresses or names to get callees for (e.g. '0x123e', 'main')"],
     limit: Annotated[int, "Max callees per function (default: 200, max: 500)"] = 200,
-) -> list[CalleesResult]:
+) -> List[CalleesResult]:
     """Return unique callees per function, capped by limit."""
     addrs = normalize_list_input(addrs)
 
@@ -1596,11 +1599,11 @@ def callees(
 @idasync
 def find_bytes(
     patterns: Annotated[
-        list[str] | str, "Byte patterns to search for (e.g. '48 8B ?? ??')"
+        List[str] | str, "Byte patterns to search for (e.g. '48 8B ?? ??')"
     ],
     limit: Annotated[int, "Max matches per pattern (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
-) -> list[FindBytesResult]:
+) -> List[FindBytesResult]:
     """Search byte patterns (supports ??) with offset/limit pagination."""
     patterns = normalize_list_input(patterns)
 
@@ -1692,12 +1695,12 @@ def find_bytes(
 @tool
 @idasync
 def basic_blocks(
-    addrs: Annotated[list[str] | str, "Function addresses or names to get basic blocks for (e.g. '0x123e', 'main')"],
+    addrs: Annotated[List[str] | str, "Function addresses or names to get basic blocks for (e.g. '0x123e', 'main')"],
     max_blocks: Annotated[
         int, "Max basic blocks per function (default: 1000, max: 10000)"
     ] = 1000,
     offset: Annotated[int, "Skip first N blocks (default: 0)"] = 0,
-) -> list[BasicBlocksResult]:
+) -> List[BasicBlocksResult]:
     """Return function CFG blocks with offset/max_blocks pagination."""
     addrs = normalize_list_input(addrs)
 
@@ -1776,11 +1779,11 @@ def find(
         str, "Search type: 'string', 'immediate', 'data_ref', or 'code_ref'"
     ],
     targets: Annotated[
-        list[str | int] | str | int, "Search targets (strings, integers, or addresses)"
+        List[str | int] | str | int, "Search targets (strings, integers, or addresses)"
     ],
     limit: Annotated[int, "Max matches per target (default: 1000, max: 10000)"] = 1000,
     offset: Annotated[int, "Skip first N matches (default: 0)"] = 0,
-) -> list[FindResult]:
+) -> List[FindResult]:
     """Search strings/immediates/refs for targets with offset/limit pagination."""
     if not isinstance(targets, list):
         targets = [targets]
@@ -2010,7 +2013,7 @@ def find(
 
 def _resolve_insn_scan_ranges(
     pattern: dict, allow_broad: bool
-) -> tuple[list[tuple[int, int]], str | None]:
+) -> Tuple[List[Tuple[int, int]], str | None]:
     func_addr = pattern.get("func")
     segment_name = pattern.get("segment")
     start_s = pattern.get("start")
@@ -2081,7 +2084,7 @@ def _resolve_insn_scan_ranges(
 
 
 def _scan_insn_ranges(
-    ranges: list[tuple[int, int]],
+    ranges: List[Tuple[int, int]],
     mnem: str,
     op0_val: int | None,
     op1_val: int | None,
@@ -2090,8 +2093,8 @@ def _scan_insn_ranges(
     limit: int,
     offset: int,
     max_scan_insns: int,
-) -> tuple[list[str], bool, int, bool, int | None]:
-    matches: list[str] = []
+) -> Tuple[List[str], bool, int, bool, int | None]:
+    matches: List[str] = []
     skipped = 0
     scanned = 0
     more = False
@@ -2164,14 +2167,14 @@ def _scan_insn_ranges(
 @idasync
 def insn_query(
     queries: Annotated[
-        list[InsnPattern] | InsnPattern,
+        List[InsnPattern] | InsnPattern,
         "Instruction query with mnemonic/operand filters and scoped scan",
     ],
-) -> list[InsnQueryResult]:
+) -> List[InsnQueryResult]:
     """Query instructions with mnemonic/operand filters and scoped scans."""
     queries = normalize_dict_list(queries)
 
-    results: list[dict] = []
+    results: List[dict] = []
     for pattern in queries:
         mnem = str(pattern.get("mnem", "") or "").strip().lower()
         if mnem == "*":
@@ -2282,7 +2285,7 @@ def insn_query(
 @tool
 @idasync
 def export_funcs(
-    addrs: Annotated[list[str] | str, "Function addresses or names to export (e.g. '0x123e', 'main')"],
+    addrs: Annotated[List[str] | str, "Function addresses or names to export (e.g. '0x123e', 'main')"],
     format: Annotated[
         str, "Export format: json (default), c_header, or prototypes"
     ] = "json",
@@ -2350,7 +2353,7 @@ def export_funcs(
 @idasync
 def callgraph(
     roots: Annotated[
-        list[str] | str, "Root function addresses to start call graph traversal from"
+        List[str] | str, "Root function addresses to start call graph traversal from"
     ],
     max_depth: Annotated[int, "Maximum depth for call graph traversal"] = 5,
     max_nodes: Annotated[
@@ -2362,7 +2365,7 @@ def callgraph(
     max_edges_per_func: Annotated[
         int, "Max edges per function (default: 200, max: 5000)"
     ] = 200,
-) -> list[CallGraphResult]:
+) -> List[CallGraphResult]:
     """Build bounded callgraph from roots with depth/node/edge limits."""
     roots = normalize_list_input(roots)
     if max_depth < 0:

--- a/src/ida_pro_mcp/ida_mcp/api_composite.py
+++ b/src/ida_pro_mcp/ida_mcp/api_composite.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Annotated, Any, TypedDict
+from typing import Any, Dict, List, TypedDict
+from typing_extensions import Annotated
 
 from .rpc import tool, unsafe
 from .sync import idasync, tool_timeout, IDAError
@@ -46,12 +47,12 @@ class AnalyzeFunctionResult(TypedDict, total=False):
     decompile_error: str | None
     decompile_truncated: int
     assembly: str | None
-    strings: list[str]
-    constants: list[dict[str, Any]]
-    callees: list[str]
-    callers: list[str]
-    xrefs: dict[str, Any]
-    comments: dict[str, Any]
+    strings: List[str]
+    constants: List[Dict[str, Any]]
+    callees: List[str]
+    callers: List[str]
+    xrefs: Dict[str, Any]
+    comments: Dict[str, Any]
     basic_blocks: BasicBlockSummary
     error: str | None
 
@@ -61,8 +62,8 @@ class ComponentFunctionSummary(TypedDict, total=False):
     name: str
     prototype: str | None
     size: int
-    callees: list[str]
-    strings: list[str]
+    callees: List[str]
+    strings: List[str]
     basic_blocks: int
     complexity: int
     error: str
@@ -75,23 +76,23 @@ ComponentGraphEdge = TypedDict(
 
 
 class InternalCallGraph(TypedDict):
-    nodes: list[str]
-    edges: list[ComponentGraphEdge]
+    nodes: List[str]
+    edges: List[ComponentGraphEdge]
 
 
 class SharedGlobalInfo(TypedDict):
     addr: str
     name: str
-    accessed_by: list[str]
+    accessed_by: List[str]
 
 
 class AnalyzeComponentResult(TypedDict, total=False):
-    functions: list[ComponentFunctionSummary]
+    functions: List[ComponentFunctionSummary]
     internal_call_graph: InternalCallGraph
-    shared_globals: list[SharedGlobalInfo]
-    interface_functions: list[str]
-    internal_only: list[str]
-    string_usage: dict[str, list[str]]
+    shared_globals: List[SharedGlobalInfo]
+    interface_functions: List[str]
+    internal_only: List[str]
+    string_usage: Dict[str, List[str]]
     error: str
 
 
@@ -122,8 +123,8 @@ class TraceDataFlowResult(TypedDict, total=False):
     start: str
     direction: str
     depth_reached: int
-    nodes: list[TraceDataFlowNode]
-    edges: list[TraceDataFlowEdge]
+    nodes: List[TraceDataFlowNode]
+    edges: List[TraceDataFlowEdge]
     error: str
 
 
@@ -163,7 +164,7 @@ def _basic_block_info(ea: int) -> BasicBlockSummary:
     return {"count": nodes, "cyclomatic_complexity": edges - nodes + 2}
 
 
-def _filter_constants(raw: list[dict], limit: int = _TOP_CONSTANTS) -> list[dict]:
+def _filter_constants(raw: List[dict], limit: int = _TOP_CONSTANTS) -> List[dict]:
     """Drop boring constants, return top N by absolute value."""
     out = []
     for c in raw:
@@ -177,7 +178,7 @@ def _filter_constants(raw: list[dict], limit: int = _TOP_CONSTANTS) -> list[dict
     return out[:limit]
 
 
-def _cap_decompile(code: str | None) -> tuple[str | None, int | None]:
+def _cap_decompile(code: str | None) -> Tuple[str | None, int | None]:
     """Cap decompiled output at _DECOMPILE_LINE_CAP lines.
     Returns (possibly_truncated_code, total_lines_or_None)."""
     if code is None:
@@ -190,10 +191,10 @@ def _cap_decompile(code: str | None) -> tuple[str | None, int | None]:
     return truncated, total
 
 
-def _compact_strings(raw: list[dict], limit: int = _TOP_STRINGS) -> list[str]:
+def _compact_strings(raw: List[dict], limit: int = _TOP_STRINGS) -> List[str]:
     """Return just the string values, deduplicated, capped at limit."""
-    seen: set[str] = set()
-    out: list[str] = []
+    seen: Set[str] = set()
+    out: List[str] = []
     for s in raw:
         val = s.get("value") or s.get("string", "")
         if val and val not in seen:
@@ -204,7 +205,7 @@ def _compact_strings(raw: list[dict], limit: int = _TOP_STRINGS) -> list[str]:
     return out
 
 
-def _compact_callees(raw: list[dict]) -> list[str]:
+def _compact_callees(raw: List[dict]) -> List[str]:
     """Return just callee names/addresses as strings."""
     return [c.get("name") or c.get("addr", "?") for c in raw]
 
@@ -298,7 +299,7 @@ def analyze_function(
 @idasync
 @tool_timeout(180.0)
 def analyze_component(
-    addrs: Annotated[list[str] | str, "Function addresses (comma-separated or list)"],
+    addrs: Annotated[List[str] | str, "Function addresses (comma-separated or list)"],
 ) -> AnalyzeComponentResult:
     """Analyze related functions as a group: per-function summaries, internal call graph, shared data."""
 
@@ -309,7 +310,7 @@ def analyze_component(
     if not raw:
         return {"error": "Empty address list"}
 
-    ea_map: dict[int, str] = {}
+    ea_map: Dict[int, str] = {}
     for a in raw:
         try:
             ea_map[_resolve_addr(a)] = a
@@ -319,7 +320,7 @@ def analyze_component(
     ea_set = set(ea_map.keys())
 
     # --- Per-function COMPACT summary (no decompile, no disasm) ---
-    functions: list[dict] = []
+    functions: List[dict] = []
     for ea in ea_set:
         func = idaapi.get_func(ea)
         if func is None:
@@ -343,7 +344,7 @@ def analyze_component(
 
     # --- Internal call graph ---
     nodes = [hex(ea) for ea in ea_set]
-    edges: list[dict] = []
+    edges: List[dict] = []
     for ea in ea_set:
         for callee in (get_callees(hex(ea)) or []):
             callee_ea = callee.get("addr")
@@ -360,9 +361,9 @@ def analyze_component(
                 })
 
     # --- Shared globals ---
-    func_globals: dict[int, set[int]] = {}
+    func_globals: Dict[int, Set[int]] = {}
     for ea in ea_set:
-        globals_accessed: set[int] = set()
+        globals_accessed: Set[int] = set()
         func = idaapi.get_func(ea)
         if func is None:
             func_globals[ea] = globals_accessed
@@ -376,7 +377,7 @@ def analyze_component(
                     globals_accessed.add(xref.to)
         func_globals[ea] = globals_accessed
 
-    global_refcount: dict[int, list[str]] = defaultdict(list)
+    global_refcount: Dict[int, List[str]] = defaultdict(list)
     for ea, gset in func_globals.items():
         fname = idaapi.get_func_name(ea) or hex(ea)
         for g in gset:
@@ -392,8 +393,8 @@ def analyze_component(
             })
 
     # --- Interface vs internal ---
-    interface_functions: list[str] = []
-    internal_only: list[str] = []
+    interface_functions: List[str] = []
+    internal_only: List[str] = []
     for ea in ea_set:
         callers = get_callers(hex(ea))
         has_external = False
@@ -414,7 +415,7 @@ def analyze_component(
             internal_only.append(hex(ea))
 
     # --- String usage across functions ---
-    string_funcs: dict[str, set[str]] = defaultdict(set)
+    string_funcs: Dict[str, Set[str]] = defaultdict(set)
     for ea in ea_set:
         fname = idaapi.get_func_name(ea) or hex(ea)
         for s in (extract_function_strings(ea) or []):
@@ -585,13 +586,13 @@ def trace_data_flow(
     if max_depth > 20:
         max_depth = 20
 
-    visited: set[int] = set()
-    nodes: list[dict] = []
-    edges: list[dict] = []
+    visited: Set[int] = set()
+    nodes: List[dict] = []
+    edges: List[dict] = []
     depth_reached = 0
 
     # BFS queue: (ea, depth)
-    queue: deque[tuple[int, int]] = deque()
+    queue: deque[Tuple[int, int]] = deque()
     queue.append((start_ea, 0))
     visited.add(start_ea)
 

--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -1,9 +1,12 @@
 """Core API Functions - IDB metadata and basic queries"""
 
+from __future__ import annotations
 import logging
 import re
 import time
-from typing import Annotated, Any, NotRequired, TypedDict
+from typing import Any, TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 
 import ida_auto
 import ida_bytes
@@ -67,7 +70,7 @@ class ServerWarmupStep(TypedDict, total=False):
 
 class ServerWarmupResult(TypedDict):
     ok: bool
-    steps: list[ServerWarmupStep]
+    steps: List[ServerWarmupStep]
     health: ServerHealthResult
 
 
@@ -89,21 +92,21 @@ class FunctionQueryRow(Function, total=False):
 
 
 class FunctionQueryPage(TypedDict, total=False):
-    data: list[FunctionQueryRow]
+    data: List[FunctionQueryRow]
     next_offset: int | None
     error: str | None
 
 
 class EntityQueryPage(TypedDict, total=False):
     kind: str
-    data: list[dict[str, Any]]
+    data: List[Dict[str, Any]]
     next_offset: int | None
     total: int
     error: str | None
 
 
 class ImportsQueryPage(TypedDict):
-    data: list[Import]
+    data: List[Import]
     next_offset: int | None
 
 
@@ -115,8 +118,8 @@ class IdbSaveResult(TypedDict):
 
 class FindRegexResult(TypedDict, total=False):
     n: int
-    matches: list[dict[str, Any]]
-    cursor: dict[str, Any]
+    matches: List[Dict[str, Any]]
+    cursor: Dict[str, Any]
     error: str | None
 
 
@@ -129,22 +132,22 @@ class SearchTextHit(TypedDict, total=False):
     addr: str
     function: str
     segment: str
-    matches: list[SearchTextLine]
+    matches: List[SearchTextLine]
 
 
 class SearchTextResult(TypedDict, total=False):
     n: int
-    hits: list[SearchTextHit]
-    cursor: dict[str, Any]
+    hits: List[SearchTextHit]
+    cursor: Dict[str, Any]
     error: str
 
 
 # Cached strings list: [(ea, text), ...]
-_strings_cache: list[tuple[int, str]] | None = None
+_strings_cache: List[Tuple[int, str]] | None = None
 _server_started_at = time.time()
 
 
-def _get_strings_cache() -> list[tuple[int, str]]:
+def _get_strings_cache() -> List[Tuple[int, str]]:
     """Get cached strings, building cache on first access."""
     global _strings_cache
     if _strings_cache is None:
@@ -204,9 +207,9 @@ def _coerce_sort_number(value, default: int = 0) -> int:
         return default
 
 
-def _collect_imports() -> list[Import]:
+def _collect_imports() -> List[Import]:
     """Collect all imports in the current database."""
-    all_imports: list[Import] = []
+    all_imports: List[Import] = []
     nimps = ida_nalt.get_import_module_qty()
 
     for i in range(nimps):
@@ -244,9 +247,9 @@ def _primary_text_key(kind: str) -> str:
     return "name"
 
 
-def _collect_entities(kind: str) -> list[dict]:
+def _collect_entities(kind: str) -> List[dict]:
     if kind == "functions":
-        rows: list[dict] = []
+        rows: List[dict] = []
         for ea in idautils.Functions():
             fn = idaapi.get_func(ea)
             if not fn:
@@ -329,7 +332,7 @@ def _collect_entities(kind: str) -> list[dict]:
     return []
 
 
-def _apply_projection(items: list[dict], fields: list[str] | None) -> list[dict]:
+def _apply_projection(items: List[dict], fields: List[str] | None) -> List[dict]:
     if not fields:
         return items
     normalized = [str(f).strip() for f in fields if str(f).strip()]
@@ -433,8 +436,8 @@ def server_warmup(
 @tool
 @idasync
 def lookup_funcs(
-    queries: Annotated[list[str] | str, "Address(es) or name(s)"],
-) -> list[LookupFuncResult]:
+    queries: Annotated[List[str] | str, "Address(es) or name(s)"],
+) -> List[LookupFuncResult]:
     """Get functions by address or name (auto-detects)"""
     queries = normalize_list_input(queries)
 
@@ -476,10 +479,10 @@ def lookup_funcs(
 @tool
 def int_convert(
     inputs: Annotated[
-        list[NumberConversion] | NumberConversion,
+        List[NumberConversion] | NumberConversion,
         "Convert numbers to various formats (hex, decimal, binary, ascii)",
     ],
-) -> list[IntConvertResult]:
+) -> List[IntConvertResult]:
     """Convert numbers to different formats"""
     inputs = normalize_dict_list(inputs, lambda s: {"text": s, "size": 64})
 
@@ -546,10 +549,10 @@ def int_convert(
 @idasync
 def list_funcs(
     queries: Annotated[
-        list[ListQuery] | ListQuery,
+        List[ListQuery] | ListQuery,
         "List functions with optional filtering and pagination",
     ],
-) -> list[Page[Function]]:
+) -> List[Page[Function]]:
     """List functions with optional filtering and offset/count pagination."""
     queries = normalize_dict_list(queries)
     all_functions = [get_function(addr) for addr in idautils.Functions()]
@@ -574,14 +577,14 @@ def list_funcs(
 @idasync
 def func_query(
     queries: Annotated[
-        list[FunctionQuery] | FunctionQuery,
+        List[FunctionQuery] | FunctionQuery,
         "Richer function query (size/type/name filters + pagination)",
     ],
-) -> list[FunctionQueryPage]:
+) -> List[FunctionQueryPage]:
     """Query functions with richer filtering than list_funcs."""
     queries = normalize_dict_list(queries)
 
-    all_functions: list[dict] = []
+    all_functions: List[dict] = []
     for addr in idautils.Functions():
         fn = idaapi.get_func(addr)
         if not fn:
@@ -599,7 +602,7 @@ def func_query(
             }
         )
 
-    def apply_name_regex(items: list[dict], expr: str) -> list[dict]:
+    def apply_name_regex(items: List[dict], expr: str) -> List[dict]:
         if not expr:
             return items
         try:
@@ -656,13 +659,13 @@ def func_query(
 @idasync
 def list_globals(
     queries: Annotated[
-        list[ListQuery] | ListQuery,
+        List[ListQuery] | ListQuery,
         "List global variables with optional filtering and pagination",
     ],
-) -> list[Page[Global]]:
+) -> List[Page[Global]]:
     """List globals with optional filtering and offset/count pagination."""
     queries = normalize_dict_list(queries)
-    all_globals: list[Global] = []
+    all_globals: List[Global] = []
     for addr, name in idautils.Names():
         if not idaapi.get_func(addr) and name is not None:
             all_globals.append(Global(addr=hex(addr), name=name))
@@ -687,13 +690,13 @@ def list_globals(
 @idasync
 def entity_query(
     queries: Annotated[
-        list[EntityQuery] | EntityQuery,
+        List[EntityQuery] | EntityQuery,
         "Generic entity query with filtering, projection, and pagination",
     ],
-) -> list[EntityQueryPage]:
+) -> List[EntityQueryPage]:
     """Query IDB entities with typed filters, projection, and pagination."""
     queries = normalize_dict_list(queries)
-    results: list[dict] = []
+    results: List[dict] = []
 
     for query in queries:
         kind = str(query.get("kind", "functions") or "functions").lower()
@@ -802,10 +805,10 @@ def imports(
 @idasync
 def imports_query(
     queries: Annotated[
-        list[ImportQuery] | ImportQuery,
+        List[ImportQuery] | ImportQuery,
         "Import query with import/module filters and pagination",
     ],
-) -> list[ImportsQueryPage]:
+) -> List[ImportsQueryPage]:
     """Query imports with richer filtering than imports(offset,count)."""
     queries = normalize_dict_list(queries)
     all_imports = _collect_imports()
@@ -941,9 +944,9 @@ def _classify_hit_lines(
     want_disasm: bool,
     want_comments: bool,
     max_lines: int = 32,
-) -> list[SearchTextLine]:
+) -> List[SearchTextLine]:
     """Render the listing for `ea` once, classify each line, return matching lines."""
-    out: list[SearchTextLine] = []
+    out: List[SearchTextLine] = []
     try:
         result = ida_lines.generate_disassembly(ea, max_lines, False, False)
     except Exception:
@@ -972,9 +975,9 @@ def _classify_hit_lines(
     return out
 
 
-def _exec_segments() -> list[tuple[int, int]]:
+def _exec_segments() -> List[Tuple[int, int]]:
     """Return [(start, end)] for executable segments in address order."""
-    ranges: list[tuple[int, int]] = []
+    ranges: List[Tuple[int, int]] = []
     for seg_ea in idautils.Segments():
         seg = idaapi.getseg(seg_ea)
         if not seg:
@@ -985,8 +988,8 @@ def _exec_segments() -> list[tuple[int, int]]:
     return ranges
 
 
-def _all_segments() -> list[tuple[int, int]]:
-    ranges: list[tuple[int, int]] = []
+def _all_segments() -> List[Tuple[int, int]]:
+    ranges: List[Tuple[int, int]] = []
     for seg_ea in idautils.Segments():
         seg = idaapi.getseg(seg_ea)
         if seg:
@@ -1068,7 +1071,7 @@ def search_text(
     if end_ea <= start_ea:
         return {"n": 0, "hits": [], "cursor": {"done": True}}
 
-    hits: list[SearchTextHit] = []
+    hits: List[SearchTextHit] = []
     next_cursor: int | None = None
     cancelled = False
     # Chunk the address space into fixed-size windows and call Heads() per
@@ -1125,7 +1128,7 @@ def search_text(
                     break
             chunk_ea = chunk_end
 
-    cursor: dict[str, Any]
+    cursor: Dict[str, Any]
     if cancelled:
         cursor = {"next": hex(next_cursor), "cancelled": True}
     elif next_cursor is not None:

--- a/src/ida_pro_mcp/ida_mcp/api_debug.py
+++ b/src/ida_pro_mcp/ida_mcp/api_debug.py
@@ -8,8 +8,11 @@ This module provides comprehensive debugging functionality including:
 - Call stack inspection
 """
 
+from __future__ import annotations
 import os
-from typing import Annotated, NotRequired, TypedDict
+from typing import TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 
 import idc
 import ida_dbg
@@ -211,7 +214,7 @@ def _get_registers_general_for_thread(
 
 
 def _get_registers_specific_for_thread(
-    dbg: "ida_idd.debugger_t", tid: int, register_names: list[str]
+    dbg: "ida_idd.debugger_t", tid: int, register_names: List[str]
 ) -> ThreadRegisters:
     """Helper to get specific registers for a given thread."""
     all_registers = _get_registers_for_thread(dbg, tid)
@@ -260,8 +263,8 @@ def _set_breakpoint_language(bpt: ida_dbg.bpt_t, language: str) -> None:
         ) from exc
 
 
-def list_breakpoints() -> list[Breakpoint]:
-    breakpoints: list[Breakpoint] = []
+def list_breakpoints() -> List[Breakpoint]:
+    breakpoints: List[Breakpoint] = []
     for i in range(ida_dbg.get_bpt_qty()):
         bpt = ida_dbg.bpt_t()
         if ida_dbg.getn_bpt(i, bpt):
@@ -539,7 +542,7 @@ def dbg_step_over() -> DebugControlResult:
 @unsafe
 @tool
 @idasync
-def dbg_bps() -> list[Breakpoint]:
+def dbg_bps() -> List[Breakpoint]:
     """List breakpoints with address, enabled status, condition, and language."""
     return list_breakpoints()
 
@@ -549,8 +552,8 @@ def dbg_bps() -> list[Breakpoint]:
 @tool
 @idasync
 def dbg_add_bp(
-    addrs: Annotated[list[str] | str, "Address(es) to add breakpoints at"],
-) -> list[BreakpointResult]:
+    addrs: Annotated[List[str] | str, "Address(es) to add breakpoints at"],
+) -> List[BreakpointResult]:
     """Add breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -579,8 +582,8 @@ def dbg_add_bp(
 @tool
 @idasync
 def dbg_delete_bp(
-    addrs: Annotated[list[str] | str, "Address(es) to delete breakpoints from"],
-) -> list[BreakpointResult]:
+    addrs: Annotated[List[str] | str, "Address(es) to delete breakpoints from"],
+) -> List[BreakpointResult]:
     """Delete breakpoints at one or more addresses."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -603,8 +606,8 @@ def dbg_delete_bp(
 @tool
 @idasync
 def dbg_toggle_bp(
-    items: list[BreakpointOp] | BreakpointOp,
-) -> list[BreakpointResult]:
+    items: List[BreakpointOp] | BreakpointOp,
+) -> List[BreakpointResult]:
     """Enable or disable existing breakpoints in batch."""
 
     items = normalize_dict_list(items)
@@ -636,8 +639,8 @@ def dbg_toggle_bp(
 @tool
 @idasync
 def dbg_set_bp_condition(
-    items: list[BreakpointConditionOp] | BreakpointConditionOp,
-) -> list[BreakpointResult]:
+    items: List[BreakpointConditionOp] | BreakpointConditionOp,
+) -> List[BreakpointResult]:
     """Set or clear breakpoint conditions in batch."""
 
     items = normalize_dict_list(items)
@@ -738,9 +741,9 @@ def dbg_set_bp_condition(
 @unsafe
 @tool
 @idasync
-def dbg_regs_all() -> list[ThreadRegisters]:
+def dbg_regs_all() -> List[ThreadRegisters]:
     """Return full register sets for all debugger threads."""
-    result: list[ThreadRegisters] = []
+    result: List[ThreadRegisters] = []
     dbg = dbg_ensure_suspended()
     for thread_index in range(ida_dbg.get_thread_qty()):
         tid = ida_dbg.getn_thread(thread_index)
@@ -753,8 +756,8 @@ def dbg_regs_all() -> list[ThreadRegisters]:
 @tool
 @idasync
 def dbg_regs_remote(
-    tids: Annotated[list[int] | int, "Thread ID(s) to get registers for"],
-) -> list[ThreadRegistersResult]:
+    tids: Annotated[List[int] | int, "Thread ID(s) to get registers for"],
+) -> List[ThreadRegistersResult]:
     """Return full register sets for specified thread IDs."""
     if isinstance(tids, int):
         tids = [tids]
@@ -794,8 +797,8 @@ def dbg_regs() -> ThreadRegisters:
 @tool
 @idasync
 def dbg_gpregs_remote(
-    tids: Annotated[list[int] | int, "Thread ID(s) to get GP registers for"],
-) -> list[ThreadRegistersResult]:
+    tids: Annotated[List[int] | int, "Thread ID(s) to get GP registers for"],
+) -> List[ThreadRegistersResult]:
     """Get GP registers for threads"""
     if isinstance(tids, int):
         tids = [tids]
@@ -875,7 +878,7 @@ def dbg_regs_named(
 @unsafe
 @tool
 @idasync
-def dbg_stacktrace() -> list[StackFrameInfo]:
+def dbg_stacktrace() -> List[StackFrameInfo]:
     """Return current call stack with module and symbol context."""
     callstack = []
     try:
@@ -928,8 +931,8 @@ def dbg_stacktrace() -> list[StackFrameInfo]:
 @tool
 @idasync
 def dbg_read(
-    regions: list[MemoryRead] | MemoryRead,
-) -> list[DebugMemoryReadResult]:
+    regions: List[MemoryRead] | MemoryRead,
+) -> List[DebugMemoryReadResult]:
     """Read debuggee memory from one or more regions."""
 
     regions = normalize_dict_list(regions)
@@ -974,8 +977,8 @@ def dbg_read(
 @tool
 @idasync
 def dbg_write(
-    regions: list[MemoryPatch] | MemoryPatch,
-) -> list[DebugMemoryWriteResult]:
+    regions: List[MemoryPatch] | MemoryPatch,
+) -> List[DebugMemoryWriteResult]:
     """Write bytes to debuggee memory regions."""
 
     regions = normalize_dict_list(regions)

--- a/src/ida_pro_mcp/ida_mcp/api_memory.py
+++ b/src/ida_pro_mcp/ida_mcp/api_memory.py
@@ -4,9 +4,12 @@ This module provides batch operations for reading and writing memory at various
 granularities (bytes, integers, strings) and patching binary data.
 """
 
+from __future__ import annotations
 import re
 
-from typing import Annotated, NotRequired, TypedDict
+from typing import TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 import ida_bytes
 import idaapi
 
@@ -69,7 +72,7 @@ class IntWriteResult(TypedDict):
 
 @tool
 @idasync
-def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[BytesReadResult]:
+def get_bytes(regions: List[MemoryRead] | MemoryRead) -> List[BytesReadResult]:
     """Read bytes from memory addresses"""
     if isinstance(regions, dict):
         regions = [regions]
@@ -93,7 +96,7 @@ def get_bytes(regions: list[MemoryRead] | MemoryRead) -> list[BytesReadResult]:
 _INT_CLASS_RE = re.compile(r"^(?P<sign>[iu])(?P<bits>8|16|32|64)(?P<endian>le|be)?$")
 
 
-def _parse_int_class(text: str) -> tuple[int, bool, str, str]:
+def _parse_int_class(text: str) -> Tuple[int, bool, str, str]:
     if not text:
         raise ValueError("Missing integer class")
 
@@ -130,10 +133,10 @@ def _parse_int_value(text: str, signed: bool, bits: int) -> int:
 @idasync
 def get_int(
     queries: Annotated[
-        list[IntRead] | IntRead,
+        List[IntRead] | IntRead,
         "Integer read requests (ty, addr). ty: i8/u64/i16le/i16be/etc",
     ],
-) -> list[IntReadResult]:
+) -> List[IntReadResult]:
     """Read integer values from memory addresses"""
     if isinstance(queries, dict):
         queries = [queries]
@@ -164,8 +167,8 @@ def get_int(
 @tool
 @idasync
 def get_string(
-    addrs: Annotated[list[str] | str, "Addresses to read strings from"],
-) -> list[StringReadResult]:
+    addrs: Annotated[List[str] | str, "Addresses to read strings from"],
+) -> List[StringReadResult]:
     """Read strings from memory addresses"""
     addrs = normalize_list_input(addrs)
     results = []
@@ -220,9 +223,9 @@ def get_global_variable_value_internal(ea: int) -> str:
 @idasync
 def get_global_value(
     queries: Annotated[
-        list[str] | str, "Global variable addresses or names to read values from"
+        List[str] | str, "Global variable addresses or names to read values from"
     ],
-) -> list[GlobalValueResult]:
+) -> List[GlobalValueResult]:
     """Read global variable values by address or symbol name."""
     from .utils import looks_like_address
 
@@ -263,7 +266,7 @@ def get_global_value(
 
 @tool
 @idasync
-def patch(patches: list[MemoryPatch] | MemoryPatch) -> list[PatchResult]:
+def patch(patches: List[MemoryPatch] | MemoryPatch) -> List[PatchResult]:
     """Patch bytes at memory addresses with hex data"""
     if isinstance(patches, dict):
         patches = [patches]
@@ -293,10 +296,10 @@ def patch(patches: list[MemoryPatch] | MemoryPatch) -> list[PatchResult]:
 @idasync
 def put_int(
     items: Annotated[
-        list[IntWrite] | IntWrite,
+        List[IntWrite] | IntWrite,
         "Integer write requests (ty, addr, value). value is a string; supports 0x.. and negatives",
     ],
-) -> list[IntWriteResult]:
+) -> List[IntWriteResult]:
     """Write integer values to memory addresses"""
     if isinstance(items, dict):
         items = [items]

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -1,4 +1,7 @@
-from typing import Annotated, Any, NotRequired, TypedDict
+from __future__ import annotations
+from typing import Any, TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 
 import idaapi
 import idautils
@@ -78,11 +81,11 @@ class RenameSummaryResult(TypedDict, total=False):
 
 
 class RenameResult(TypedDict, total=False):
-    func: list[RenameItemResult]
-    data: list[RenameItemResult]
-    global_alias: list[RenameItemResult]
-    local: list[RenameItemResult]
-    stack: list[RenameItemResult]
+    func: List[RenameItemResult]
+    data: List[RenameItemResult]
+    global_alias: List[RenameItemResult]
+    local: List[RenameItemResult]
+    stack: List[RenameItemResult]
     summary: RenameSummaryResult
 
 
@@ -161,7 +164,7 @@ def add_bookmark(
 
 @tool
 @idasync
-def set_comments(items: list[CommentOp] | CommentOp) -> list[CommentResult]:
+def set_comments(items: List[CommentOp] | CommentOp) -> List[CommentResult]:
     """Set comments at addresses (both disassembly and decompiler views)"""
     if isinstance(items, dict):
         items = [items]
@@ -242,8 +245,8 @@ def set_comments(items: list[CommentOp] | CommentOp) -> list[CommentResult]:
 @tool
 @idasync
 def append_comments(
-    items: list[CommentAppendOp] | CommentAppendOp,
-) -> list[AppendCommentResult]:
+    items: List[CommentAppendOp] | CommentAppendOp,
+) -> List[AppendCommentResult]:
     """Append comments at addresses, deduping exact text by default."""
     if isinstance(items, dict):
         items = [items]
@@ -307,7 +310,7 @@ def append_comments(
     return results
 
 
-def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> tuple[str, bool]:
+def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> Tuple[str, bool]:
     normalized_new = new_text.strip()
     if dedupe and normalized_new:
         existing_entries = [line.strip() for line in current.splitlines()]
@@ -323,7 +326,7 @@ def _append_comment_text(current: str, new_text: str, *, dedupe: bool) -> tuple[
 
 @tool
 @idasync
-def patch_asm(items: list[AsmPatchOp] | AsmPatchOp) -> list[PatchAsmResult]:
+def patch_asm(items: List[AsmPatchOp] | AsmPatchOp) -> List[PatchAsmResult]:
     """Patch assembly instructions at addresses"""
     if isinstance(items, dict):
         items = [items]
@@ -369,7 +372,7 @@ def rename_at_ea(
     *,
     allow_overwrite: bool = False,
     dry_run: bool = False,
-) -> tuple[bool, str | None]:
+) -> Tuple[bool, str | None]:
     """Rename at address with detailed error reporting."""
     conflict_ea = idaapi.get_name_ea(idaapi.BADADDR, new_name)
     if (
@@ -436,7 +439,7 @@ def rename(
             pass
         return False
 
-    def _set_name_checked(ea: int, new_name: str) -> tuple[bool, str | None]:
+    def _set_name_checked(ea: int, new_name: str) -> Tuple[bool, str | None]:
         return rename_at_ea(
             ea,
             new_name,
@@ -444,7 +447,7 @@ def rename(
             dry_run=dry_run,
         )
 
-    def _place_func_in_vibe_dir(ea: int) -> tuple[bool, str | None]:
+    def _place_func_in_vibe_dir(ea: int) -> Tuple[bool, str | None]:
         if dry_run:
             return True, None
 
@@ -475,8 +478,8 @@ def rename(
 
         return True, None
 
-    def _rename_funcs(items: list[FunctionRename]) -> tuple[list[dict], bool]:
-        results: list[dict] = []
+    def _rename_funcs(items: List[FunctionRename]) -> Tuple[List[dict], bool]:
+        results: List[dict] = []
         halted = False
         for item in items:
             try:
@@ -542,8 +545,8 @@ def rename(
                     break
         return results, halted
 
-    def _rename_globals(items: list[GlobalRename]) -> tuple[list[dict], bool]:
-        results: list[dict] = []
+    def _rename_globals(items: List[GlobalRename]) -> Tuple[List[dict], bool]:
+        results: List[dict] = []
         halted = False
         for item in items:
             try:
@@ -611,8 +614,8 @@ def rename(
                     break
         return results, halted
 
-    def _rename_locals(items: list[LocalRename]) -> tuple[list[dict], bool]:
-        results: list[dict] = []
+    def _rename_locals(items: List[LocalRename]) -> Tuple[List[dict], bool]:
+        results: List[dict] = []
         halted = False
         for item in items:
             try:
@@ -696,8 +699,8 @@ def rename(
                     break
         return results, halted
 
-    def _rename_stack(items: list[StackRename]) -> tuple[list[dict], bool]:
-        results: list[dict] = []
+    def _rename_stack(items: List[StackRename]) -> Tuple[List[dict], bool]:
+        results: List[dict] = []
         halted = False
         for item in items:
             try:
@@ -904,7 +907,7 @@ def rename(
 
 @tool
 @idasync
-def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
+def define_func(items: List[DefineOp] | DefineOp) -> List[DefineResult]:
     """Define functions; IDA infers bounds unless end is provided."""
     if isinstance(items, dict):
         items = [items]
@@ -956,7 +959,7 @@ def define_func(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
 
 @tool
 @idasync
-def define_code(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
+def define_code(items: List[DefineOp] | DefineOp) -> List[DefineResult]:
     """Convert bytes to code instruction(s) at address(es)."""
     if isinstance(items, dict):
         items = [items]
@@ -988,7 +991,7 @@ def define_code(items: list[DefineOp] | DefineOp) -> list[DefineResult]:
 
 @tool
 @idasync
-def undefine(items: list[UndefineOp] | UndefineOp) -> list[DefineResult]:
+def undefine(items: List[UndefineOp] | UndefineOp) -> List[DefineResult]:
     """Undefine item(s) at address(es), converting back to raw bytes."""
     if isinstance(items, dict):
         items = [items]
@@ -1055,7 +1058,7 @@ class ForceRecompileResult(TypedDict, total=False):
 @idasync
 def force_recompile(
     items: Annotated[
-        list[ForceRecompileOp] | ForceRecompileOp,
+        List[ForceRecompileOp] | ForceRecompileOp,
         "List of {addr: function-entry-EA} ops, or a single op. Omit / pass empty list to recompile every function.",
     ] = None,
 ) -> dict:
@@ -1065,7 +1068,7 @@ def force_recompile(
     `make_data` so the next `decompile` call regenerates fresh pseudocode
     instead of returning a cached, stale view.
     """
-    targets: list[int] = []
+    targets: List[int] = []
     invalidate_all = False
 
     if items is None:
@@ -1090,7 +1093,7 @@ def force_recompile(
             except Exception:
                 pass
 
-    results: list[ForceRecompileResult] = []
+    results: List[ForceRecompileResult] = []
     for ea in targets:
         try:
             ida_hexrays.mark_cfunc_dirty(ea)
@@ -1143,10 +1146,10 @@ _OP_FORMAT_FLAGS = {
 @idasync
 def set_op_type(
     items: Annotated[
-        list[SetOpTypeOp] | SetOpTypeOp,
+        List[SetOpTypeOp] | SetOpTypeOp,
         "Operand-typing ops. Equivalent to GUI 'Y' (struct offset) or 'O' (offset) operations.",
     ],
-) -> list[SetOpTypeResult]:
+) -> List[SetOpTypeResult]:
     """Set the type of an instruction operand. GUI 'Y' / 'O' / '#' equivalent.
 
     Tags an operand at a specific instruction with a desired interpretation.
@@ -1162,7 +1165,7 @@ def set_op_type(
     if isinstance(items, dict):
         items = [items]
 
-    results: list[SetOpTypeResult] = []
+    results: List[SetOpTypeResult] = []
     for item in items:
         addr_str = item.get("addr", "")
         op_n = int(item.get("op_n", 0))
@@ -1242,10 +1245,10 @@ class MakeDataResult(TypedDict, total=False):
 @idasync
 def make_data(
     items: Annotated[
-        list[MakeDataOp] | MakeDataOp,
+        List[MakeDataOp] | MakeDataOp,
         "Data-creation ops. Each {addr, type, name?} replaces existing data items at addr with a fresh symbol of the given type.",
     ],
-) -> list[MakeDataResult]:
+) -> List[MakeDataResult]:
     """Create a typed data symbol at an address, replacing any prior items.
 
     Use this to harden a symbol boundary that the decompiler is currently
@@ -1260,7 +1263,7 @@ def make_data(
     if isinstance(items, dict):
         items = [items]
 
-    results: list[MakeDataResult] = []
+    results: List[MakeDataResult] = []
     for item in items:
         addr_str = item.get("addr", "")
         type_decl = str(item.get("type", "")).strip()

--- a/src/ida_pro_mcp/ida_mcp/api_python.py
+++ b/src/ida_pro_mcp/ida_mcp/api_python.py
@@ -1,4 +1,6 @@
-from typing import Annotated, TypedDict
+from __future__ import annotations
+from typing import TypedDict
+from typing_extensions import Annotated
 import ast
 import io
 import sys

--- a/src/ida_pro_mcp/ida_mcp/api_resources.py
+++ b/src/ida_pro_mcp/ida_mcp/api_resources.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
 """MCP Resources - browsable IDB state
 
 Resources represent browsable state (read-only data) following MCP's philosophy.
 Use tools for actions that modify state or perform expensive computations.
 """
 
-from typing import Annotated
+from typing_extensions import Annotated
 
 import ida_nalt
 import ida_segment
@@ -69,7 +70,7 @@ def idb_metadata_resource() -> Metadata:
 
 @resource("ida://idb/segments")
 @idasync
-def idb_segments_resource() -> list[Segment]:
+def idb_segments_resource() -> List[Segment]:
     """Get all memory segments with permissions"""
     segments = []
     for seg_ea in idautils.Segments():
@@ -97,7 +98,7 @@ def idb_segments_resource() -> list[Segment]:
 
 @resource("ida://idb/entrypoints")
 @idasync
-def idb_entrypoints_resource() -> list[dict]:
+def idb_entrypoints_resource() -> List[dict]:
     """Get entry points (main, TLS callbacks, etc.)"""
     entrypoints = []
     entry_count = compat.get_entry_qty()
@@ -154,7 +155,7 @@ def selection_resource() -> dict:
 
 @resource("ida://types")
 @idasync
-def types_resource() -> list[dict]:
+def types_resource() -> List[dict]:
     """Get all local types"""
     types = []
     for ordinal in range(1, compat.get_ordinal_limit(None)):
@@ -167,7 +168,7 @@ def types_resource() -> list[dict]:
 
 @resource("ida://structs")
 @idasync
-def structs_resource() -> list[dict]:
+def structs_resource() -> List[dict]:
     """Get all structures/unions"""
     structs = []
     limit = compat.get_ordinal_limit()
@@ -278,7 +279,7 @@ def export_name_resource(name: Annotated[str, "Export name"]) -> dict:
 
 @resource("ida://xrefs/from/{addr}")
 @idasync
-def xrefs_from_resource(addr: Annotated[str, "Source address"]) -> list[dict]:
+def xrefs_from_resource(addr: Annotated[str, "Source address"]) -> List[dict]:
     """Get cross-references from address"""
     ea = parse_address(addr)
     xrefs = []

--- a/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
+++ b/src/ida_pro_mcp/ida_mcp/api_sigmaker.py
@@ -7,7 +7,10 @@ This module integrates sigmaker.py functionality to provide:
 - Multiple output formats: IDA, x64dbg, mask, bitmask
 """
 
-from typing import Annotated, NotRequired, TypedDict
+from __future__ import annotations
+from typing import TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 
 import idaapi
 import ida_funcs
@@ -99,7 +102,7 @@ class MakeSigForFunctionResult(TypedDict):
 class XrefSigResult(TypedDict):
     query: str
     addr: str | None
-    signatures: list[dict] | None
+    signatures: List[dict] | None
     total_xrefs: NotRequired[int]
     error: NotRequired[str]
 
@@ -113,7 +116,7 @@ class XrefSigResult(TypedDict):
 @idasync
 def make_signature(
     addrs: Annotated[
-        list[str] | str,
+        List[str] | str,
         "Address(es) or name(s) to create unique signatures for "
         "(e.g. '0x401000', 'main', or ['0x401000', 'sub_402000'])",
     ],
@@ -129,7 +132,7 @@ def make_signature(
         int,
         "Maximum signature length in bytes before giving up (default: 1000)",
     ] = 1000,
-) -> list[MakeSigResult]:
+) -> List[MakeSigResult]:
     """Create unique byte signatures for addresses. Generates the shortest
     unique signature starting at each address by walking instructions and
     wildcarding operands. Useful for finding stable patterns that survive
@@ -140,7 +143,7 @@ def make_signature(
     maker = sm.SignatureMaker()
     addrs_list = normalize_list_input(addrs)
 
-    results: list[MakeSigResult] = []
+    results: List[MakeSigResult] = []
     for addr_str in addrs_list:
         try:
             ea = _resolve_addr(addr_str)
@@ -170,7 +173,7 @@ def make_signature(
 @idasync
 def make_signature_for_function(
     addrs: Annotated[
-        list[str] | str,
+        List[str] | str,
         "Function address(es) or name(s) to create signatures for "
         "(e.g. 'main', '0x401000', or ['main', 'sub_402000'])",
     ],
@@ -186,7 +189,7 @@ def make_signature_for_function(
         int,
         "Maximum signature length in bytes before giving up (default: 1000)",
     ] = 1000,
-) -> list[MakeSigForFunctionResult]:
+) -> List[MakeSigForFunctionResult]:
     """Create unique byte signatures for function entry points. Resolves each
     name/address to a function, then generates the shortest unique signature
     starting at the function start."""
@@ -196,7 +199,7 @@ def make_signature_for_function(
     maker = sm.SignatureMaker()
     addrs_list = normalize_list_input(addrs)
 
-    results: list[MakeSigForFunctionResult] = []
+    results: List[MakeSigForFunctionResult] = []
     for addr_str in addrs_list:
         ea = None
         try:
@@ -285,7 +288,7 @@ def make_signature_for_range(
 @idasync
 def find_xref_signatures(
     addrs: Annotated[
-        list[str] | str,
+        List[str] | str,
         "Address(es) or name(s) to find XREF signatures for "
         "(e.g. a data address referenced by code)",
     ],
@@ -301,7 +304,7 @@ def find_xref_signatures(
         int,
         "Maximum signature length in bytes (default: 250)",
     ] = 250,
-) -> list[XrefSigResult]:
+) -> List[XrefSigResult]:
     """Find signatures for code locations that reference an address. For each
     input address, finds all code cross-references TO it, generates a unique
     signature at each xref site, and returns the shortest ones. Ideal for
@@ -315,7 +318,7 @@ def find_xref_signatures(
     finder = sm.XrefFinder()
     addrs_list = normalize_list_input(addrs)
 
-    results: list[XrefSigResult] = []
+    results: List[XrefSigResult] = []
     for addr_str in addrs_list:
         ea = None
         try:

--- a/src/ida_pro_mcp/ida_mcp/api_stack.py
+++ b/src/ida_pro_mcp/ida_mcp/api_stack.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
 """Stack frame operations for IDA Pro MCP.
 
 This module provides batch operations for managing stack frame variables,
 including reading, creating, and deleting stack variables in functions.
 """
 
-from typing import Annotated, NotRequired, TypedDict
+from typing import TypedDict
+from typing_extensions import Annotated
+from typing_extensions import NotRequired
 import ida_typeinf
 import ida_frame
 import idaapi
@@ -26,7 +29,7 @@ from .utils import (
 
 class StackFrameResult(TypedDict):
     addr: str
-    vars: list[StackFrameVariable] | None
+    vars: List[StackFrameVariable] | None
     error: NotRequired[str]
 
 
@@ -44,8 +47,8 @@ class StackMutationResult(TypedDict):
 @tool
 @idasync
 def stack_frame(
-    addrs: Annotated[list[str] | str, "Address(es)"]
-) -> list[StackFrameResult]:
+    addrs: Annotated[List[str] | str, "Address(es)"]
+) -> List[StackFrameResult]:
     """Return stack variables for function address(es)."""
     addrs = normalize_list_input(addrs)
     results = []
@@ -64,8 +67,8 @@ def stack_frame(
 @tool
 @idasync
 def declare_stack(
-    items: list[StackVarDecl] | StackVarDecl,
-) -> list[StackMutationResult]:
+    items: List[StackVarDecl] | StackVarDecl,
+) -> List[StackMutationResult]:
     """Create stack variables from typed stack declarations."""
     items = normalize_dict_list(items)
     results = []
@@ -109,8 +112,8 @@ def declare_stack(
 @tool
 @idasync
 def delete_stack(
-    items: list[StackVarDelete] | StackVarDelete,
-) -> list[StackMutationResult]:
+    items: List[StackVarDelete] | StackVarDelete,
+) -> List[StackMutationResult]:
     """Delete stack variables by name or offset."""
 
     items = normalize_dict_list(items)

--- a/src/ida_pro_mcp/ida_mcp/api_survey.py
+++ b/src/ida_pro_mcp/ida_mcp/api_survey.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 import re
 from itertools import islice
-from typing import Annotated, TypedDict
+from typing import TypedDict
+from typing_extensions import Annotated
 
 from .rpc import tool
 from .sync import idasync, tool_timeout
@@ -69,28 +70,28 @@ class SurveyImportEntry(TypedDict):
 
 
 class SurveyImportsByCategory(TypedDict):
-    crypto: list[SurveyImportEntry]
-    network: list[SurveyImportEntry]
-    file_io: list[SurveyImportEntry]
-    process: list[SurveyImportEntry]
-    registry: list[SurveyImportEntry]
-    other: list[SurveyImportEntry]
+    crypto: List[SurveyImportEntry]
+    network: List[SurveyImportEntry]
+    file_io: List[SurveyImportEntry]
+    process: List[SurveyImportEntry]
+    registry: List[SurveyImportEntry]
+    other: List[SurveyImportEntry]
 
 
 class SurveyCallGraphSummary(TypedDict):
     total_edges: int
     max_depth_estimate: None
-    root_functions: list[str]
+    root_functions: List[str]
     leaf_functions_count: int
 
 
 class SurveyBinaryResult(TypedDict, total=False):
     metadata: SurveyMetadata
     statistics: SurveyStatistics
-    segments: list[SurveySegmentInfo]
-    entrypoints: list[SurveyEntrypoint]
-    interesting_strings: list[SurveyInterestingString]
-    interesting_functions: list[SurveyInterestingFunction]
+    segments: List[SurveySegmentInfo]
+    entrypoints: List[SurveyEntrypoint]
+    interesting_strings: List[SurveyInterestingString]
+    interesting_functions: List[SurveyInterestingFunction]
     imports_by_category: SurveyImportsByCategory
     call_graph_summary: SurveyCallGraphSummary
     _note: str
@@ -106,7 +107,7 @@ _MAX_XREFS_PER_STRING = 200
 
 # Import category rules: keyword -> category name.
 # Order matters: first match wins.
-_IMPORT_CATEGORIES: list[tuple[str, re.Pattern[str]]] = [
+_IMPORT_CATEGORIES: List[Tuple[str, re.Pattern[str]]] = [
     ("crypto", re.compile(r"crypt|aes|sha[^r]|md5|hash|rsa|\bssl\b|\btls\b|\bcert", re.IGNORECASE)),
     ("network", re.compile(r"socket|connect|send|recv|http|url|internet|ws2|winsock", re.IGNORECASE)),
     ("process", re.compile(r"process|thread|terminate|execute|shell|pipe|virtual", re.IGNORECASE)),
@@ -153,7 +154,7 @@ def _build_metadata() -> dict:
     }
 
 
-def _build_segments() -> list[dict]:
+def _build_segments() -> List[dict]:
     import idaapi
     import idautils
     import ida_segment
@@ -180,7 +181,7 @@ def _build_segments() -> list[dict]:
     return segments
 
 
-def _build_entrypoints() -> list[dict]:
+def _build_entrypoints() -> List[dict]:
     entrypoints = []
     entry_count = compat.get_entry_qty()
     for i in range(entry_count):
@@ -191,7 +192,7 @@ def _build_entrypoints() -> list[dict]:
     return entrypoints
 
 
-def _build_statistics(func_eas: list[int], string_count: int, segment_count: int) -> dict:
+def _build_statistics(func_eas: List[int], string_count: int, segment_count: int) -> dict:
     import idaapi
     import idc
 
@@ -222,7 +223,7 @@ def _build_statistics(func_eas: list[int], string_count: int, segment_count: int
     }
 
 
-def _build_interesting_strings() -> list[dict]:
+def _build_interesting_strings() -> List[dict]:
     import idautils
 
     strings = _get_strings_cache()
@@ -230,7 +231,7 @@ def _build_interesting_strings() -> list[dict]:
     if len(strings) > _MAX_STRING_ITER:
         strings = strings[:_MAX_STRING_ITER]
 
-    scored: list[tuple[int, int, str]] = []
+    scored: List[Tuple[int, int, str]] = []
 
     for ea, s in strings:
         count = sum(1 for _ in islice(idautils.XrefsTo(ea, 0), _MAX_XREFS_PER_STRING))
@@ -270,12 +271,12 @@ def _classify_func(ea: int, func, name: str, callee_count: int) -> str:
     return "complex"
 
 
-def _build_interesting_functions(func_eas: list[int], truncated: bool) -> list[dict]:
+def _build_interesting_functions(func_eas: List[int], truncated: bool) -> List[dict]:
     import idaapi
     import idautils
     import idc
 
-    candidates: list[tuple[int, int, str, int, int]] = []
+    candidates: List[Tuple[int, int, str, int, int]] = []
 
     for ea in func_eas:
         func = idaapi.get_func(ea)
@@ -316,10 +317,10 @@ def _build_interesting_functions(func_eas: list[int], truncated: bool) -> list[d
     return result
 
 
-def _build_imports_by_category() -> dict[str, list[dict]]:
+def _build_imports_by_category() -> Dict[str, List[dict]]:
     import ida_nalt
 
-    categories: dict[str, list[dict]] = {
+    categories: Dict[str, List[dict]] = {
         "crypto": [],
         "network": [],
         "file_io": [],
@@ -332,7 +333,7 @@ def _build_imports_by_category() -> dict[str, list[dict]]:
     for i in range(nimps):
         module_name = ida_nalt.get_import_module_name(i) or "<unnamed>"
 
-        collected: list[tuple[int, str]] = []
+        collected: List[Tuple[int, str]] = []
 
         def imp_cb(ea: int, symbol_name: str | None, ordinal: int) -> bool:
             name = symbol_name if symbol_name else f"#{ordinal}"
@@ -352,12 +353,12 @@ def _build_imports_by_category() -> dict[str, list[dict]]:
     return categories
 
 
-def _build_call_graph_summary(func_eas: list[int]) -> dict:
+def _build_call_graph_summary(func_eas: List[int]) -> dict:
     import idaapi
     import idautils
 
     total_edges = 0
-    root_functions: list[str] = []
+    root_functions: List[str] = []
     leaf_count = 0
 
     for ea in func_eas:

--- a/src/ida_pro_mcp/ida_mcp/api_types.py
+++ b/src/ida_pro_mcp/ida_mcp/api_types.py
@@ -1,4 +1,6 @@
-from typing import Annotated, Any, TypedDict
+from __future__ import annotations
+from typing import Any, TypedDict
+from typing_extensions import Annotated
 
 import idc
 import ida_typeinf
@@ -57,7 +59,7 @@ class EnumUpsertResult(TypedDict, total=False):
     enum_id: str
     created: bool
     bitfield: bool
-    members: list[EnumMemberUpsertResult]
+    members: List[EnumMemberUpsertResult]
     summary: EnumUpsertSummaryResult
     error: str
 
@@ -73,7 +75,7 @@ class StructMemberValueResult(TypedDict):
 class ReadStructResult(TypedDict, total=False):
     addr: str | None
     struct: str | None
-    members: list[StructMemberValueResult] | None
+    members: List[StructMemberValueResult] | None
     error: str
 
 
@@ -99,16 +101,16 @@ class TypeCatalogRow(TypedDict, total=False):
     kind: str
     declaration: str
     member_count: int
-    members: list[TypeCatalogMemberResult]
+    members: List[TypeCatalogMemberResult]
     members_truncated: bool
     related_count: int
-    related_types: list[str]
+    related_types: List[str]
     related_truncated: bool
 
 
 class TypeQueryResult(TypedDict):
     kind: str
-    data: list[TypeCatalogRow]
+    data: List[TypeCatalogRow]
     next_offset: int | None
     total: int
 
@@ -122,13 +124,13 @@ class TypeInspectResult(TypedDict, total=False):
     is_ptr: bool
     is_enum: bool
     is_udt: bool
-    members: list[TypeCatalogMemberResult] | None
+    members: List[TypeCatalogMemberResult] | None
     member_count: int
     error: str
 
 
 class SetTypeResult(TypedDict, total=False):
-    edit: dict[str, Any]
+    edit: Dict[str, Any]
     kind: str
     ok: bool
     error: str
@@ -139,7 +141,7 @@ class TypeApplyBatchResult(TypedDict):
     applied: int
     failed: int
     stopped: bool
-    results: list[SetTypeResult]
+    results: List[SetTypeResult]
 
 
 class InferTypeResult(TypedDict, total=False):
@@ -158,8 +160,8 @@ class InferTypeResult(TypedDict, total=False):
 @tool
 @idasync
 def declare_type(
-    decls: Annotated[list[str] | str, "C type declarations"],
-) -> list[DeclareTypeResult]:
+    decls: Annotated[List[str] | str, "C type declarations"],
+) -> List[DeclareTypeResult]:
     """Declare C type definitions in local type library."""
     decls = normalize_list_input(decls)
     results = []
@@ -186,10 +188,10 @@ def declare_type(
 @idasync
 def enum_upsert(
     queries: Annotated[
-        list[EnumUpsert] | EnumUpsert,
+        List[EnumUpsert] | EnumUpsert,
         "Create enums if missing and upsert enum members without destructive replacement",
     ],
-) -> list[EnumUpsertResult]:
+) -> List[EnumUpsertResult]:
     """Create or extend local enums in an idempotent way."""
     queries = normalize_dict_list(queries)
     results = []
@@ -336,8 +338,8 @@ def _parse_enum_value(value: int | str | None) -> int:
 @tool
 @idasync
 def read_struct(
-    queries: list[StructRead] | StructRead,
-) -> list[ReadStructResult]:
+    queries: List[StructRead] | StructRead,
+) -> List[ReadStructResult]:
     """Read struct fields from memory at address; auto-detect type when possible."""
 
     queries = normalize_dict_list(queries)
@@ -475,7 +477,7 @@ def search_structs(
     filter: Annotated[
         str, "Case-insensitive substring to search for in structure names"
     ],
-) -> list[SearchStructResult]:
+) -> List[SearchStructResult]:
     """Search local structs/unions by name pattern."""
     results = []
     limit = compat.get_ordinal_limit()
@@ -562,15 +564,15 @@ def _type_matches_kind(kind: str, tif: ida_typeinf.tinfo_t) -> bool:
 @idasync
 def type_query(
     queries: Annotated[
-        list[TypeQuery] | TypeQuery,
+        List[TypeQuery] | TypeQuery,
         "Type catalog query with filtering, pagination, and optional relationships",
     ],
-) -> list[TypeQueryResult]:
+) -> List[TypeQueryResult]:
     """Query local types with structured filters/projection-friendly output."""
     queries = normalize_dict_list(queries)
 
     # Build one local catalog and page/filter it per query.
-    catalog: list[dict] = []
+    catalog: List[dict] = []
     limit = ida_typeinf.get_ordinal_limit()
     for ordinal in range(1, limit):
         tif = ida_typeinf.tinfo_t()
@@ -589,7 +591,7 @@ def type_query(
             }
         )
 
-    results: list[dict] = []
+    results: List[dict] = []
     for query in queries:
         filter_pattern = str(query.get("filter", "") or "")
         kind = str(query.get("kind", "any") or "any").lower()
@@ -610,7 +612,7 @@ def type_query(
         if max_members > 4096:
             max_members = 4096
 
-        filtered: list[dict] = []
+        filtered: List[dict] = []
         for row in catalog:
             tif = row.get("_tif")
             if not isinstance(tif, ida_typeinf.tinfo_t):
@@ -629,7 +631,7 @@ def type_query(
         else:
             filtered.sort(key=lambda r: str(r.get("name", "")).lower(), reverse=descending)
 
-        output_rows: list[dict] = []
+        output_rows: List[dict] = []
         for row in filtered:
             tif = row["_tif"]
             out = {
@@ -667,7 +669,7 @@ def type_query(
                 out["members_truncated"] = members_truncated
 
             if include_relationships:
-                related: set[str] = set()
+                related: Set[str] = set()
                 if tif.is_udt():
                     udt = ida_typeinf.udt_type_data_t()
                     if tif.get_udt_details(udt):
@@ -709,10 +711,10 @@ def type_query(
 @idasync
 def type_inspect(
     queries: Annotated[
-        list[TypeInspectQuery] | TypeInspectQuery,
+        List[TypeInspectQuery] | TypeInspectQuery,
         "Inspect named types and optionally include member layout",
     ],
-) -> list[TypeInspectResult]:
+) -> List[TypeInspectResult]:
     """Inspect named types (size/kind/declaration/members)."""
     queries = normalize_dict_list(queries)
     results = []
@@ -902,7 +904,7 @@ def _infer_type_edit_kind(edit: dict) -> str:
     return "global"
 
 
-def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
+def _apply_type_edit(edit: Dict[str, Any]) -> SetTypeResult:
     try:
         kind = _infer_type_edit_kind(edit)
         type_text = _resolve_type_text(edit)
@@ -1026,7 +1028,7 @@ def _apply_type_edit(edit: dict[str, Any]) -> SetTypeResult:
 
 @tool
 @idasync
-def set_type(edits: list[TypeEdit] | TypeEdit) -> list[SetTypeResult]:
+def set_type(edits: List[TypeEdit] | TypeEdit) -> List[SetTypeResult]:
     """Apply types (function/global/local/stack)"""
     normalized_edits = normalize_dict_list(edits, _parse_addr_type_shorthand)
     return [_apply_type_edit(edit) for edit in normalized_edits]
@@ -1046,7 +1048,7 @@ def type_apply_batch(
     )
     stop_on_error = bool(batch.get("stop_on_error", False))
 
-    results: list[dict] = []
+    results: List[dict] = []
     for edit in normalized_edits:
         result = _apply_type_edit(edit)
         results.append(result)
@@ -1067,8 +1069,8 @@ def type_apply_batch(
 @tool
 @idasync
 def infer_types(
-    addrs: Annotated[list[str] | str, "Addresses to infer types for"],
-) -> list[InferTypeResult]:
+    addrs: Annotated[List[str] | str, "Addresses to infer types for"],
+) -> List[InferTypeResult]:
     """Infer and apply likely types at target addresses."""
     addrs = normalize_list_input(addrs)
     results = []

--- a/src/ida_pro_mcp/ida_mcp/compat.py
+++ b/src/ida_pro_mcp/ida_mcp/compat.py
@@ -27,7 +27,7 @@ import ida_typeinf
 # ============================================================================
 
 
-def _parse_kernel_version(v: str) -> tuple[int, int, int]:
+def _parse_kernel_version(v: str) -> Tuple[int, int, int]:
     # Parse formats like "9.2", "9.2.0", "9.2sp1"
     nums = [int(x) for x in re.findall(r"\d+", v)]
     major = nums[0] if len(nums) > 0 else 0
@@ -36,7 +36,7 @@ def _parse_kernel_version(v: str) -> tuple[int, int, int]:
     return (major, minor, patch)
 
 
-def _check_required_apis(version: tuple[int, int, int]) -> None:
+def _check_required_apis(version: Tuple[int, int, int]) -> None:
     """
     Check that required Python APIs are available.
 
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
     import ida_ida
     import ida_hexrays
 
-    IDA_VERSION: tuple[int, int, int] = cast(tuple[int, int, int], (9, 2, 0))
+    IDA_VERSION: Tuple[int, int, int] = cast(Tuple[int, int, int], (9, 2, 0))
 else:
     IDA_VERSION = _parse_kernel_version(idaapi.get_kernel_version())
 
@@ -251,7 +251,7 @@ def raw_bin_search(
 
 def make_bytes_searcher(
     pattern: str,
-) -> tuple[Callable[[int, int], int] | None, str | None]:
+) -> Tuple[Callable[[int, int], int] | None, str | None]:
     tokens = pattern.strip().split()
     if not tokens:
         return None, "Empty pattern"
@@ -321,7 +321,7 @@ def guess_tinfo(tif: ida_typeinf.tinfo_t, ea: int) -> bool:
 
 def tinfo_get_udm(
     tif: ida_typeinf.tinfo_t, name: str
-) -> tuple[int, ida_typeinf.udm_t | None]:
+) -> Tuple[int, ida_typeinf.udm_t | None]:
     """
     Get a UDM (user-defined member) from a tinfo_t by name.
 

--- a/src/ida_pro_mcp/ida_mcp/discovery.py
+++ b/src/ida_pro_mcp/ida_mcp/discovery.py
@@ -5,6 +5,7 @@ IDA plugin instances register themselves by writing JSON files to
 instances by reading these files and validating PID liveness.
 """
 
+from __future__ import annotations
 import datetime
 import glob
 import json
@@ -126,13 +127,13 @@ def probe_instance(host: str, port: int, timeout: float = 2.0) -> bool:
         return False
 
 
-def discover_instances() -> list[InstanceInfo]:
+def discover_instances() -> List[InstanceInfo]:
     """Scan for registered instances, cleaning up stale entries."""
     instances_dir = get_instances_dir()
     if not os.path.isdir(instances_dir):
         return []
 
-    result: list[InstanceInfo] = []
+    result: List[InstanceInfo] = []
     pattern = os.path.join(instances_dir, "instance_*.json")
     for file_path in glob.glob(pattern):
         try:

--- a/src/ida_pro_mcp/ida_mcp/framework.py
+++ b/src/ida_pro_mcp/ida_mcp/framework.py
@@ -15,23 +15,29 @@ Usage from command line:
     ida-mcp-test tests/crackme03.elf --pattern "*meta*"
 """
 
+from __future__ import annotations
 import fnmatch
 import time
 import traceback
 from dataclasses import dataclass, field
-from types import UnionType
+try:
+    from types import UnionType  # Python 3.10+
+except ImportError:
+    UnionType = ()  # Python 3.8/3.9
 from typing import (
-    Annotated,
     Any,
     Callable,
     Literal,
-    NotRequired,
     Optional,
-    Required,
     Union,
     get_args,
     get_origin,
     get_type_hints,
+)
+from typing_extensions import (
+    Annotated,
+    NotRequired,
+    Required,
     is_typeddict,
 )
 
@@ -52,7 +58,7 @@ class TestInfo:
 
 
 # Global test registry: name -> TestInfo
-TESTS: dict[str, TestInfo] = {}
+TESTS: Dict[str, TestInfo] = {}
 
 
 class SkipTest(Exception):
@@ -140,7 +146,7 @@ class TestResults:
     failed: int = 0
     skipped: int = 0
     total_time: float = 0.0
-    results: list[TestResult] = field(default_factory=list)
+    results: List[TestResult] = field(default_factory=list)
 
     def add(self, result: TestResult) -> None:
         """Add a test result and update counts."""
@@ -184,7 +190,7 @@ class ListOfShape:
 
 @dataclass(frozen=True)
 class OneOfShape:
-    schemas: tuple[Any, ...]
+    schemas: Tuple[Any, ...]
 
 
 def optional(schema: Any) -> OptionalShape:
@@ -513,7 +519,7 @@ def get_any_string() -> Optional[str]:
     return None
 
 
-def get_first_segment() -> Optional[tuple[str, str]]:
+def get_first_segment() -> Optional[Tuple[str, str]]:
     """Returns (start_addr, end_addr) of first segment, or None.
 
     Must be called from within IDA context.
@@ -594,7 +600,7 @@ def run_tests(
     current_binary = get_current_binary_name()
 
     # Group tests by category
-    tests_by_category: dict[str, list[tuple[str, TestInfo]]] = {}
+    tests_by_category: Dict[str, List[Tuple[str, TestInfo]]] = {}
     for name, info in sorted(TESTS.items()):
         # Filter by pattern
         if not fnmatch.fnmatch(name, pattern):

--- a/src/ida_pro_mcp/ida_mcp/http.py
+++ b/src/ida_pro_mcp/ida_mcp/http.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import html
 import json
 import logging
@@ -79,15 +80,15 @@ DEFAULT_CORS_POLICY = "local"
 
 def get_cors_policy(port: int) -> str:
     """Retrieve the current CORS policy from configuration."""
-    match config_json_get("cors_policy", DEFAULT_CORS_POLICY):
-        case "unrestricted":
-            return "*"
-        case "local":
-            return "127.0.0.1 localhost"
-        case "direct":
-            return f"http://127.0.0.1:{port} http://localhost:{port}"
-        case _:
-            return "*"
+    policy = config_json_get("cors_policy", DEFAULT_CORS_POLICY)
+    if policy == "unrestricted":
+        return "*"
+    elif policy == "local":
+        return "127.0.0.1 localhost"
+    elif policy == "direct":
+        return f"http://127.0.0.1:{port} http://localhost:{port}"
+    else:
+        return "*"
 
 
 ORIGINAL_TOOLS = handle_enabled_tools(MCP_SERVER.tools, "enabled_tools")
@@ -99,13 +100,13 @@ class IdaMcpHttpRequestHandler(McpHttpRequestHandler):
         self.update_cors_policy()
 
     def update_cors_policy(self):
-        match config_json_get("cors_policy", DEFAULT_CORS_POLICY):
-            case "unrestricted":
-                self.mcp_server.cors_allowed_origins = "*"
-            case "local":
-                self.mcp_server.cors_allowed_origins = self.mcp_server.cors_localhost
-            case "direct":
-                self.mcp_server.cors_allowed_origins = None
+        policy = config_json_get("cors_policy", DEFAULT_CORS_POLICY)
+        if policy == "unrestricted":
+            self.mcp_server.cors_allowed_origins = "*"
+        elif policy == "local":
+            self.mcp_server.cors_allowed_origins = self.mcp_server.cors_localhost
+        elif policy == "direct":
+            self.mcp_server.cors_allowed_origins = None
 
     def do_POST(self):
         """Handles POST requests."""

--- a/src/ida_pro_mcp/ida_mcp/profile.py
+++ b/src/ida_pro_mcp/ida_mcp/profile.py
@@ -4,13 +4,14 @@ Format: one tool name per line; ``#`` starts a comment; blank lines are ignored.
 Passed to ``idalib-mcp --profile PATH`` or exported from ``/config.html``.
 """
 
+from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
 
-def parse_profile(text: str) -> set[str]:
+def parse_profile(text: str) -> Set[str]:
     """Parse profile text into a set of tool names."""
-    names: set[str] = set()
+    names: Set[str] = set()
     for line in text.splitlines():
         name = line.split("#", 1)[0].strip()
         if name:
@@ -18,7 +19,7 @@ def parse_profile(text: str) -> set[str]:
     return names
 
 
-def load_profile(path: str | Path) -> set[str]:
+def load_profile(path: str | Path) -> Set[str]:
     """Read a profile file and return its whitelisted tool names."""
     return parse_profile(Path(path).read_text(encoding="utf-8"))
 
@@ -35,10 +36,10 @@ def dump_profile(names: Iterable[str], *, header: str | None = None) -> str:
 
 def apply_profile(
     tools: dict,
-    whitelist: set[str],
+    whitelist: Set[str],
     *,
     protected: Iterable[str] = (),
-) -> tuple[list[str], list[str]]:
+) -> Tuple[List[str], List[str]]:
     """Filter ``tools`` in place to ``whitelist`` plus ``protected`` names.
 
     Returns ``(kept, unknown)``: tools from the whitelist that survived, and

--- a/src/ida_pro_mcp/ida_mcp/rpc.py
+++ b/src/ida_pro_mcp/ida_mcp/rpc.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import os
 from typing import Any, Optional
@@ -9,8 +10,8 @@ from .zeromcp import (
     get_current_request_external_base_url,
 )
 
-MCP_UNSAFE: set[str] = set()
-MCP_EXTENSIONS: dict[str, set[str]] = {}  # group -> set of function names
+MCP_UNSAFE: Set[str] = set()
+MCP_EXTENSIONS: Dict[str, Set[str]] = {}  # group -> set of function names
 MCP_SERVER = McpServer("ida-pro-mcp", extensions=MCP_EXTENSIONS)
 
 # ============================================================================
@@ -19,7 +20,7 @@ MCP_SERVER = McpServer("ida-pro-mcp", extensions=MCP_EXTENSIONS)
 
 OUTPUT_LIMIT_MAX_CHARS = 50000
 OUTPUT_CACHE_MAX_SIZE = 100
-_output_cache: dict[str, Any] = {}
+_output_cache: Dict[str, Any] = {}
 _download_base_url: str = os.environ.get("IDA_MCP_URL", "http://127.0.0.1:13337")
 
 

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import queue
 import functools
@@ -198,7 +199,7 @@ def sync_wrapper(
             # set_cancelled() is THREAD_SAFE so firing it from a Timer
             # thread is safe.
             ida_kernwin.clr_cancelled()
-            cancel_fired_at: list[float | None] = [None]
+            cancel_fired_at: List[float | None] = [None]
             native_timer: threading.Timer | None = None
             if deadline is not None:
                 def _fire_native_cancel():

--- a/src/ida_pro_mcp/ida_mcp/trace.py
+++ b/src/ida_pro_mcp/ida_mcp/trace.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """Tool-call tracing.
 
 Always-on. The trace lives in the IDB under netnode `$ ida_mcp.trace` as
@@ -40,7 +41,7 @@ _DEFAULT_BATCH_BYTES = 64 * 1024
 
 
 _state_lock = threading.Lock()
-_state: dict[str, Any] = {
+_state: Dict[str, Any] = {
     "idb_backend": None,
     "atexit_registered": False,
     "idb_hook": None,
@@ -77,19 +78,19 @@ def _netnode_flush_segment(payload: bytes, record_count: int) -> None:
 
 
 @idasync
-def _netnode_iter_blobs() -> list[bytes]:
+def _netnode_iter_blobs() -> List[bytes]:
     """Return every segment's compressed blob in segment-id order."""
     import ida_netnode
     node = ida_netnode.netnode(IDB_NETNODE_NAME, 0, False)
     if node == ida_netnode.BADNODE:
         return []
-    pairs: list[tuple[int, int]] = []
+    pairs: List[Tuple[int, int]] = []
     i = node.altfirst(_TAG_INDEX)
     while i != ida_netnode.BADNODE:
         pairs.append((i, node.altval(i, _TAG_INDEX)))
         i = node.altnext(i, _TAG_INDEX)
     pairs.sort()
-    blobs: list[bytes] = []
+    blobs: List[bytes] = []
     for _, start in pairs:
         blob = node.getblob(start, _TAG_DATA)
         if isinstance(blob, tuple):
@@ -107,7 +108,7 @@ class NetnodeBackend:
         self.batch_bytes = max(1024, batch_bytes)
         self._lock = threading.Lock()
         self._flush_lock = threading.Lock()
-        self._buffer: list[bytes] = []
+        self._buffer: List[bytes] = []
         self._buffered_bytes = 0
         self._closed = False
 
@@ -295,7 +296,7 @@ def install_tracer() -> None:
 
     def traced(name, arguments=None, _meta=None):
         start = time.monotonic()
-        record: dict[str, Any] = {
+        record: Dict[str, Any] = {
             "ts": _now_iso(),
             "tool": name,
             "arguments": arguments or {},

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import fnmatch
 import json
 import os
@@ -6,17 +7,16 @@ import struct
 import sys
 import tempfile
 from typing import (
-    Annotated,
     Any,
     Callable,
     Generic,
     Literal,
-    NotRequired,
     Optional,
     TypedDict,
     TypeVar,
     overload,
 )
+from typing_extensions import Annotated, NotRequired
 
 import ida_bytes
 import ida_funcs
@@ -141,16 +141,16 @@ class RenameBatch(TypedDict, total=False):
     """
 
     func: Annotated[
-        list[FunctionRename] | FunctionRename, "Function rename operations"
+        List[FunctionRename] | FunctionRename, "Function rename operations"
     ]
     data: Annotated[
-        list[GlobalRename] | GlobalRename, "Global/data variable rename operations"
+        List[GlobalRename] | GlobalRename, "Global/data variable rename operations"
     ]
     local: Annotated[
-        list[LocalRename] | LocalRename, "Local variable rename operations"
+        List[LocalRename] | LocalRename, "Local variable rename operations"
     ]
     stack: Annotated[
-        list[StackRename] | StackRename, "Stack variable rename operations"
+        List[StackRename] | StackRename, "Stack variable rename operations"
     ]
     stop_on_error: Annotated[bool, "Stop on first failure"]
     dry_run: Annotated[bool, "Validate only, no changes"]
@@ -214,7 +214,7 @@ class EntityQuery(TypedDict):
     count: NotRequired[Annotated[int, "Max results (0=all)"]]
     sort_by: NotRequired[Annotated[str, "Sort: addr|name|size|length"]]
     descending: NotRequired[Annotated[bool, "Descending"]]
-    fields: NotRequired[Annotated[list[str], "Projection field list"]]
+    fields: NotRequired[Annotated[List[str], "Projection field list"]]
 
 
 class FuncProfileQuery(TypedDict, total=False):
@@ -371,14 +371,14 @@ class EnumUpsert(TypedDict, total=False):
     """Enum create/update operation"""
 
     name: Annotated[str, "Enum type name"]
-    members: Annotated[list[EnumMemberUpsert] | EnumMemberUpsert, "Members to upsert"]
+    members: Annotated[List[EnumMemberUpsert] | EnumMemberUpsert, "Members to upsert"]
     bitfield: Annotated[bool, "Bitfield enum"]
 
 
 class TypeApplyBatch(TypedDict):
     """Batch type application configuration"""
 
-    edits: Annotated[list[TypeEdit] | TypeEdit, "Type edits to apply"]
+    edits: Annotated[List[TypeEdit] | TypeEdit, "Type edits to apply"]
     stop_on_error: NotRequired[Annotated[bool, "Stop on first failure"]]
 
 
@@ -481,8 +481,8 @@ class DisassemblyLine(TypedDict):
     addr: str
     label: NotRequired[str]
     instruction: str
-    comments: NotRequired[list[str]]
-    refs: NotRequired[list[Ref]]
+    comments: NotRequired[List[str]]
+    refs: NotRequired[List[Ref]]
 
 
 class Argument(TypedDict):
@@ -502,9 +502,9 @@ class DisassemblyFunction(TypedDict):
     start_ea: str
     segment: NotRequired[str]
     return_type: NotRequired[str]
-    arguments: NotRequired[list[Argument]]
-    stack_frame: NotRequired[list[StackFrameVariable]]
-    lines: list[DisassemblyLine]
+    arguments: NotRequired[List[Argument]]
+    stack_frame: NotRequired[List[StackFrameVariable]]
+    lines: List[DisassemblyLine]
 
 
 class Xref(TypedDict):
@@ -523,7 +523,7 @@ class StructureMember(TypedDict):
 class StructureDefinition(TypedDict):
     name: str
     size: str
-    members: list[StructureMember]
+    members: List[StructureMember]
 
 
 class RegisterValue(TypedDict):
@@ -533,7 +533,7 @@ class RegisterValue(TypedDict):
 
 class ThreadRegisters(TypedDict):
     thread_id: int
-    registers: list[RegisterValue]
+    registers: List[RegisterValue]
 
 
 class Breakpoint(TypedDict):
@@ -548,26 +548,26 @@ class FunctionAnalysis(TypedDict):
     name: Optional[str]
     code: Optional[str]
     asm: Optional[str]
-    xto: list[Xref]
-    xfrom: list[Xref]
-    callees: list[dict]
-    callers: list[Function]
-    strings: list[String]
-    constants: list[dict]
-    blocks: list[dict]
+    xto: List[Xref]
+    xfrom: List[Xref]
+    callees: List[dict]
+    callers: List[Function]
+    strings: List[String]
+    constants: List[dict]
+    blocks: List[dict]
     error: Optional[str]
     prompt: Optional[str]
 
 
 class PatternMatch(TypedDict):
     pattern: str
-    matches: list[str]
+    matches: List[str]
     count: int
 
 
 class CodePattern(TypedDict):
     mnemonic: str
-    operands: NotRequired[list[str]]
+    operands: NotRequired[List[str]]
 
 
 class BasicBlock(TypedDict):
@@ -575,15 +575,15 @@ class BasicBlock(TypedDict):
     end: str
     size: int
     type: int
-    successors: list[str]
-    predecessors: list[str]
+    successors: List[str]
+    predecessors: List[str]
 
 
 T = TypeVar("T")
 
 
 class Page(TypedDict, Generic[T]):
-    data: list[T]
+    data: List[T]
     next_offset: Optional[int]
 
 
@@ -671,21 +671,21 @@ def normalize_list_input(value: list | str) -> list:
 
 
 def normalize_dict_list(
-    value: list[dict] | dict | str | list[str] | Any,
+    value: List[dict] | dict | str | List[str] | Any,
     string_parser: Optional[Callable[[str], dict]] = None,
-) -> list[dict]:
-    """Normalize input to list[dict] with optional string parsing
+) -> List[dict]:
+    """Normalize input to List[dict] with optional string parsing
 
     Args:
-        value: Input value (dict, list[dict], str, list[str], or any)
+        value: Input value (dict, List[dict], str, List[str], or any)
         string_parser: Optional function to convert string → dict
                       If None, strings → empty dict
 
     Flow:
         dict → [dict]
-        str → split by ',' → list[str] → map(string_parser) → list[dict]
-        list[str] → map(string_parser) → list[dict]
-        list[dict] → list[dict]
+        str → split by ',' → List[str] → map(string_parser) → List[dict]
+        List[str] → map(string_parser) → List[dict]
+        List[dict] → List[dict]
         Any → [{}]
     """
     if isinstance(value, dict):
@@ -693,11 +693,11 @@ def normalize_dict_list(
     elif isinstance(value, list):
         if not value:
             return [{}]
-        # Check if list[str] or list[dict]
+        # Check if List[str] or List[dict]
         if all(isinstance(item, dict) for item in value):
             return value
         elif all(isinstance(item, str) for item in value):
-            # list[str] → map with parser
+            # List[str] → map with parser
             if string_parser:
                 return [string_parser(s.strip()) for s in value if s.strip()]
             return [{}]
@@ -910,7 +910,7 @@ def get_type_by_name(type_name: str) -> ida_typeinf.tinfo_t:
     raise IDAError(f"Unable to retrieve {type_name} type info object")
 
 
-def paginate(data: list[T], offset: int, count: int) -> Page[T]:
+def paginate(data: List[T], offset: int, count: int) -> Page[T]:
     if count == 0:
         count = len(data)
     next_offset = offset + count
@@ -922,7 +922,7 @@ def paginate(data: list[T], offset: int, count: int) -> Page[T]:
     }
 
 
-def pattern_filter(data: list[T], pattern: str, key: str) -> list[T]:
+def pattern_filter(data: List[T], pattern: str, key: str) -> List[T]:
     if not pattern:
         return data
 
@@ -1023,7 +1023,7 @@ def hexrays_local_var_exists(func_ea: int, var_name: str) -> bool:
     return False
 
 
-def parse_decls_ctypes(decls: str, hti_flags: int) -> tuple[int, list[str]]:
+def parse_decls_ctypes(decls: str, hti_flags: int) -> Tuple[int, List[str]]:
     if sys.platform == "win32":
         import ctypes
 
@@ -1040,7 +1040,7 @@ def parse_decls_ctypes(decls: str, hti_flags: int) -> tuple[int, list[str]]:
         ]
         ida_dll.parse_decls.restype = ctypes.c_int
 
-        messages: list[str] = []
+        messages: List[str] = []
 
         @ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p)
         def magic_printer(fmt: bytes, arg1: bytes):
@@ -1061,7 +1061,7 @@ def parse_decls_ctypes(decls: str, hti_flags: int) -> tuple[int, list[str]]:
 
 def get_stack_frame_variables_internal(
     fn_addr: int, raise_error: bool
-) -> list[StackFrameVariable]:
+) -> List[StackFrameVariable]:
     from .sync import ida_major
 
     if ida_major < 9:
@@ -1077,7 +1077,7 @@ def get_stack_frame_variables_internal(
     if not tif.get_type_by_tid(func.frame) or not tif.is_udt():
         return []
 
-    members: list[StackFrameVariable] = []
+    members: List[StackFrameVariable] = []
     udt = ida_typeinf.udt_type_data_t()
     tif.get_udt_details(udt)
     for udm in udt:
@@ -1140,7 +1140,7 @@ def decompile_checked(addr: int):
 
 def decompile_function_safe(
     ea: int, include_addresses: bool = True
-) -> tuple[str | None, str | None]:
+) -> Tuple[str | None, str | None]:
     """Safely decompile a function. Returns (code, error); exactly one is non-None."""
     import ida_lines
     import ida_kernwin
@@ -1237,7 +1237,7 @@ def get_all_comments(ea: int) -> dict:
     return comments
 
 
-def get_callees(addr: str) -> list[dict]:
+def get_callees(addr: str) -> List[dict]:
     """Get callees for a single function address"""
     try:
         func_start = parse_address(addr)
@@ -1245,7 +1245,7 @@ def get_callees(addr: str) -> list[dict]:
         if not func:
             return []
         func_end = idc.find_func_end(func_start)
-        callees: list[dict[str, str]] = []
+        callees: List[Dict[str, str]] = []
         current_ea = func_start
         while current_ea < func_end:
             insn = idaapi.insn_t()
@@ -1277,7 +1277,7 @@ def get_callees(addr: str) -> list[dict]:
         return []
 
 
-def get_callers(addr: str, limit: int = 50) -> list[Function]:
+def get_callers(addr: str, limit: int = 50) -> List[Function]:
     """Get callers for a single function address"""
     try:
         callers = {}
@@ -1305,7 +1305,7 @@ def get_callers(addr: str, limit: int = 50) -> list[Function]:
         return []
 
 
-def get_xrefs_from_internal(ea: int) -> list[Xref]:
+def get_xrefs_from_internal(ea: int) -> List[Xref]:
     """Get all xrefs from an address"""
     xrefs = []
     for xref in idautils.XrefsFrom(ea, 0):
@@ -1319,7 +1319,7 @@ def get_xrefs_from_internal(ea: int) -> list[Xref]:
     return xrefs
 
 
-def extract_function_strings(ea: int) -> list[String]:
+def extract_function_strings(ea: int) -> List[String]:
     """Extract string references from a function"""
     func = idaapi.get_func(ea)
     if not func:
@@ -1348,7 +1348,7 @@ def extract_function_strings(ea: int) -> list[String]:
     return strings
 
 
-def extract_function_constants(ea: int) -> list[dict]:
+def extract_function_constants(ea: int) -> List[dict]:
     """Extract immediate constants from a function"""
     func = idaapi.get_func(ea)
     if not func:

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/__init__.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 # NOTE: Vendored from zeromcp 1.3.0
 
 from .mcp import (

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/jsonrpc.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import inspect
 import logging
@@ -5,17 +6,21 @@ import os
 import threading
 import time
 import traceback
-from typing import Any, Callable, get_type_hints, get_origin, get_args, Union, TypedDict, TypeAlias, NotRequired, is_typeddict
-from types import UnionType
+from typing import Any, Callable, Dict, get_type_hints, get_origin, get_args, List, Union, TypedDict
+from typing_extensions import NotRequired, TypeAlias, is_typeddict
+try:
+    from types import UnionType  # Python 3.10+
+except ImportError:
+    UnionType = ()  # Python 3.8/3.9
 
-JsonRpcId: TypeAlias = str | int | float | None
+JsonRpcId: TypeAlias = Union[str, int, float, None]
 
 # Thread-local storage for current request context (ID + cancel event)
 _current_request = threading.local()
 
 # Global pending requests for cancellation
 _pending_requests_lock = threading.Lock()
-_pending_requests: dict[int | str, threading.Event] = {}
+_pending_requests: Dict[int | str, threading.Event] = {}
 
 
 def get_current_request_id() -> JsonRpcId:
@@ -74,7 +79,7 @@ _LOG_SKIP_METHODS = {
     for m in os.getenv("IDA_MCP_LOG_SKIP_METHODS", "tools/call").split(",")
     if m.strip()
 }
-JsonRpcParams: TypeAlias = dict[str, Any] | list[Any] | None
+JsonRpcParams: TypeAlias = Union[Dict[str, Any], List[Any], None]
 
 class JsonRpcRequest(TypedDict):
     jsonrpc: str
@@ -106,8 +111,8 @@ class RequestCancelledError(Exception):
 
 class JsonRpcRegistry:
     def __init__(self):
-        self.methods: dict[str, Callable] = {}
-        self._cache: dict[Callable, tuple[inspect.Signature, dict, list[str]]] = {}
+        self.methods: Dict[str, Callable] = {}
+        self._cache: Dict[Callable, Tuple[inspect.Signature, dict, List[str]]] = {}
         self.redact_exceptions = False
 
     def method(self, func: Callable, name: str | None = None) -> Callable:
@@ -329,7 +334,7 @@ class JsonRpcRegistry:
                     validated_params[param_name] = value
                     continue
 
-                # Handle generic types (list[X], dict[K,V])
+                # Handle generic types (List[X], Dict[K,V])
                 if origin is not None:
                     if not isinstance(value, origin):
                         raise JsonRpcException(

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 import select
 import socket
@@ -12,8 +13,12 @@ import inspect
 import logging
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer, HTTPServer
-from typing import Any, Callable, Union, Annotated, BinaryIO, NotRequired, get_origin, get_args, get_type_hints, is_typeddict
-from types import UnionType
+from typing import Any, Callable, Union, BinaryIO, get_origin, get_args, get_type_hints
+from typing_extensions import Annotated, NotRequired, is_typeddict
+try:
+    from types import UnionType  # Python 3.10+
+except ImportError:
+    UnionType = ()  # Python 3.8/3.9: | syntax not supported, never matches
 from urllib.parse import urlparse, parse_qs, urlunparse
 from io import BufferedIOBase
 
@@ -72,7 +77,7 @@ class _McpSseConnection:
 
 
 def _origin_allowed_by_policy(
-    allowed: Callable[[str], bool] | list[str] | str | None,
+    allowed: Callable[[str], bool] | List[str] | str | None,
     origin: str,
 ) -> bool:
     if not origin or allowed is None:
@@ -181,10 +186,10 @@ def _append_forwarded_port(authority: str, port: str | None) -> str:
     return authority
 
 
-def _parse_forwarded_header(forwarded: str | None) -> dict[str, str]:
+def _parse_forwarded_header(forwarded: str | None) -> Dict[str, str]:
     if not forwarded:
         return {}
-    result: dict[str, str] = {}
+    result: Dict[str, str] = {}
     first_entry = forwarded.split(",", 1)[0]
     for item in first_entry.split(";"):
         if "=" not in item:
@@ -239,7 +244,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
         self.mcp_server: "McpServer" = getattr(server, "mcp_server")
         super().__init__(request, client_address, server)
 
-    def _parse_extensions(self, path: str) -> set[str]:
+    def _parse_extensions(self, path: str) -> Set[str]:
         """Parse ?ext=dbg,foo query param into set of enabled extensions"""
         query = parse_qs(urlparse(path).query)
         ext_param = query.get("ext", [""])[0]
@@ -301,13 +306,13 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if not self._check_api_request():
             return
-        match urlparse(self.path).path:
-            case "/sse":
-                self._handle_sse_get()
-            case "/mcp":
-                self.send_error(405, "Method Not Allowed")
-            case _:
-                self.send_error(404, "Not Found")
+        path = urlparse(self.path).path
+        if path == "/sse":
+            self._handle_sse_get()
+        elif path == "/mcp":
+            self.send_error(405, "Method Not Allowed")
+        else:
+            self.send_error(404, "Not Found")
 
     def do_POST(self):
         if not self._check_api_request():
@@ -316,13 +321,13 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
         if body is None:
             return
 
-        match urlparse(self.path).path:
-            case "/sse":
-                self._handle_sse_post(body)
-            case "/mcp":
-                self._handle_mcp_post(body)
-            case _:
-                self.send_error(404, "Not Found")
+        path = urlparse(self.path).path
+        if path == "/sse":
+            self._handle_sse_post(body)
+        elif path == "/mcp":
+            self._handle_mcp_post(body)
+        else:
+            self.send_error(404, "Not Found")
 
     def do_OPTIONS(self):
         """Handle CORS preflight requests"""
@@ -551,10 +556,10 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
             send_response(200, json.dumps(response).encode("utf-8"))
 
 class McpServer:
-    def __init__(self, name: str, version = "1.0.0", *, extensions: dict[str, set[str]] | None = None):
+    def __init__(self, name: str, version = "1.0.0", *, extensions: Dict[str, Set[str]] | None = None):
         self.name = name
         self.version = version
-        self.cors_allowed_origins: Callable[[str], bool] | list[str] | str | None = self.cors_localhost
+        self.cors_allowed_origins: Callable[[str], bool] | List[str] | str | None = self.cors_localhost
         self.post_body_limit = 10 * 1024 * 1024  # 10MB
         self.tools = McpRpcRegistry()
         self.resources = McpRpcRegistry()
@@ -563,14 +568,14 @@ class McpServer:
         self._http_server: HTTPServer | None = None
         self._server_thread: threading.Thread | None = None
         self._running = False
-        self._sse_connections: dict[str, _McpSseConnection] = {}
-        self._http_sessions: dict[str, float] = {}
+        self._sse_connections: Dict[str, _McpSseConnection] = {}
+        self._http_sessions: Dict[str, float] = {}
         self._http_sessions_lock = threading.Lock()
         self.http_session_ttl_sec = 24 * 60 * 60
         self.http_session_max_count = 4096
         self._protocol_version = threading.local()
         self._transport_session_id = threading.local()
-        self._enabled_extensions = threading.local()  # set[str] per request
+        self._enabled_extensions = threading.local()  # Set[str] per request
         self._extensions_registry = extensions if extensions is not None else {}  # group -> set of tool names
         self.require_streamable_http_session = False
 
@@ -932,7 +937,7 @@ class McpServer:
                 }
 
         # No matching resource found
-        available: list[str] = [getattr(f, "__resource_uri__") for f in self.resources.methods.values()]
+        available: List[str] = [getattr(f, "__resource_uri__") for f in self.resources.methods.values()]
         return {
             "contents": [{
                 "uri": uri,
@@ -1001,7 +1006,7 @@ class McpServer:
         # Build arguments list (PromptArgument format)
         arguments = []
         for param_name, param_type in hints.items():
-            arg: dict[str, Any] = {"name": param_name}
+            arg: Dict[str, Any] = {"name": param_name}
 
             # Extract description from Annotated
             origin = get_origin(param_type)
@@ -1016,7 +1021,7 @@ class McpServer:
 
             arguments.append(arg)
 
-        schema: dict[str, Any] = {
+        schema: Dict[str, Any] = {
             "name": func_name,
             "description": (func.__doc__ or f"Prompt {func_name}").strip(),
         }
@@ -1060,14 +1065,14 @@ class McpServer:
         if origin in (Union, UnionType):
             return {"anyOf": [self._type_to_json_schema(t) for t in get_args(py_type)]}
 
-        # list[T]
+        # List[T]
         if origin is list:
             return {
                 "type": "array",
                 "items": self._type_to_json_schema(get_args(py_type)[0]),
             }
 
-        # dict[str, T]
+        # Dict[str, T]
         if origin is dict:
             return {
                 "type": "object",
@@ -1131,7 +1136,7 @@ class McpServer:
                 else:
                     properties[param_name]["default"] = param.default
 
-        schema: dict[str, Any] = {
+        schema: Dict[str, Any] = {
             "name": func_name,
             "description": (func.__doc__ or f"Call {func_name}").strip(),
             "inputSchema": {


### PR DESCRIPTION
- Replace match/case with if/elif/else (Python 3.10+ only)
- Move NotRequired, Annotated, Required, is_typeddict, TypeAlias from typing to typing_extensions
- Add from __future__ import annotations to files missing it
- Replace runtime list[X]/dict[X]/tuple[X]/set[X] with List[X]/Dict[X]/Tuple[X]/Set[X] for Python 3.8
- Fix UnionType import (try/except for Python <3.10)
- Fix functools.cache -> lru_cache(maxsize=None)
- Fix dataclass(slots=True) -> remove slots (Python 3.10+ only)
- Fix X | Y union syntax in functional TypedDict bodies
- Adjust pyproject.toml: requires-python >=3.8, remove idapro dep
- Add typing_extensions dependency via pip install