### PR TITLE
feat: expose ignore_micro (skippable instructions) in disasm output and add set_ignore_micro tool

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_analysis.py
+++ b/src/ida_pro_mcp/ida_mcp/api_analysis.py
@@ -45,6 +45,8 @@ from .utils import (
     InsnPattern,
     FuncProfileQuery,
     AnalyzeBatchQuery,
+    im_get_node,
+    im_get_tag,
 )
 from . import compat
 
@@ -616,13 +618,16 @@ def _limit_items(items: list, limit: int) -> tuple[list, bool]:
 def _disasm_lines_limited(func: ida_funcs.func_t, max_insns: int) -> tuple[list[str], bool]:
     lines: list[str] = []
     truncated = False
+    im_node = im_get_node()
     for item_ea in idautils.FuncItems(func.start_ea):
         if len(lines) >= max_insns:
             truncated = True
             break
         line = ida_lines.generate_disasm_line(item_ea, 0)
         instruction = ida_lines.tag_remove(line) if line else ""
-        lines.append(f"{item_ea:x}  {compact_whitespace(instruction)}")
+        tag = im_get_tag(item_ea, im_node)
+        suffix = f"  [SKIP:{tag}]" if tag else ""
+        lines.append(f"{item_ea:x}  {compact_whitespace(instruction)}{suffix}")
     return lines, truncated
 
 
@@ -795,7 +800,17 @@ def disasm(
         bool, "Compute total instruction count (default: false)"
     ] = False,
 ) -> DisasmResult:
-    """Disassemble function with offset/max_instructions pagination and optional total count."""
+    """Disassemble function with offset/max_instructions pagination and optional total count.
+
+    Each instruction line may include an 'ignore_micro' field ("prolog", "epilog",
+    or "switch") indicating the decompiler will skip/NOP this instruction.
+    If decompiled output looks wrong, an incorrectly marked instruction may be
+    the cause. Use set_ignore_micro(im_type='none') to clear the mark and
+    re-decompile.
+
+    If a comment contains '[ida-mcp: restore ignore_micro to <type>]', it means
+    the instruction was previously modified. To undo, call set_ignore_micro with
+    im_type set to the <type> value shown after 'to' in that comment."""
 
     # Enforce max limit
     if max_instructions <= 0 or max_instructions > 50000:
