### PR TITLE
fix(idb_save): never DBFL_KILL working files of an open database

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -835,43 +835,24 @@ def idb_save(
 ) -> IdbSaveResult:
     """Save active IDB to disk, optionally to a provided path.
 
-    In the GUI (idaq) the open database is backed by loose working files
-    (.id0/.id1/.id2/.nam/.til) that IDA actively manages; packing+killing them
-    out from under the running GUI corrupts the database on the next reopen
-    (issue #446). So in GUI mode this uses IDA's native in-place save
-    (equivalent to Ctrl+W / save_database(None, 0)), and for an explicit
-    different destination writes a compressed copy WITHOUT killing the live
-    working files.
-
-    Only headless idalib — which has no live loose files to clobber — packs into
-    a single compressed .i64/.idb, removing the loose working files.
+    The open database is backed by loose working files (.id0/.id1/.id2/.nam/.til)
+    that IDA actively manages, headless included. Killing them out from under the
+    open database corrupts it (issues #446, #498), so DBFL_KILL is never used
+    here: an in-place save uses IDA's native save (Ctrl+W), and an explicit
+    different destination gets a compressed copy while the working files stay.
     """
     try:
         save_path = path.strip() if path else ""
+        current = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
         if not save_path:
-            save_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+            save_path = current
         if not save_path:
             return {"ok": False, "path": None, "error": "Could not resolve IDB path"}
 
-        try:
-            is_gui = bool(ida_kernwin.is_idaq())
-        except Exception:
-            is_gui = False
-
-        if is_gui:
-            # GUI: never DBFL_KILL the loose files of the open database.
-            current = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
-            if path and save_path != current:
-                # Save-as a compressed snapshot to a new path; leaves the live
-                # working files intact.
-                ok = bool(ida_loader.save_database(save_path, ida_loader.DBFL_COMP))
-            else:
-                # Native in-place save (Ctrl+W).
-                ok = bool(ida_loader.save_database(None, 0))
+        if save_path != current:
+            ok = bool(ida_loader.save_database(save_path, ida_loader.DBFL_COMP))
         else:
-            # Headless idalib: safe to pack into a single compressed file.
-            flags = ida_loader.DBFL_KILL | ida_loader.DBFL_COMP
-            ok = bool(ida_loader.save_database(save_path, flags))
+            ok = bool(ida_loader.save_database(None, 0))
 
         result: dict = {"ok": ok, "path": save_path}
         if not ok:

--- a/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/tests/test_api_core.py
@@ -30,6 +30,7 @@ from ..api_core import (
     server_warmup,
     find_regex,
     search_text,
+    idb_save,
 )
 
 
@@ -553,3 +554,25 @@ def test_search_text_regex_mode():
         skip_test("no call/jmp in binary")
     for h in result["hits"]:
         assert h["matches"]
+
+
+@test()
+def test_idb_save_keeps_working_files():
+    """Repeated saves must not delete the open database's working files (#498)."""
+    import os
+    import ida_loader
+
+    idb = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+    base = os.path.splitext(idb)[0] if idb.lower().endswith((".i64", ".idb")) else idb
+    parts = [base + ext for ext in (".id0", ".id1", ".id2", ".nam", ".til")]
+    before = [p for p in parts if os.path.exists(p)]
+    if not before:
+        skip_test("no loose working files for this database")
+
+    for _ in range(2):
+        result = idb_save()
+        assert result["ok"], result.get("error")
+        missing = [p for p in before if not os.path.exists(p)]
+        assert not missing, f"save removed working files: {missing}"
+
+    assert_non_empty(list_funcs({"offset": 0, "count": 5})[0]["data"])

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -971,6 +971,11 @@ class IdalibSupervisor:
             if self.sessions.get(database) is session:
                 self._unregister_session_locked(database)
         self._terminate_worker(session)
+        if saved and session.owned:
+            # The worker is SIGTERM'd without a clean close_database(), so the
+            # working files it unpacked stay behind; the save above already
+            # rewrote the packed database.
+            self._cleanup_partial_database(session.input_path)
 
         info: IdalibCloseResult = {
             "success": True,


### PR DESCRIPTION
Closes #498.

- `idb_save` no longer branches on GUI vs headless: the database is open either way, so the loose `.id0/.id1/.id2/.nam/.til` files are live and `DBFL_KILL` corrupts them mid-session. In-place saves use IDA's native save, an explicit different destination gets a `DBFL_COMP` copy.
- `close_session` now cleans up the leftover working files after terminating the worker, since the SIGTERM path has no clean `close_database()`.
- New `test_idb_save_keeps_working_files` verified failing on the old behavior, passing on the fix. Full fixture suites green (349 / 323+2 skipped), supervisor tests 69 passed.
