### PR TITLE
feat(idalib): configure startup worker idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ _Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://githu
 
 ## Headless idalib Session Model
 
-`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 1 hour). Call `idb_close` to release a worker eagerly (freeing a slot toward `--max-workers`), adopted GUI/worker instances are detached rather than killed.
+`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 10 minutes). Call `idb_close` to release a worker eagerly (freeing a slot toward `--max-workers`), adopted GUI/worker instances are detached rather than killed.
 
 `idb_open` picks the backend via its `mode` parameter:
 
@@ -249,6 +249,8 @@ Worker controls:
 
 - `--max-workers N`: maximum simultaneous database workers (`0` = unlimited, default `4`).
 - `IDA_MCP_MAX_WORKERS`: environment default for `--max-workers`.
+- `--idle-timeout SECONDS`: idle timeout for a new worker opened from the positional `input_path` (`0` = disabled, default `600`). An existing worker keeps its current timeout.
+- `IDA_MCP_IDLE_TIMEOUT`: environment default for `--idle-timeout`.
 
 The bundled Codex plugin forwards the runtime's `IDA_MCP_*` configuration variables from the Codex host environment:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ _Note_: The `idalib` feature was contributed by [Willi Ballenthin](https://githu
 
 ## Headless idalib Session Model
 
-`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 1 hour). Call `idb_close` to release a worker eagerly (freeing a slot toward `--max-workers`), adopted GUI/worker instances are detached rather than killed.
+`idalib-mcp` is a supervisor that keeps each open database in its own idalib worker process. Workers register themselves in a host-local discovery directory and outlive the supervisor that spawned them; any subsequent supervisor that wants the same path adopts the running worker. A worker self-exits when no request has hit it for its idle TTL (default 10 minutes). Call `idb_close` to release a worker eagerly (freeing a slot toward `--max-workers`), adopted GUI/worker instances are detached rather than killed.
 
 `idb_open` picks the backend via its `mode` parameter:
 
@@ -249,6 +249,8 @@ Worker controls:
 
 - `--max-workers N`: maximum simultaneous database workers (`0` = unlimited, default `4`).
 - `IDA_MCP_MAX_WORKERS`: environment default for `--max-workers`.
+- `--idle-timeout SECONDS`: idle timeout for a new worker opened from the positional `input_path` (`0` = disabled, default `600`). An existing worker keeps its current timeout.
+- `IDA_MCP_IDLE_TIMEOUT`: environment default for `--idle-timeout`.
 
 
 ## MCP Resources

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -103,7 +103,7 @@ def idb_open(
     init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler after open"] = True,
     idle_ttl_sec: Annotated[
         int,
-        "Minimum idle TTL in seconds before the headless worker self-exits.",
+        "Minimum idle TTL in seconds before the headless worker self-exits (0 disables the timeout).",
     ] = 600,
     preferred_session_id: Annotated[
         str,

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -1293,7 +1293,7 @@ def idb_open(
     init_hexrays: Annotated[bool, "Initialize Hex-Rays decompiler after open"] = True,
     idle_ttl_sec: Annotated[
         int,
-        "Minimum idle TTL in seconds before the headless worker self-exits.",
+        "Minimum idle TTL in seconds before the headless worker self-exits (0 disables the timeout).",
     ] = 600,
     preferred_session_id: Annotated[
         str, "Preferred session ID (auto-generated if empty). Ignored if the file is already open in a GUI or worker session."
@@ -1485,8 +1485,18 @@ def main() -> None:
         default=int(os.environ.get("IDA_MCP_MAX_WORKERS", "4")),
         help="Maximum simultaneous idalib worker databases (0 = unlimited, default: 4).",
     )
+    parser.add_argument(
+        "--idle-timeout",
+        type=int,
+        default=os.environ.get("IDA_MCP_IDLE_TIMEOUT", "600"),
+        metavar="SECONDS",
+        help="Idle timeout for a new worker opened from the initial input path (0 = disabled, default: 600).",
+    )
     parser.add_argument("input_path", type=Path, nargs="?", help="Optional binary to open on startup.")
     args = parser.parse_args()
+
+    if args.idle_timeout < 0:
+        parser.error("--idle-timeout must be 0 or greater")
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
@@ -1508,7 +1518,7 @@ def main() -> None:
 
     if args.input_path is not None:
         try:
-            supervisor.open_session(str(args.input_path))
+            supervisor.open_session(str(args.input_path), idle_ttl_sec=args.idle_timeout)
         except Exception as e:
             raise SystemExit(f"Failed to open initial binary: {e}")
 

--- a/src/ida_pro_mcp/worker_lifecycle.py
+++ b/src/ida_pro_mcp/worker_lifecycle.py
@@ -73,6 +73,9 @@ class WorkerLifecycle:
 
     def set_idle_ttl(self, user_ttl_sec: float, load_time_sec: float = 0.0) -> None:
         with self._lock:
+            if user_ttl_sec == 0:
+                self.idle_ttl_sec = 0
+                return
             self.idle_ttl_sec = (
                 max(self.MIN_IDLE_TTL_SEC, user_ttl_sec) + max(0.0, load_time_sec)
             )

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -591,6 +591,70 @@ def test_open_session_defaults_idle_ttl_sec_to_baseline(tmp_path):
     assert args["idle_ttl_sec"] == 600
 
 
+@pytest.mark.parametrize(
+    ("extra_args", "environment", "expected_timeout"),
+    [
+        ([], {}, 600),
+        (["--idle-timeout", "0"], {}, 0),
+        ([], {"IDA_MCP_IDLE_TIMEOUT": "1800"}, 1800),
+        (["--idle-timeout", "0"], {"IDA_MCP_IDLE_TIMEOUT": "1800"}, 0),
+        (["--idle-timeout", "0"], {"IDA_MCP_IDLE_TIMEOUT": "garbage"}, 0),
+    ],
+)
+def test_main_forwards_initial_worker_idle_timeout(
+    tmp_path, monkeypatch, extra_args, environment, expected_timeout
+):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    opened = []
+
+    class _MainSupervisor:
+        def __init__(self, _mcp, **_kwargs):
+            pass
+
+        def open_session(self, input_path, **kwargs):
+            opened.append((input_path, kwargs))
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(supmod, "supervisor", None)
+    monkeypatch.setattr(supmod, "IdalibSupervisor", _MainSupervisor)
+    test_mcp = supmod.McpServer("test")
+    monkeypatch.setattr(supmod, "mcp", test_mcp)
+    monkeypatch.setattr(test_mcp, "serve", lambda **_kwargs: None)
+    monkeypatch.setattr(supmod.signal, "signal", lambda *_args: None)
+    monkeypatch.delenv("IDA_MCP_IDLE_TIMEOUT", raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(sys, "argv", ["idalib-mcp", *extra_args, str(sample)])
+
+    supmod.main()
+
+    assert opened == [(str(sample), {"idle_ttl_sec": expected_timeout})]
+
+
+def test_main_rejects_negative_initial_worker_idle_timeout(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["idalib-mcp", "--idle-timeout", "-1"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        supmod.main()
+
+    assert exc_info.value.code == 2
+    assert "--idle-timeout must be 0 or greater" in capsys.readouterr().err
+
+
+def test_main_help_ignores_invalid_idle_timeout_environment(monkeypatch, capsys):
+    monkeypatch.setenv("IDA_MCP_IDLE_TIMEOUT", "garbage")
+    monkeypatch.setattr(sys, "argv", ["idalib-mcp", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        supmod.main()
+
+    assert exc_info.value.code == 0
+    assert "--idle-timeout SECONDS" in capsys.readouterr().out
+
+
 def test_open_session_skips_warmup_when_flags_disabled(tmp_path):
     sample = tmp_path / "sample.bin"
     sample.write_bytes(b"x")

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -75,10 +75,16 @@ def test_set_idle_ttl_uses_request_when_above_min():
     assert lc.idle_ttl_sec == 1800.0
 
 
-def test_set_idle_ttl_clamps_to_min():
+def test_set_idle_ttl_zero_disables_timeout():
     lc = WorkerLifecycle(idle_ttl_sec=1000.0)
-    lc.set_idle_ttl(0)
-    assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC
+    lc.set_idle_ttl(0, load_time_sec=120.0)
+    assert lc.idle_ttl_sec == 0
+    lc._last_request_at = time.monotonic() - 1000
+    assert lc.check_shutdown_reason() is None
+
+
+def test_set_idle_ttl_clamps_nonzero_values_below_min():
+    lc = WorkerLifecycle(idle_ttl_sec=1000.0)
     lc.set_idle_ttl(-50.0)
     assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC
     lc.set_idle_ttl(3.0)
@@ -93,7 +99,7 @@ def test_set_idle_ttl_adds_load_time():
 
 def test_set_idle_ttl_clamps_user_then_adds_load_time():
     lc = WorkerLifecycle(idle_ttl_sec=10.0)
-    lc.set_idle_ttl(0.0, load_time_sec=120.0)
+    lc.set_idle_ttl(3.0, load_time_sec=120.0)
     assert lc.idle_ttl_sec == WorkerLifecycle.MIN_IDLE_TTL_SEC + 120.0
 
 


### PR DESCRIPTION
Calls to `idb_open` already accept `idle_ttl_sec`, but the positional startup path always requests a 600-second timeout. In long-running coding-agent sessions, more than ten minutes can pass between IDA calls while the agent analyzes earlier results or works in the surrounding codebase. Keeping the initialized worker available currently requires periodic requests.

Add CLI and environment controls while preserving the existing default. CLI values take precedence over `IDA_MCP_IDLE_TIMEOUT`, which takes precedence over the 600-second default. Zero disables idle expiry.

## Verification

- `uv run pytest -q tests` (`251 passed, 114 subtests passed`)
- Live idle A/B with no worker RPC traffic:
  - `--idle-timeout 10`: registration and listening socket were gone after 15 seconds.
  - `--idle-timeout 0`: registration, listening socket, worker, and supervisor were still present after 630 seconds.