@@ -833,6 +848,8 @@ def disasm(
         total_count = 0
         more = False
 
+        _im_node = im_get_node()
+
         def _maybe_add(ea: int) -> bool:
             nonlocal seen, total_count, more
             if include_total:
@@ -856,6 +873,9 @@ def disasm(
                 refs = _collect_line_refs(ea)
                 if refs:
                     entry["refs"] = refs
+                tag = im_get_tag(ea, _im_node)
+                if tag:
+                    entry["ignore_micro"] = tag
                 lines.append(entry)
                 seen += 1
                 return True
@@ -2225,12 +2245,17 @@ def insn_query(
             )
 
             rows = []
+            _im_node = im_get_node()
             for addr_s in addresses:
                 ea = int(addr_s, 16)
                 row = {"addr": addr_s}
                 if include_disasm:
                     line = ida_lines.generate_disasm_line(ea, 0)
-                    row["disasm"] = compact_whitespace(ida_lines.tag_remove(line)) if line else ""
+                    disasm_text = compact_whitespace(ida_lines.tag_remove(line)) if line else ""
+                    tag = im_get_tag(ea, _im_node)
+                    if tag:
+                        disasm_text += f"  [SKIP:{tag}]"
+                    row["disasm"] = disasm_text
                 if include_fn:
                     row["fn"] = get_function(ea, raise_error=False)
                 rows.append(row)

--- a/src/ida_pro_mcp/ida_mcp/api_modify.py
+++ b/src/ida_pro_mcp/ida_mcp/api_modify.py
@@ -1317,3 +1317,121 @@ def make_data(
             results.append({"addr": addr_str, "ok": False, "error": str(e)})
 
     return results
+
+
+# ============================================================================
+# Ignore Micro (Skippable Instructions)
+# ============================================================================
+
+
+class IgnoreMicroOp(TypedDict):
+    addr: str
+    im_type: str
+
+
+class IgnoreMicroResult(TypedDict, total=False):
+    addr: str
+    previous: str
+    current: str
+    restore_to: str
+    warning: str
+    error: str
+
+
+@tool
+@idasync
+def set_ignore_micro(
+    ops: Annotated[
+        list[IgnoreMicroOp],
+        "List of {addr, im_type} to set. "
+        "im_type: 'none' to clear, 'prolog', 'epilog', or 'switch' to mark.",
+    ],
+) -> list[IgnoreMicroResult]:
+    """Set or clear the ignore_micro (skippable instruction) flag for one or more addresses.
+
+    Instructions marked as 'prolog', 'epilog', or 'switch' are skipped by the
+    decompiler and shown with a colored background in disassembly view.
+    Use 'none' to clear an incorrect mark so the decompiler processes the
+    instruction normally.
+
+    When a mark is changed for the first time, the original value is saved as a
+    comment (e.g. '[ida-mcp: restore ignore_micro to prolog]'). To undo the
+    change, set im_type to the value shown after 'to' in that comment. The
+    backup comment is removed automatically upon successful restoration.
+
+    IMPORTANT: To restore instructions to their original state, you MUST first
+    call disasm() to read the comments and find the '[ida-mcp: restore
+    ignore_micro to <type>]' tag. The <type> after 'to' is the correct value
+    to restore. Do NOT assume the default is 'none'.
+
+    After modifying, re-decompile (F5) to see updated pseudocode.
+    """
+    from .utils import (
+        IM_FROM_STR, IM_NAMES,
+        im_get_node,
+        im_backup_comment,
+        im_remove_backup_comment,
+        im_get_backup_type,
+    )
+
+    node = im_get_node()
+    results: list[IgnoreMicroResult] = []
+
+    for op in ops:
+        addr_str = op.get("addr", "?")
+        try:
+            ea = parse_address(addr_str)
+            im_type_str = op["im_type"].strip().lower()
+            im_val = IM_FROM_STR.get(im_type_str)
+            if im_val is None:
+                results.append({
+                    "addr": f"{ea:x}",
+                    "previous": "",
+                    "current": "",
+                    "error": f"Invalid im_type '{op['im_type']}'. "
+                             f"Valid values: {', '.join(IM_FROM_STR.keys())}",
+                })
+                continue
+
+            prev = node.charval_ea(ea, 0)
+            prev_str = IM_NAMES.get(prev, "none")
+
+            existing_backup = im_get_backup_type(ea)
+            if existing_backup is None:
+                # First time modified: save the original initial state
+                if im_type_str != prev_str:
+                    im_backup_comment(ea, prev_str)
+            else:
+                # Remove backup only if restored to the original initial state
+                if im_type_str == existing_backup:
+                    im_remove_backup_comment(ea)
+
+            if im_val == 0:
+                node.chardel_ea(ea, 0)
+            else:
+                node.charset_ea(ea, im_val, 0)
+
+            result_entry: IgnoreMicroResult = {
+                "addr": f"{ea:x}",
+                "previous": prev_str,
+                "current": im_type_str,
+            }
+            remaining_backup = im_get_backup_type(ea)
+            if remaining_backup:
+                result_entry["restore_to"] = remaining_backup
+                if im_type_str != remaining_backup:
+                    result_entry["warning"] = (
+                        f"This instruction's original value was '{remaining_backup}'. "
+                        f"To restore, use set_ignore_micro with "
+                        f"im_type='{remaining_backup}', not '{im_type_str}'."
+                    )
+            results.append(result_entry)
+        except Exception as e:
+            results.append({
+                "addr": addr_str,
+                "previous": "",
+                "current": "",
+                "error": str(e),
+            })
+
+    return results

--- a/src/ida_pro_mcp/ida_mcp/utils.py
+++ b/src/ida_pro_mcp/ida_mcp/utils.py
@@ -22,13 +22,89 @@ import ida_bytes
 import ida_funcs
 import ida_hexrays
 import ida_kernwin
+import ida_name
 import ida_nalt
+import ida_netnode
 import ida_typeinf
 import idaapi
 import idautils
 import idc
 
 from .sync import IDAError
+
+# ============================================================================
+# Ignore Micro (Skippable Instructions) Constants & Helpers
+# ============================================================================
+
+IM_NONE = 0
+IM_PROLOG = 1
+IM_EPILOG = 2
+IM_SWITCH = 3
+IM_NAMES: dict[int, str] = {IM_PROLOG: "prolog", IM_EPILOG: "epilog", IM_SWITCH: "switch"}
+IM_FROM_STR: dict[str, int] = {"none": IM_NONE, "prolog": IM_PROLOG, "epilog": IM_EPILOG, "switch": IM_SWITCH}
+IM_NETNODE_NAME = "$ ignore micro"
+_IM_CMT_PREFIX = "[ida-mcp: restore ignore_micro to "
+
+
+def im_get_node() -> ida_netnode.netnode:
+    """Get the ignore_micro netnode instance."""
+    return ida_netnode.netnode(IM_NETNODE_NAME)
+
+
+def im_get_tag(ea: int, node: ida_netnode.netnode | None = None) -> str | None:
+    """Return the ignore_micro type string for ea, or None if not marked."""
+    if node is None:
+        node = im_get_node()
+    val = node.charval_ea(ea, 0)
+    return IM_NAMES.get(val)
+
+
+def im_backup_comment(ea: int, im_type_str: str) -> None:
+    """Save the original ignore_micro type as a comment for cross-session recovery.
+
+    Prefers regular comments (0) so the tag is always visible in IDA GUI,
+    even when another regular comment already exists on the line.
+    """
+    tag = f"{_IM_CMT_PREFIX}{im_type_str}]"
+    reg_cmt = ida_bytes.get_cmt(ea, 0) or ""
+    rep_cmt = ida_bytes.get_cmt(ea, 1) or ""
+    if tag in reg_cmt or tag in rep_cmt:
+        return
+
+    # Clean existing tags from both comment types first
+    im_remove_backup_comment(ea)
+
+    # Re-fetch existing regular comment after cleanup and attach tag
+    reg_cmt = ida_bytes.get_cmt(ea, 0) or ""
+    new_cmt = f"{reg_cmt} {tag}".strip() if reg_cmt else tag
+    ida_bytes.set_cmt(ea, new_cmt, 0)
+
+
+def im_remove_backup_comment(ea: int) -> None:
+    """Remove the ignore_micro backup tag from both regular and repeatable comments."""
+    for r in (0, 1):
+        existing = ida_bytes.get_cmt(ea, r) or ""
+        if _IM_CMT_PREFIX in existing:
+            cleaned = im_remove_backup_comment_str(existing)
+            ida_bytes.set_cmt(ea, cleaned if cleaned else None, r)
+
+
+def im_remove_backup_comment_str(cmt: str) -> str:
+    """Strip the [ida-mcp: restore ignore_micro to ...] tag from a comment string."""
+    import re
+    cleaned = re.sub(r"\s*\[ida-mcp: restore ignore_micro to \w+\]", "", cmt).strip()
+    return cleaned
+
+
+def im_get_backup_type(ea: int) -> str | None:
+    """Read the backed-up original ignore_micro type from regular or repeatable comment."""
+    import re
+    for r in (0, 1):
+        cmt = ida_bytes.get_cmt(ea, r) or ""
+        m = re.search(r"\[ida-mcp: restore ignore_micro to (\w+)\]", cmt)
+        if m:
+            return m.group(1)
+    return None
 
 # ============================================================================
 # Analysis Prompt Configuration
@@ -483,6 +559,18 @@ class DisassemblyLine(TypedDict):
     instruction: str
     comments: NotRequired[list[str]]
     refs: NotRequired[list[Ref]]
+    ignore_micro: NotRequired[str]
+    """If present, the instruction is marked as a skippable instruction
+    ("prolog", "epilog", or "switch") that the decompiler will skip/NOP.
+    When the decompiler produces incorrect pseudocode, check whether
+    a necessary instruction was incorrectly marked. Use set_ignore_micro
+    with im_type='none' to clear the mark, then re-decompile.
+
+    If a comment contains '[ida-mcp: restore ignore_micro to <type>]',
+    the instruction was previously modified by set_ignore_micro. To undo
+    the change, call set_ignore_micro with im_type=<type> (the value
+    shown after 'to'). The backup comment is removed automatically
+    upon successful restoration."""
 
 
 class Argument(TypedDict):
@@ -1191,6 +1279,7 @@ def get_assembly_lines(ea: int) -> str:
     # Build compact string format
     lines_str = f"{func_name} ({segment_name} @ {hex(func.start_ea)}):"
 
+    im_node = im_get_node()
     for item_ea in idautils.FuncItems(func.start_ea):
         mnem = idc.print_insn_mnem(item_ea) or ""
         ops = []
@@ -1199,7 +1288,9 @@ def get_assembly_lines(ea: int) -> str:
                 break
             ops.append(idc.print_operand(item_ea, n) or "")
         instruction = f"{mnem} {', '.join(ops)}".rstrip()
-        lines_str += f"\n{item_ea:x}  {instruction}"
+        tag = im_get_tag(item_ea, im_node)
+        suffix = f"  [SKIP:{tag}]" if tag else ""
+        lines_str += f"\n{item_ea:x}  {instruction}{suffix}"
 
     return lines_str
 


### PR DESCRIPTION
## Motivation

While using ida-pro-mcp with an AI assistant to analyze a DLL containing hand-written x86 assembly, I encountered a case where the decompiler produced incorrect pseudocode. The root cause turned out to be IDA's **"skippable instructions"** mechanism (`ignore_micro`): the processor module had incorrectly marked two `push` instructions as function **prolog**, causing the decompiler to NOP them during microcode generation.

I reported this issue on the Hex-Rays community forum:
- **[The x86 decompiler plugin incorrectly NOPs necessary assembly instructions, leading to incorrect C pseudocode generation](https://community.hex-rays.com/t/the-x86-decompiler-plugin-incorrectly-nops-necessary-assembly-instructions-leading-to-incorrect-c-pseudocode-generation/728)**

Following the official guidance from [Igor's tip of the week #68: Skippable instructions](https://hex-rays.com/blog/igors-tip-of-the-week-68-skippable-instructions), I was able to fix the issue by manually clearing the incorrect `ignore_micro` flags. However, the entire diagnosis and fix process required deep knowledge of IDA internals (netnodes, `ignore_micro_t`, etc.) — something an AI assistant currently has no visibility into.

**This PR gives the AI full visibility into skippable instruction flags and the ability to fix them**, making it possible for an AI to autonomously diagnose and repair this class of decompilation errors.

## What's Changed

### 1. Expose `ignore_micro` status in all disassembly output

Every disassembly output path now indicates when an instruction is marked as skippable:

- **`disasm` tool** (structured output): Adds an `ignore_micro` field (`"prolog"`, `"epilog"`, or `"switch"`) to `DisassemblyLine`
- **`func_profile`** / **`insn_query`** / **`get_assembly_lines`** (text output): Appends `[SKIP:<type>]` suffix to marked instruction lines

This means the AI can see at a glance which instructions the decompiler will skip, regardless of which tool it uses.

### 2. Add `set_ignore_micro` tool

A new batch modification tool that sets or clears `ignore_micro` flags:
```json
{"ops": [
  {"addr": "0x100010C5", "im_type": "none"},
  {"addr": "0x100010C6", "im_type": "prolog"}
]}
```

### 3. Cross-session state tracking with automatic backup/restore

When `set_ignore_micro` modifies a flag for the first time, the original value is saved as a regular comment visible in IDA's GUI:
```
push ebx  ; y [ida-mcp: restore ignore_micro to prolog]
```

This ensures:
- A **new AI session** can read the comment and know exactly what value to restore to
- The backup comment is **automatically removed** when the instruction is restored to its original state
- If the AI sets a wrong value, the result includes a `warning` field with explicit guidance:
  ```json
  {
    "addr": "100010c5",
    "previous": "epilog",
    "current": "none",
    "restore_to": "prolog",
    "warning": "This instruction's original value was 'prolog'. To restore, use set_ignore_micro with im_type='prolog', not 'none'."
  }
  ```

### 4. Self-documenting design

All docstrings (`disasm`, `DisassemblyLine`, `set_ignore_micro`) explain what `ignore_micro` means and how to use it. Even if `set_ignore_micro` is disabled via the config page, the AI can still understand the `ignore_micro` field in disasm output.

## Files Changed

| File | Lines | Summary |
|------|-------|---------|
| `utils.py` | +93 | Constants, helpers (`im_get_tag`, `im_backup_comment`, etc.), `DisassemblyLine.ignore_micro` field |
| `api_analysis.py` | +31 | `disasm`, `_disasm_lines_limited`, `insn_query`, `get_assembly_lines` all output ignore_micro info |
| `api_modify.py` | +118 | New `set_ignore_micro` tool with backup/restore logic |

## Example Workflow

**Before this PR**: The AI sees wrong pseudocode, has no way to know *why*, and cannot fix it.

**After this PR**:
1. AI calls `disasm("__Hello2")` → sees `"ignore_micro": "prolog"` on `push ebx`
2. AI recognizes this instruction shouldn't be skipped → calls `set_ignore_micro(addr="0x100010C5", im_type="none")`
3. AI re-decompiles → correct pseudocode ✅
4. In a future session, another AI sees `[ida-mcp: restore ignore_micro to prolog]` in comments → knows exactly how to undo if needed
