### PR TITLE
docs: add Linux idalib activation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The binaries and prompt for the video are available in the [mcp-reversing-datase
 uv run "C:\Program Files\IDA Professional 9.3\idalib\python\py-activate-idalib.py"
 # macos
 uv run "/Applications/IDA Professional 9.3.app/Contents/MacOS/idalib/python/py-activate-idalib.py"
+# linux
+uv run "/path/to/idapro-9.3/idalib/python/py-activate-idalib.py"
 ```
 
 ## Installation (Claude Code)


### PR DESCRIPTION
The IDALib activation instructions currently include Windows and macOS paths, but no Linux equivalent. This adds the matching Linux command with a generic IDA installation path.

I verified the Linux activation flow with an IDA Pro 9.0.240925 portable installation. The bundled activation script configured IDALib successfully, and `idalib-mcp` initialized IDALib and Hex-Rays, opened and analyzed an ELF binary, and returned a healthy server status.