### PR TITLE
feat(idalib): add idb_close tool to save and release worker sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ _Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://githu
 
 ## Headless idalib Session Model
 
-`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 1 hour). There is no `idb_close` tool — clients that no longer care about a database simply stop using it, and only the user can close a GUI window.
+`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 1 hour). Call `idb_close` to release a worker eagerly (freeing a slot toward `--max-workers`), adopted GUI/worker instances are detached rather than killed.
 
 `idb_open` picks the backend via its `mode` parameter:
 
@@ -225,6 +225,7 @@ xrefs_to("ImportantExport", database="library")
 
 - `idb_open(input_path, mode="prefer_headless", run_auto_analysis=True, build_caches=True, init_hexrays=True, preferred_session_id="")`: Open a binary, warm up subsystems (strings cache, Hex-Rays), and return its session ID. If a worker or GUI for this path is already running on the host, that instance is adopted and `preferred_session_id` is ignored.
 - `idb_list()`: List open sessions and running GUI IDA instances. Each entry has `adopted` (True if this supervisor manages it, False for GUIs/workers discovered but not yet opened via `idb_open`), `backend` (`worker` or `gui`), `is_active`, and process IDs.
+- `idb_close(database, save=True)`: Save (optionally), unregister the session, and terminate its owned worker, freeing a slot toward `--max-workers`. Adopted GUI/worker instances are detached, not killed.
 - `idb_save(session_id, path="")`: Save a session's IDB to disk. Forwarded as a regular worker tool (`database=<id>` injected) — same signature in both backends.
 - Per-database health: call `server_health(database=<id>)` (forwarded). `idb_list()` reports `is_active` from the supervisor's TCP/RPC probe.
 

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -52,6 +52,7 @@ IDB_OPEN_MODES = {
 IDB_MANAGEMENT_TOOLS = {
     "idb_open",
     "idb_list",
+    "idb_close",
 }
 WORKER_TCP_HEALTH_TIMEOUT_SEC = 0.5
 WORKER_RPC_HEALTH_TIMEOUT_SEC = 2.0
@@ -134,6 +135,17 @@ class IdalibOpenResult(TypedDict, total=False):
 class IdalibListResult(TypedDict, total=False):
     sessions: list[IdalibSessionListInfo]
     count: int
+    error: str
+
+
+class IdalibCloseResult(TypedDict, total=False):
+    success: bool
+    session_id: str
+    backend: str
+    owned: bool
+    saved: bool | None
+    save_error: str
+    message: str
     error: str
 
 
@@ -908,6 +920,42 @@ class IdalibSupervisor:
             session.last_accessed = datetime.now()
             return session
 
+    def close_session(self, database: str, *, save: bool = True) -> IdalibCloseResult:
+        """Save (optionally), unregister, and terminate a session's owned worker.
+
+        Adopted GUI/worker instances (``owned`` is False) are detached rather
+        than killed: they keep running so another supervisor can adopt them.
+        """
+        session = self.peek_session(database)
+        saved: bool | None = None
+        save_error: str | None = None
+        if save and self._session_is_reachable(session):
+            try:
+                result = self.call_worker_tool(session, "idb_save")
+                if isinstance(result, dict):
+                    saved = bool(result.get("ok"))
+                    if result.get("error"):
+                        save_error = str(result["error"])
+            except Exception as e:
+                save_error = str(e)
+
+        with self._lock:
+            if self.sessions.get(database) is session:
+                self._unregister_session_locked(database)
+        self._terminate_worker(session)
+
+        info: IdalibCloseResult = {
+            "success": True,
+            "session_id": database,
+            "backend": session.backend,
+            "owned": session.owned,
+            "saved": saved,
+            "message": f"Session closed: {session.filename} ({database})",
+        }
+        if save_error is not None:
+            info["save_error"] = save_error
+        return info
+
     def list_sessions(self) -> list[IdalibSessionListInfo]:
         with self._lock:
             adopted = [
@@ -1086,6 +1134,23 @@ def idb_list() -> IdalibListResult:
         return {"sessions": sessions, "count": len(sessions)}
     except Exception as e:
         return {"error": f"Failed to list sessions: {e}"}
+
+
+@mcp.tool
+def idb_close(
+    database: Annotated[str, "Session ID returned by idb_open (see idb_list)."],
+    save: Annotated[bool, "Save the database before closing"] = True,
+) -> IdalibCloseResult:
+    """
+    Close a session: optionally save it, unregister it from the supervisor, and
+    terminate its owned worker (freeing a worker slot). Adopted GUI/worker instances
+    are detached, not killed.
+    """
+    sup = _require_supervisor()
+    try:
+        return sup.close_session(database, save=save)
+    except Exception as e:
+        return {"error": str(e)}
 
 
 @mcp.resource("ida://databases")

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -765,6 +765,158 @@ def test_list_sessions_reports_is_active_from_health_probe(tmp_path):
     assert listed == {"first": True, "second": False}
 
 
+def test_close_session_saves_and_terminates_owned_worker(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+
+    result = sup.close_session("sample", save=True)
+
+    assert result["success"] is True
+    assert result["saved"] is True
+    assert result["owned"] is True
+    assert ("idb_save", None) in sup.tool_calls
+    assert "sample" not in sup.sessions
+    assert sup.path_to_session == {}
+    assert session.process.returncode == 0
+
+
+def test_close_session_without_save_skips_idb_save(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+
+    result = sup.close_session("sample", save=False)
+
+    assert result["saved"] is None
+    assert all(name != "idb_save" for name, _ in sup.tool_calls)
+    assert "sample" not in sup.sessions
+    assert session.process.returncode == 0
+
+
+def test_close_session_unknown_session_raises():
+    sup = _FakeSupervisor()
+    try:
+        sup.close_session("nope")
+    except RuntimeError as e:
+        assert "not found" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError for unknown session")
+
+
+def test_close_session_requires_database():
+    sup = _FakeSupervisor()
+    try:
+        sup.close_session("")
+    except RuntimeError as e:
+        assert "database is required" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError for empty database")
+
+
+def test_close_session_detaches_adopted_worker_without_killing(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    adopted = supmod.WorkerSession(
+        session_id="adopted",
+        input_path=str(sample.resolve()),
+        filename="sample.bin",
+        process=_FakeProcess(),
+        owned=False,
+    )
+    with sup._lock:
+        sup._register_session_locked(adopted, str(sample.resolve()))
+
+    result = sup.close_session("adopted", save=False)
+
+    assert result["owned"] is False
+    assert "adopted" not in sup.sessions
+    assert sup.path_to_session == {}
+    assert adopted.process.returncode is None
+
+
+def test_close_session_reports_save_failure_but_still_closes(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+
+    class _SaveFailsSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None, *, timeout=None):
+            if name == "idb_save":
+                self.tool_calls.append((name, arguments))
+                return {"ok": False, "path": None, "error": "disk full"}
+            return super().call_worker_tool(worker, name, arguments)
+
+    sup = _SaveFailsSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+
+    result = sup.close_session("sample", save=True)
+
+    assert result["saved"] is False
+    assert result["save_error"] == "disk full"
+    assert "sample" not in sup.sessions
+    assert session.process.returncode == 0
+
+
+def test_close_session_frees_worker_slot(tmp_path):
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    first.write_bytes(b"1")
+    second.write_bytes(b"2")
+    restore = _patch_discovery(instances=[], probe=False)
+    try:
+        sup = _FakeSupervisor()
+        sup.max_workers = 1
+        sup.open_session(str(first), session_id="first")
+
+        # A second open is blocked while the single slot is occupied.
+        try:
+            sup.open_session(str(second), session_id="second")
+        except RuntimeError as e:
+            assert "Maximum idalib worker count reached" in str(e)
+        else:
+            raise AssertionError("expected the worker limit to be reached")
+
+        sup.close_session("first", save=False)
+
+        reopened = sup.open_session(str(second), session_id="second")
+        assert reopened.session_id == "second"
+    finally:
+        restore()
+
+
+def test_close_session_skips_save_when_unreachable(tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    session = sup.open_session(str(sample), session_id="sample")
+    sup._session_is_reachable = lambda candidate: False
+
+    result = sup.close_session("sample", save=True)
+
+    assert result["saved"] is None
+    assert all(name != "idb_save" for name, _ in sup.tool_calls)
+    assert "sample" not in sup.sessions
+    assert session.process.returncode == 0
+
+
+def test_idb_close_tool_returns_error_for_unknown_session():
+    old_supervisor = supmod.supervisor
+    supmod.supervisor = _FakeSupervisor()
+    try:
+        result = supmod.idb_close("nope")
+        assert "not found" in result["error"]
+    finally:
+        supmod.supervisor = old_supervisor
+
+
+def test_idb_close_is_a_management_tool_symbol():
+    assert "idb_close" in supmod.IDB_MANAGEMENT_TOOLS
+    assert callable(supmod.idb_close)
+
+
 def test_supervisor_uses_idb_prefixed_management_tools_only():
     """No legacy names should leak into IDB_MANAGEMENT_TOOLS or module symbols."""
     legacy = {
@@ -772,14 +924,13 @@ def test_supervisor_uses_idb_prefixed_management_tools_only():
         "idalib_close",
         "idalib_list",
         "idalib_save",
-        "idb_close",
         "idalib_switch",
         "idalib_unbind",
         "idalib_current",
         "idalib_warmup",
         "idalib_health",
     }
-    assert supmod.IDB_MANAGEMENT_TOOLS == {"idb_open", "idb_list"}
+    assert supmod.IDB_MANAGEMENT_TOOLS == {"idb_open", "idb_list", "idb_close"}
     for name in legacy:
         assert not hasattr(supmod, name), f"{name} should have been deleted"
     for typename in ("IdalibWarmupResult", "IdalibHealthResult"):


### PR DESCRIPTION
Fixes #486. The idalib supervisor caps concurrent workers at `--max-workers` (default 4) and workers only self-exit after their idle TTL, so opening more binaries fails with *"Maximum idalib worker count reached"* with no way to release a session.

Adds an `idb_close(database, save=True)` management tool that saves the DB (via the worker's `idb_save`), unregisters the session and its path bindings, and terminates the owned worker to free a slot. Adopted GUI/worker instances are detached, not killed.

If you see anything to change or ways to improve the feature, feel free to let me know. Happy to iterate.