### PR TITLE
fix(idalib): keep busy workers reachable instead of reaping them

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/api_core.py
+++ b/src/ida_pro_mcp/ida_mcp/api_core.py
@@ -20,6 +20,7 @@ import ida_nalt
 import ida_typeinf
 import idc
 
+from .mainthread import get_pump
 from .rpc import tool
 from .sync import idasync, get_tool_deadline
 from .utils import (
@@ -45,7 +46,7 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
-class ServerHealthResult(TypedDict):
+class ServerHealthResult(TypedDict, total=False):
     status: str
     uptime_sec: float
     idb_path: str | None
@@ -56,6 +57,9 @@ class ServerHealthResult(TypedDict):
     hexrays_ready: bool
     strings_cache_ready: bool
     strings_cache_size: int
+    busy_tool: str
+    busy_sec: float
+    queued_calls: int
 
 
 class ServerWarmupStep(TypedDict, total=False):
@@ -382,11 +386,26 @@ def _build_health_payload() -> dict:
     }
 
 
-@tool
 @idasync
+def _server_health_full() -> ServerHealthResult:
+    return _build_health_payload()
+
+
+@tool
 def server_health() -> ServerHealthResult:
     """Health/ready probe for MCP server and current IDB state."""
-    return _build_health_payload()
+    # Every field below needs the IDA main thread. Report the busy state
+    # rather than queueing behind the very call we are meant to observe.
+    busy = get_pump().busy_status()
+    if busy is not None:
+        return {
+            "status": "busy",
+            "uptime_sec": round(time.time() - _server_started_at, 3),
+            "busy_tool": busy["tool"],
+            "busy_sec": busy["elapsed_sec"],
+            "queued_calls": busy["queued"],
+        }
+    return _server_health_full()
 
 
 @idasync

--- a/src/ida_pro_mcp/ida_mcp/mainthread.py
+++ b/src/ida_pro_mcp/ida_mcp/mainthread.py
@@ -1,0 +1,160 @@
+"""Main-thread job pump for headless (idalib) workers.
+
+idalib has no UI event loop, so execute_sync posted from a secondary thread is
+never dispatched. IDA work must run on the thread that owns the database, so
+the main thread parks here draining jobs while HTTP is served on background
+threads. No IDA imports, so this is unit-testable outside IDA.
+"""
+
+import logging
+import queue
+import threading
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class PumpBusyError(RuntimeError):
+    """A job did not reach the main thread before its deadline."""
+
+
+class _Job:
+    __slots__ = ("fn", "label", "done", "result", "error", "cancelled", "started_at")
+
+    def __init__(self, fn: Callable[[], Any], label: str):
+        self.fn = fn
+        self.label = label
+        self.done = threading.Event()
+        self.result: Any = None
+        self.error: BaseException | None = None
+        self.cancelled = False
+        self.started_at: float | None = None
+
+    def run(self) -> None:
+        self.started_at = time.monotonic()
+        try:
+            self.result = self.fn()
+        except BaseException as e:  # noqa: BLE001 - handed to the waiter
+            self.error = e
+        finally:
+            self.done.set()
+
+
+class MainThreadPump:
+    """Queue of callables executed on the thread that calls :meth:`run`."""
+
+    def __init__(self):
+        self._queue: queue.Queue[_Job] = queue.Queue()
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._thread_id: int | None = None
+        self._current: _Job | None = None
+        self._running = False
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def active(self) -> bool:
+        return self._running
+
+    def on_main_thread(self) -> bool:
+        return self._thread_id == threading.get_ident()
+
+    def busy_status(self) -> dict[str, Any] | None:
+        """Describe the job occupying the main thread, or None if idle."""
+        job = self._current
+        if job is None:
+            return None
+        started = job.started_at
+        return {
+            "tool": job.label,
+            "elapsed_sec": round(time.monotonic() - started, 3) if started else 0.0,
+            "queued": self._queue.qsize(),
+        }
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def arm(self) -> None:
+        """Claim the calling thread as the pump thread, before run().
+
+        HTTP starts first, and a request landing in that gap would otherwise
+        call execute_sync on its handler thread and hang there forever.
+        """
+        self._thread_id = threading.get_ident()
+        self._running = True
+
+    def run(self, poll_interval: float = 0.25) -> None:
+        """Drain jobs until :meth:`stop`. Call from the IDA main thread."""
+        self.arm()
+        try:
+            while not self._stop.is_set():
+                try:
+                    job = self._queue.get(timeout=poll_interval)
+                except queue.Empty:
+                    continue
+                if job.cancelled:
+                    job.done.set()
+                    continue
+                self._current = job
+                try:
+                    job.run()
+                finally:
+                    self._current = None
+        finally:
+            self._running = False
+            self._drain_pending()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _drain_pending(self) -> None:
+        while True:
+            try:
+                job = self._queue.get_nowait()
+            except queue.Empty:
+                return
+            job.error = RuntimeError("worker is shutting down")
+            job.done.set()
+
+    # -- submission --------------------------------------------------------
+
+    def submit(
+        self,
+        fn: Callable[[], Any],
+        *,
+        label: str = "",
+        timeout: float | None = None,
+    ) -> Any:
+        """Run `fn` on the main thread and return its result.
+
+        Raises PumpBusyError past `timeout`. The job is dropped if it never
+        started, else left running: IDA cannot be interrupted from here.
+        """
+        if not self._running:
+            raise RuntimeError("main-thread pump is not running")
+        if self.on_main_thread():
+            return fn()
+
+        job = _Job(fn, label)
+        self._queue.put(job)
+        if job.done.wait(timeout):
+            if job.error is not None:
+                raise job.error
+            return job.result
+
+        if job.started_at is None:
+            job.cancelled = True
+        busy = self.busy_status()
+        raise PumpBusyError(
+            f"worker did not run '{label or 'tool'}' within {timeout:.1f}s; "
+            f"the IDA main thread is busy"
+            + (f" with '{busy['tool']}' ({busy['elapsed_sec']:.1f}s)" if busy else "")
+        )
+
+
+_pump = MainThreadPump()
+
+
+def get_pump() -> MainThreadPump:
+    return _pump

--- a/src/ida_pro_mcp/ida_mcp/sync.py
+++ b/src/ida_pro_mcp/ida_mcp/sync.py
@@ -8,6 +8,7 @@ import time
 import idaapi
 import ida_kernwin
 import idc
+from .mainthread import PumpBusyError, get_pump
 from .rpc import McpToolError
 from .zeromcp.jsonrpc import get_current_cancel_event, RequestCancelledError
 
@@ -40,6 +41,9 @@ class CancelledError(RequestCancelledError):
 logger = logging.getLogger(__name__)
 _TOOL_TIMEOUT_ENV = "IDA_MCP_TOOL_TIMEOUT_SEC"
 _DEFAULT_TOOL_TIMEOUT_SEC = 60.0
+# Waiters allow a bit more than the tool's own timeout, so a tool that times
+# out reports its own error rather than a generic busy one.
+_PUMP_WAIT_SLACK_SEC = 30.0
 
 
 # Thread-local: while a synchronized tool body is running, holds the monotonic
@@ -167,16 +171,22 @@ def _normalize_timeout(value: object) -> float | None:
 
 
 def sync_wrapper(
-    ff, timeout_override: float | None = None, keep_batch: bool = False
+    ff,
+    timeout_override: float | None = None,
+    keep_batch: bool = False,
+    cancel_event: "threading.Event | None" = None,
 ):
     """Wrapper to enable timeout and cancellation during IDA synchronization.
 
     Note: Batch mode is now handled in _sync_wrapper to ensure it's always
     applied consistently for all synchronized operations. Pass keep_batch=True
     to opt out of the post-call batch restore (see _sync_wrapper docstring).
+
+    `cancel_event` is passed explicitly when the body runs on the main-thread
+    pump rather than the requesting thread, where the thread-local is absent.
     """
-    # Capture cancel event from thread-local before execute_sync
-    cancel_event = get_current_cancel_event()
+    if cancel_event is None:
+        cancel_event = get_current_cancel_event()
 
     timeout = timeout_override
     if timeout is None:
@@ -261,7 +271,27 @@ def idasync(f):
             getattr(f, "__ida_mcp_timeout_sec__", None)
         )
         keep_batch = bool(getattr(f, "__ida_mcp_keep_batch__", False))
-        return sync_wrapper(ff, timeout_override, keep_batch=keep_batch)
+
+        pump = get_pump()
+        if not pump.active or pump.on_main_thread():
+            return sync_wrapper(ff, timeout_override, keep_batch=keep_batch)
+
+        # Headless: IDA only runs on the pump thread, so hand the whole
+        # synchronized body over and wait for it there.
+        cancel_event = get_current_cancel_event()
+        timeout = timeout_override
+        if timeout is None:
+            timeout = _get_tool_timeout_seconds()
+        try:
+            return pump.submit(
+                lambda: sync_wrapper(
+                    ff, timeout_override, keep_batch=keep_batch, cancel_event=cancel_event
+                ),
+                label=f.__name__,
+                timeout=(timeout + _PUMP_WAIT_SLACK_SEC) if timeout > 0 else None,
+            )
+        except PumpBusyError as e:
+            raise IDAError(str(e)) from None
 
     return wrapper
 

--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -600,14 +600,22 @@ class McpServer:
     def prompt(self, func: Callable) -> Callable:
         return self.prompts.method(func)
 
-    def serve(self, host: str, port: int, *, background = True, request_handler = McpHttpRequestHandler):
+    def serve(self, host: str, port: int, *, background = True, threaded = True, request_handler = McpHttpRequestHandler):
+        """Serve HTTP.
+
+        `background` controls whether serve_forever() blocks the caller;
+        `threaded` controls request concurrency. They are independent: a
+        caller can keep its own thread free (background=True) while still
+        serving requests concurrently, or park on serve_forever with a
+        single-threaded server.
+        """
         if self._running:
             logger.info("[MCP] Server is already running")
             return
 
         # Create server with deferred binding
         assert issubclass(request_handler, McpHttpRequestHandler)
-        self._http_server = (ThreadingHTTPServer if background else HTTPServer)(
+        self._http_server = (ThreadingHTTPServer if threaded else HTTPServer)(
             (host, port),
             request_handler,
             bind_and_activate=False

--- a/src/ida_pro_mcp/idalib_server.py
+++ b/src/ida_pro_mcp/idalib_server.py
@@ -17,6 +17,7 @@ from ida_pro_mcp.ida_mcp.api_core import (
 )
 from ida_pro_mcp.ida_mcp.discovery import register_instance, unregister_instance
 from ida_pro_mcp.ida_mcp.http import IdaMcpHttpRequestHandler
+from ida_pro_mcp.ida_mcp.mainthread import get_pump
 from ida_pro_mcp.ida_mcp.profile import apply_profile, load_profile
 from ida_pro_mcp.ida_mcp.rpc import set_download_base_url, tool
 from ida_pro_mcp.idalib_session_manager import get_session_manager
@@ -60,6 +61,7 @@ IDB_MANAGEMENT_TOOLS = {
 
 
 _LIFECYCLE = WorkerLifecycle()
+_PUMP = get_pump()
 _REGISTERED_PORT: int | None = None
 _BOUND_HOST: str = ""
 _BOUND_PORT: int = 0
@@ -109,6 +111,20 @@ def idb_open(
     ] = "",
 ) -> IdalibOpenResult:
     """Open a binary, activate it, and warm up subsystems in one call."""
+
+    if _PUMP.active and not _PUMP.on_main_thread():
+        # open_database and everything after it must run on the IDA thread.
+        return _PUMP.submit(
+            lambda: idb_open(
+                input_path,
+                run_auto_analysis,
+                build_caches,
+                init_hexrays,
+                idle_ttl_sec,
+                preferred_session_id,
+            ),
+            label="idb_open",
+        )
 
     try:
         manager = get_session_manager()
@@ -239,22 +255,22 @@ def main():
         logger.info("Worker lifecycle requesting shutdown: %s", reason)
         # MCP_SERVER.stop() must be called from outside the serve_forever
         # thread; our watchdog thread qualifies.
+        _PUMP.stop()
         try:
             MCP_SERVER.stop()
         except Exception:
             logger.exception("MCP_SERVER.stop() failed during lifecycle shutdown")
 
+    _LIFECYCLE.set_busy_probe(lambda: _PUMP.busy_status() is not None)
     _LIFECYCLE.start(on_shutdown=_on_lifecycle_exit)
     _install_dispatch_hook()
 
     def cleanup_and_exit(signum, frame):
         logger.info("Signal %s received; shutting down", signum)
-        # MCP_SERVER.stop() blocks until serve_forever() returns, but this
-        # handler runs on the main thread — the same thread that is parked
-        # inside serve_forever() underneath this frame. Calling stop() here
-        # deadlocks the process forever (and, having flipped _running to
-        # False, turns every later stop() — watchdog TTL, repeat signals —
-        # into a no-op). Stop from a helper thread instead.
+        # The main thread runs the pump, not serve_forever, so stopping the
+        # server from a helper thread is both safe and required.
+        _PUMP.stop()
+
         def _stop():
             try:
                 MCP_SERVER.stop()
@@ -301,16 +317,25 @@ def main():
         set_download_base_url(f"http://{args.host}:{args.port}")
 
     try:
+        # HTTP on background threads keeps ping/health/cancel answerable while
+        # a tool occupies IDA. Arm first: requests may arrive before run().
+        _PUMP.arm()
         MCP_SERVER.serve(
             host=args.host,
             port=args.port,
-            background=False,
+            background=True,
+            threaded=True,
             request_handler=IdaMcpHttpRequestHandler,
         )
+        _PUMP.run()
     finally:
-        # Reached when MCP_SERVER.serve returns: either signal handler called
-        # .stop(), watchdog called .stop(), or the loop errored out.
+        # Reached once the pump stops: signal handler, watchdog, or an error.
         logger.info("Server loop exited; cleaning up")
+        _PUMP.stop()
+        try:
+            MCP_SERVER.stop()
+        except Exception:
+            logger.exception("MCP_SERVER.stop() failed during cleanup")
         _LIFECYCLE.stop()
         _deregister_from_discovery()
         try:

--- a/src/ida_pro_mcp/idalib_supervisor.py
+++ b/src/ida_pro_mcp/idalib_supervisor.py
@@ -54,8 +54,29 @@ IDB_MANAGEMENT_TOOLS = {
     "idb_list",
     "idb_close",
 }
-WORKER_TCP_HEALTH_TIMEOUT_SEC = 0.5
-WORKER_RPC_HEALTH_TIMEOUT_SEC = 2.0
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "").strip() or default)
+    except ValueError:
+        return default
+
+
+# A worker cannot answer a ping while a tool occupies its IDA main thread, so
+# probing must separate "process gone" (reap) from "alive but busy" (wait).
+WORKER_TCP_HEALTH_TIMEOUT_SEC = _env_float("IDA_MCP_HEALTH_TCP_TIMEOUT", 2.0)
+WORKER_RPC_HEALTH_TIMEOUT_SEC = _env_float("IDA_MCP_HEALTH_RPC_TIMEOUT", 10.0)
+WORKER_QUICK_TCP_TIMEOUT_SEC = 0.5
+WORKER_QUICK_RPC_TIMEOUT_SEC = 2.0
+WORKER_HEALTH_RETRIES = int(_env_float("IDA_MCP_HEALTH_RETRIES", 3))
+WORKER_HEALTH_RETRY_BACKOFF_SEC = _env_float("IDA_MCP_HEALTH_RETRY_BACKOFF", 1.0)
+# How long a live-but-silent worker is tolerated before counting as wedged.
+# Generous: analysing a large database legitimately takes a while. 0 disables.
+WORKER_WEDGED_GRACE_SEC = _env_float("IDA_MCP_WEDGED_GRACE_SEC", 1800.0)
+# Backstop on a forwarded tools/call; the worker has its own per-tool
+# timeouts. 0 waits indefinitely.
+WORKER_CALL_TIMEOUT_SEC = _env_float("IDA_MCP_WORKER_CALL_TIMEOUT", 900.0)
+
 PARTIAL_DATABASE_EXTENSIONS = (".id0", ".id1", ".id2", ".nam", ".til")
 
 # Upper bound (seconds) on how long a worker may take to open and auto-analyze a
@@ -118,6 +139,7 @@ class IdalibSessionInfo(TypedDict):
 
 class IdalibSessionListInfo(IdalibSessionInfo, total=False):
     is_active: bool
+    busy: bool
     backend: str
     owned: bool
     adopted: bool
@@ -166,6 +188,7 @@ class WorkerSession:
     owned: bool = True
     pid: int | None = None
     last_warmup: dict[str, Any] | None = None
+    unresponsive_since: float | None = None
 
     def to_dict(self) -> IdalibSessionInfo:
         return {
@@ -380,7 +403,7 @@ class IdalibSupervisor:
         stale_session_ids = [
             session.session_id
             for session in self.sessions.values()
-            if session.backend == "worker" and session.owned and not self._session_is_reachable(session)
+            if session.backend == "worker" and session.owned and self._process_exited(session)
         ]
         for session_id in stale_session_ids:
             stale = self._unregister_session_locked(session_id)
@@ -535,29 +558,94 @@ class IdalibSupervisor:
     def _session_is_reachable(self, session: WorkerSession) -> bool:
         return bool(self._probe_session_health(session)["reachable"])
 
-    def _probe_session_health(self, session: WorkerSession) -> dict[str, Any]:
-        process_alive = session.is_alive()
+    def _session_is_usable(self, session: WorkerSession) -> bool:
+        """True unless the session is provably gone; a busy worker stays usable.
+
+        Quick timeouts: callers hold the lock and a dead worker refuses the
+        connection at once, so waiting longer only pins the lock.
+        """
+        health = self._probe_session_health(
+            session,
+            tcp_timeout=WORKER_QUICK_TCP_TIMEOUT_SEC,
+            rpc_timeout=WORKER_QUICK_RPC_TIMEOUT_SEC,
+        )
+        return self._health_state(health) != "dead"
+
+    def _concurrent_session_for_path(self, resolved: str) -> WorkerSession | None:
+        """Session another thread registered for `resolved` while we opened.
+
+        Two clients can now open the same binary at once; the loser's idb_open
+        fails on the database lock. Return the winner rather than erroring —
+        and never clean up working files that are now the winner's.
+        """
+        with self._lock:
+            existing = self.path_to_session.get(self._path_key(resolved))
+            if existing is None:
+                return None
+            session = self.sessions.get(existing)
+            if session is None or not self._session_is_usable(session):
+                return None
+            session.last_accessed = datetime.now()
+            return session
+
+    def _process_exited(self, session: WorkerSession) -> bool:
+        process = session.process
+        return process is not None and process.poll() is not None
+
+    def _probe_session_health(
+        self,
+        session: WorkerSession,
+        *,
+        tcp_timeout: float | None = None,
+        rpc_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Classify a session as ok / busy / dead.
+
+        `busy` is alive but not answering, i.e. mid tool call. Only `dead`
+        justifies reaping.
+        """
         result: dict[str, Any] = {
             "backend": session.backend,
-            "process_alive": process_alive,
+            "process_alive": None,
             "tcp_connect": None,
             "rpc_ping": None,
             "reachable": False,
+            "state": "dead",
             "failed_probe": None,
             "error": None,
         }
-        if not process_alive:
+
+        if session.backend != "worker":
+            alive = session.is_alive()
+            result["process_alive"] = alive
+            result["reachable"] = alive
+            result["state"] = "ok" if alive else "dead"
+            if not alive:
+                result["failed_probe"] = "process"
+                result["error"] = "instance is not responding"
+            return result
+
+        if self._process_exited(session):
+            result["process_alive"] = False
             result["failed_probe"] = "process"
             result["error"] = "worker process is not running"
             return result
-        if session.backend != "worker":
-            result["reachable"] = True
+        # Adopted workers have no Popen handle, so liveness is unknown here.
+        result["process_alive"] = True if session.process is not None else None
+
+        def busy(probe: str, error: str) -> dict[str, Any]:
+            result["failed_probe"] = probe
+            result["error"] = error
+            # A completed TCP handshake proves the listener is up, which is
+            # all we have for adopted workers we hold no process handle for.
+            alive = result["process_alive"] is True or result["tcp_connect"] is True
+            result["state"] = "busy" if alive else "dead"
             return result
 
         try:
             with socket.create_connection(
                 (session.host, session.port),
-                timeout=WORKER_TCP_HEALTH_TIMEOUT_SEC,
+                timeout=tcp_timeout or WORKER_TCP_HEALTH_TIMEOUT_SEC,
             ):
                 pass
         except Exception as e:
@@ -567,16 +655,14 @@ class IdalibSupervisor:
                 exc_info=True,
             )
             result["tcp_connect"] = False
-            result["failed_probe"] = "tcp_connect"
-            result["error"] = str(e)
-            return result
+            return busy("tcp_connect", str(e))
         result["tcp_connect"] = True
 
         try:
             response = self._worker_rpc(
                 session,
                 {"jsonrpc": "2.0", "id": 1, "method": "ping"},
-                timeout=WORKER_RPC_HEALTH_TIMEOUT_SEC,
+                timeout=rpc_timeout or WORKER_RPC_HEALTH_TIMEOUT_SEC,
             )
         except Exception as e:
             logger.debug(
@@ -585,19 +671,47 @@ class IdalibSupervisor:
                 exc_info=True,
             )
             result["rpc_ping"] = False
-            result["failed_probe"] = "rpc_ping"
-            result["error"] = str(e)
-            return result
+            return busy("rpc_ping", str(e))
 
         if "error" in response:
             result["rpc_ping"] = False
-            result["failed_probe"] = "rpc_ping"
-            result["error"] = response["error"].get("message", "JSON-RPC ping returned error")
-            return result
+            return busy(
+                "rpc_ping", response["error"].get("message", "JSON-RPC ping returned error")
+            )
 
         result["rpc_ping"] = True
         result["reachable"] = True
+        result["state"] = "ok"
         return result
+
+    @staticmethod
+    def _health_state(health: dict[str, Any]) -> str:
+        state = health.get("state")
+        if state:
+            return str(state)
+        return "ok" if health.get("reachable") else "dead"
+
+    def _probe_session_health_retrying(self, session: WorkerSession) -> dict[str, Any]:
+        health = self._probe_session_health(session)
+        for attempt in range(1, max(0, WORKER_HEALTH_RETRIES)):
+            if self._health_state(health) != "busy":
+                break
+            time.sleep(WORKER_HEALTH_RETRY_BACKOFF_SEC * attempt)
+            health = self._probe_session_health(session)
+        health["state"] = self._health_state(health)
+        return health
+
+    def _record_health_state(self, session: WorkerSession, state: str) -> bool:
+        """Track how long a live worker has been silent. Returns True if wedged."""
+        if state != "busy":
+            session.unresponsive_since = None
+            return False
+        now = time.monotonic()
+        if session.unresponsive_since is None:
+            session.unresponsive_since = now
+        if WORKER_WEDGED_GRACE_SEC <= 0:
+            return False
+        return (now - session.unresponsive_since) >= WORKER_WEDGED_GRACE_SEC
 
     def _unregister_session_locked(self, session_id: str) -> WorkerSession | None:
         session = self.sessions.pop(session_id, None)
@@ -678,7 +792,7 @@ class IdalibSupervisor:
             existing = self.path_to_session.get(self._path_key(resolved_path))
             if existing is not None:
                 existing_session = self.sessions.get(existing)
-                if existing_session is not None and self._session_is_reachable(existing_session):
+                if existing_session is not None and self._session_is_usable(existing_session):
                     existing_session.last_accessed = datetime.now()
                     return existing_session
                 self._unregister_session_locked(existing)
@@ -714,7 +828,7 @@ class IdalibSupervisor:
             existing = self.path_to_session.get(self._path_key(resolved))
             if existing is not None:
                 session = self.sessions.get(existing)
-                if session is not None and self._session_is_reachable(session):
+                if session is not None and self._session_is_usable(session):
                     session.last_accessed = datetime.now()
                     return session
                 self._unregister_session_locked(existing)
@@ -779,6 +893,9 @@ class IdalibSupervisor:
                 raise RuntimeError(str(opened["error"]))
         except TimeoutError:
             self._terminate_worker(worker)
+            winner = self._concurrent_session_for_path(resolved)
+            if winner is not None:
+                return winner
             self._cleanup_partial_database(resolved, preserve=preexisting_parts)
             raise RuntimeError(
                 f"idalib worker timed out after {open_timeout:.0f}s while opening and "
@@ -788,6 +905,9 @@ class IdalibSupervisor:
             ) from None
         except Exception:
             self._terminate_worker(worker)
+            winner = self._concurrent_session_for_path(resolved)
+            if winner is not None:
+                return winner
             self._cleanup_partial_database(resolved, preserve=preexisting_parts)
             raise
 
@@ -810,7 +930,7 @@ class IdalibSupervisor:
             existing = self.path_to_session.get(self._path_key(resolved))
             if existing is not None:
                 existing_session = self.sessions.get(existing)
-                if existing_session is not None and self._session_is_reachable(existing_session):
+                if existing_session is not None and self._session_is_usable(existing_session):
                     existing_session.last_accessed = datetime.now()
                 else:
                     self._unregister_session_locked(existing)
@@ -822,7 +942,7 @@ class IdalibSupervisor:
             if existing_session is None:
                 existing_by_id = self.sessions.get(session_id)
                 if existing_by_id is not None:
-                    if self._session_is_reachable(existing_by_id):
+                    if self._session_is_usable(existing_by_id):
                         existing_by_id.last_accessed = datetime.now()
                         session_collision_error = ValueError(f"Session already exists: {session_id}")
                     else:
@@ -904,7 +1024,7 @@ class IdalibSupervisor:
             if current is session:
                 self._register_session_locked(replacement, resolved)
                 return replacement
-            if current is not None and self._session_is_reachable(current):
+            if current is not None and self._session_is_usable(current):
                 current.last_accessed = datetime.now()
                 replacement_session = current
                 reopen_error = None
@@ -925,9 +1045,41 @@ class IdalibSupervisor:
 
     def resolve_session(self, database: str) -> WorkerSession:
         session = self.peek_session(database)
-        if self._session_is_reachable(session):
+        # Short timeouts: a busy worker is forwarded to anyway, so waiting
+        # longer here only adds latency to every call.
+        health = self._probe_session_health(
+            session,
+            tcp_timeout=WORKER_QUICK_TCP_TIMEOUT_SEC,
+            rpc_timeout=WORKER_QUICK_RPC_TIMEOUT_SEC,
+        )
+        state = self._health_state(health)
+        wedged = self._record_health_state(session, state)
+        if state == "ok":
             session.last_accessed = datetime.now()
             return session
+        if state == "busy":
+            if not wedged:
+                # Mid tool call: let the request queue on the worker rather
+                # than killing the analysis.
+                logger.info(
+                    "Worker session %s is busy (%s); forwarding anyway",
+                    session.session_id,
+                    health.get("failed_probe"),
+                )
+                session.last_accessed = datetime.now()
+                return session
+            # Silent past the grace window: confirm with generous timeouts
+            # before killing a process that may still be working.
+            confirmed = self._probe_session_health_retrying(session)
+            if self._health_state(confirmed) == "ok":
+                self._record_health_state(session, "ok")
+                session.last_accessed = datetime.now()
+                return session
+            logger.warning(
+                "Worker session %s unresponsive for over %.0fs; reaping",
+                session.session_id,
+                WORKER_WEDGED_GRACE_SEC,
+            )
         if session.backend == "gui":
             return self._reopen_gui_session_headless(session)
         session_id = session.session_id
@@ -989,11 +1141,22 @@ class IdalibSupervisor:
             info["save_error"] = save_error
         return info
 
+    def _session_list_entry(self, session: WorkerSession) -> IdalibSessionListInfo:
+        """Listing must stay snappy, so probe with short timeouts only."""
+        health = self._probe_session_health(
+            session,
+            tcp_timeout=WORKER_QUICK_TCP_TIMEOUT_SEC,
+            rpc_timeout=WORKER_QUICK_RPC_TIMEOUT_SEC,
+        )
+        state = self._health_state(health)
+        entry = session.to_list_dict(active=state != "dead")
+        entry["busy"] = state == "busy"
+        return entry
+
     def list_sessions(self) -> list[IdalibSessionListInfo]:
         with self._lock:
             adopted = [
-                session.to_list_dict(active=self._session_is_reachable(session))
-                for session in self.sessions.values()
+                self._session_list_entry(session) for session in self.sessions.values()
             ]
             adopted_path_keys = {
                 key
@@ -1225,7 +1388,25 @@ def _handle_tools_call(request_obj: dict[str, Any]) -> dict[str, Any] | None:
     forwarded = copy.deepcopy(request_obj)
     forwarded.setdefault("params", {})["arguments"] = arguments
     try:
-        return sup._worker_rpc(session, forwarded)
+        return sup._worker_rpc(
+            session, forwarded, timeout=WORKER_CALL_TIMEOUT_SEC or None
+        )
+    except socket.timeout:
+        return _jsonrpc_result(
+            request_id,
+            _call_tool_result(
+                {
+                    "error": (
+                        f"Worker for session '{database}' did not respond within "
+                        f"{WORKER_CALL_TIMEOUT_SEC:.0f}s; it is still busy with an "
+                        f"earlier call. The session is kept open — retry later or "
+                        f"raise IDA_MCP_WORKER_CALL_TIMEOUT."
+                    ),
+                    "busy": True,
+                },
+                is_error=True,
+            ),
+        )
     except Exception as e:
         return _jsonrpc_result(request_id, _call_tool_result({"error": str(e)}, is_error=True))
 
@@ -1344,7 +1525,9 @@ def main() -> None:
         if args.stdio:
             mcp.stdio()
         else:
-            mcp.serve(host=args.host, port=args.port, background=False)
+            # Threaded: a call to one busy worker must not block requests
+            # aimed at a different, idle one.
+            mcp.serve(host=args.host, port=args.port, background=False, threaded=True)
     finally:
         if supervisor is not None:
             supervisor.shutdown()

--- a/src/ida_pro_mcp/worker_lifecycle.py
+++ b/src/ida_pro_mcp/worker_lifecycle.py
@@ -41,6 +41,15 @@ class WorkerLifecycle:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._on_shutdown: Callable[[str], None] | None = None
+        self._busy_probe: Callable[[], bool] | None = None
+
+    def set_busy_probe(self, probe: Callable[[], bool]) -> None:
+        """Register a callback reporting whether a call is currently running.
+
+        Requests touch the timer on arrival, so a call longer than the TTL
+        would otherwise look idle and be shut down mid-work.
+        """
+        self._busy_probe = probe
 
     def start(self, on_shutdown: Callable[[str], None]) -> None:
         if self._thread is not None:
@@ -80,6 +89,10 @@ class WorkerLifecycle:
         with self._lock:
             last_req = self._last_request_at
             ttl = self.idle_ttl_sec
+        if ttl <= 0:
+            return None  # long-lived worker: never self-exit
+        if self._busy_probe is not None and self._busy_probe():
+            return None  # mid tool call: not idle, however long it takes
         now = time.monotonic()
         if (now - last_req) > ttl:
             return f"no requests for {now - last_req:.1f}s"

--- a/tests/test_idalib_supervisor.py
+++ b/tests/test_idalib_supervisor.py
@@ -99,7 +99,7 @@ class _FakeSupervisor(supmod.IdalibSupervisor):
     def _session_is_reachable(self, session):
         return session.is_alive()
 
-    def _probe_session_health(self, session):
+    def _probe_session_health(self, session, *, tcp_timeout=None, rpc_timeout=None):
         reachable = self._session_is_reachable(session)
         return {
             "backend": session.backend,
@@ -107,6 +107,7 @@ class _FakeSupervisor(supmod.IdalibSupervisor):
             "tcp_connect": reachable if session.backend == "worker" else None,
             "rpc_ping": reachable if session.backend == "worker" else None,
             "reachable": reachable,
+            "state": "ok" if reachable else "dead",
             "failed_probe": None if reachable else "tcp_connect",
             "error": None if reachable else "unreachable",
         }
@@ -833,6 +834,159 @@ def test_probe_session_health_reports_rpc_ping_failure(monkeypatch):
     assert "rpc timeout" in health["error"]
 
 
+def _silent_worker_supervisor(monkeypatch, *, process):
+    """Supervisor whose worker accepts TCP but never answers ping."""
+    sup = supmod.IdalibSupervisor(supmod.McpServer("test"))
+    worker = supmod.WorkerSession(
+        session_id="worker",
+        input_path="sample.bin",
+        filename="sample.bin",
+        host="127.0.0.1",
+        port=12345,
+        process=process,
+    )
+
+    class _FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(
+        supmod.socket, "create_connection", lambda *_a, **_k: _FakeSocket()
+    )
+    sup._worker_rpc = lambda *_a, **_k: (_ for _ in ()).throw(TimeoutError("busy"))
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRIES", 1)
+    return sup, worker
+
+
+def test_probe_reports_live_but_silent_worker_as_busy(monkeypatch):
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=_FakeProcess())
+
+    health = sup._probe_session_health(worker)
+
+    assert health["state"] == "busy"
+    assert health["reachable"] is False
+
+
+def test_probe_reports_exited_worker_as_dead(monkeypatch):
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=_DeadProcess())
+
+    health = sup._probe_session_health(worker)
+
+    assert health["state"] == "dead"
+    assert health["failed_probe"] == "process"
+
+
+def test_resolve_session_keeps_busy_worker(monkeypatch):
+    process = _FakeProcess()
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=process)
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+
+    resolved = sup.resolve_session("worker")
+
+    assert resolved is worker
+    assert "worker" in sup.sessions
+    assert process.returncode is None
+    assert worker.unresponsive_since is not None
+
+
+def test_resolve_session_does_not_retry_probe_on_busy_worker(monkeypatch):
+    """Busy calls are forwarded, so extra probing is pure added latency."""
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=_FakeProcess())
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+    monkeypatch.setattr(supmod, "WORKER_HEALTH_RETRIES", 5)
+    probes = []
+    original = sup._probe_session_health
+    sup._probe_session_health = lambda *a, **kw: (
+        probes.append(kw), original(*a, **kw)
+    )[1]
+
+    sup.resolve_session("worker")
+
+    assert len(probes) == 1
+    assert probes[0]["rpc_timeout"] == supmod.WORKER_QUICK_RPC_TIMEOUT_SEC
+
+
+def test_resolve_session_reaps_worker_wedged_past_grace(monkeypatch):
+    process = _FakeProcess()
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=process)
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+    monkeypatch.setattr(supmod, "WORKER_WEDGED_GRACE_SEC", 60.0)
+    worker.unresponsive_since = supmod.time.monotonic() - 120.0
+
+    try:
+        sup.resolve_session("worker")
+    except RuntimeError as e:
+        assert "not reachable" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+    assert "worker" not in sup.sessions
+    assert process.returncode == 0
+
+
+def test_zero_wedged_grace_never_reaps_live_worker(monkeypatch):
+    process = _FakeProcess()
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=process)
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+    monkeypatch.setattr(supmod, "WORKER_WEDGED_GRACE_SEC", 0.0)
+    worker.unresponsive_since = supmod.time.monotonic() - 10_000.0
+
+    assert sup.resolve_session("worker") is worker
+    assert process.returncode is None
+
+
+def test_list_sessions_marks_busy_worker_active(monkeypatch):
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=_FakeProcess())
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+    monkeypatch.setattr(supmod._discovery, "discover_instances", lambda: [])
+
+    entry = sup.list_sessions()[0]
+
+    assert entry["is_active"] is True
+    assert entry["busy"] is True
+
+
+def test_handle_tools_call_reports_busy_on_worker_timeout(monkeypatch, tmp_path):
+    sample = tmp_path / "sample.bin"
+    sample.write_bytes(b"x")
+    sup = _FakeSupervisor()
+    sup.open_session(str(sample), session_id="sample")
+
+    def timeout_rpc(*_a, **_k):
+        raise supmod.socket.timeout("timed out")
+
+    sup._worker_rpc = timeout_rpc
+    old_supervisor = supmod.supervisor
+    supmod.supervisor = sup
+    try:
+        result = supmod._handle_tools_call(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "decompile",
+                    "arguments": {"addr": "0x1000", "database": "sample"},
+                },
+            }
+        )
+    finally:
+        supmod.supervisor = old_supervisor
+
+    assert result is not None
+    assert result["result"]["isError"] is True
+    assert "still busy" in result["result"]["content"][0]["text"]
+    assert "sample" in sup.sessions
+
+
 def test_list_sessions_reports_is_active_from_health_probe(tmp_path):
     first = tmp_path / "first.bin"
     second = tmp_path / "second.bin"
@@ -1269,3 +1423,86 @@ def test_closed_gui_session_does_not_reappear_if_closed_during_headless_fallback
         assert sup.spawned[-1].process.returncode == 0
     finally:
         restore()
+
+
+def test_probe_reports_busy_adopted_worker_as_busy(monkeypatch):
+    """No Popen handle, but a completed TCP handshake proves it is alive."""
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=None)
+    worker.owned = False
+
+    health = sup._probe_session_health(worker)
+
+    assert health["tcp_connect"] is True
+    assert health["state"] == "busy"
+
+
+def test_probe_reports_adopted_worker_with_no_listener_as_dead(monkeypatch):
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=None)
+    worker.owned = False
+    monkeypatch.setattr(
+        supmod.socket,
+        "create_connection",
+        lambda *_a, **_k: (_ for _ in ()).throw(ConnectionRefusedError("refused")),
+    )
+
+    health = sup._probe_session_health(worker)
+
+    assert health["tcp_connect"] is False
+    assert health["state"] == "dead"
+
+
+def test_resolve_session_keeps_busy_adopted_worker(monkeypatch):
+    sup, worker = _silent_worker_supervisor(monkeypatch, process=None)
+    worker.owned = False
+    with sup._lock:
+        sup._register_session_locked(worker, worker.input_path)
+
+    assert sup.resolve_session("worker") is worker
+    assert "worker" in sup.sessions
+
+
+def test_open_session_returns_winner_when_concurrent_open_fails(tmp_path):
+    """The loser of a same-path race must get the winner, not a locked-DB error."""
+    binary = tmp_path / "sample.bin"
+    binary.write_bytes(b"\x00")
+    resolved = str(binary.resolve())
+
+    winner = supmod.WorkerSession(
+        session_id="winner",
+        input_path=resolved,
+        filename=binary.name,
+        host="127.0.0.1",
+        port=12345,
+        process=_FakeProcess(),
+    )
+
+    class _LosingSupervisor(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None, *, timeout=None):
+            if name == "idb_open":
+                # The winner registers while this open is in flight.
+                with self._lock:
+                    self._register_session_locked(winner, resolved)
+                raise RuntimeError(f"Failed to open database: {resolved}")
+            return super().call_worker_tool(worker, name, arguments, timeout=timeout)
+
+    sup = _LosingSupervisor()
+    cleaned: list = []
+    sup._cleanup_partial_database = lambda *a, **k: cleaned.append(a)
+
+    assert sup.open_session(resolved) is winner
+    assert cleaned == [], "must not delete working files owned by the winner"
+
+
+def test_open_session_still_raises_when_no_concurrent_winner(tmp_path):
+    binary = tmp_path / "sample.bin"
+    binary.write_bytes(b"\x00")
+
+    class _FailingOpen(_FakeSupervisor):
+        def call_worker_tool(self, worker, name, arguments=None, *, timeout=None):
+            if name == "idb_open":
+                raise RuntimeError("Failed to open database")
+            return super().call_worker_tool(worker, name, arguments, timeout=timeout)
+
+    sup = _FailingOpen()
+    with pytest.raises(RuntimeError, match="Failed to open database"):
+        sup.open_session(str(binary.resolve()))

--- a/tests/test_mainthread_pump.py
+++ b/tests/test_mainthread_pump.py
@@ -1,0 +1,170 @@
+"""Main-thread job pump tests (no IDA required)."""
+
+import importlib.util
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# Import by path: ida_mcp/__init__.py pulls in IDA, which is absent here.
+_spec = importlib.util.spec_from_file_location(
+    "ida_mcp_mainthread",
+    Path(__file__).resolve().parents[1] / "src/ida_pro_mcp/ida_mcp/mainthread.py",
+)
+assert _spec is not None and _spec.loader is not None
+_mainthread = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mainthread)
+MainThreadPump = _mainthread.MainThreadPump
+PumpBusyError = _mainthread.PumpBusyError
+
+
+def _run_pump(pump: MainThreadPump) -> threading.Thread:
+    thread = threading.Thread(target=pump.run, kwargs={"poll_interval": 0.01}, daemon=True)
+    thread.start()
+    for _ in range(200):
+        if pump.active:
+            return thread
+        time.sleep(0.01)
+    raise AssertionError("pump did not start")
+
+
+def test_submit_runs_job_on_pump_thread():
+    pump = MainThreadPump()
+    thread = _run_pump(pump)
+    try:
+        assert pump.submit(lambda: threading.get_ident(), timeout=5) == thread.ident
+    finally:
+        pump.stop()
+
+
+def test_submit_propagates_exception():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    try:
+        with pytest.raises(ValueError, match="boom"):
+            pump.submit(lambda: (_ for _ in ()).throw(ValueError("boom")), timeout=5)
+    finally:
+        pump.stop()
+
+
+def test_submit_on_pump_thread_runs_inline():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    try:
+        nested = pump.submit(lambda: pump.submit(lambda: "inner", timeout=5), timeout=5)
+        assert nested == "inner"
+    finally:
+        pump.stop()
+
+
+def test_busy_status_reports_running_job():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    release = threading.Event()
+    try:
+        blocker = threading.Thread(
+            target=lambda: pump.submit(release.wait, label="slow", timeout=10), daemon=True
+        )
+        blocker.start()
+        for _ in range(200):
+            if pump.busy_status() is not None:
+                break
+            time.sleep(0.01)
+        busy = pump.busy_status()
+        assert busy is not None and busy["tool"] == "slow"
+        assert busy["elapsed_sec"] >= 0
+    finally:
+        release.set()
+        pump.stop()
+
+
+def test_submit_times_out_while_pump_is_busy():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    release = threading.Event()
+    try:
+        blocker = threading.Thread(
+            target=lambda: pump.submit(release.wait, label="slow", timeout=10), daemon=True
+        )
+        blocker.start()
+        time.sleep(0.05)
+        with pytest.raises(PumpBusyError, match="slow"):
+            pump.submit(lambda: "never", label="quick", timeout=0.2)
+    finally:
+        release.set()
+        pump.stop()
+
+
+def test_queued_job_is_dropped_after_its_waiter_gives_up():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    release = threading.Event()
+    ran = []
+    try:
+        blocker = threading.Thread(
+            target=lambda: pump.submit(release.wait, label="slow", timeout=10), daemon=True
+        )
+        blocker.start()
+        time.sleep(0.05)
+        with pytest.raises(PumpBusyError):
+            pump.submit(lambda: ran.append("late"), label="abandoned", timeout=0.2)
+        release.set()
+        time.sleep(0.2)
+        assert ran == []
+    finally:
+        release.set()
+        pump.stop()
+
+
+def test_submit_without_running_pump_raises():
+    pump = MainThreadPump()
+    with pytest.raises(RuntimeError, match="not running"):
+        pump.submit(lambda: None, timeout=1)
+
+
+def test_stop_fails_pending_jobs():
+    pump = MainThreadPump()
+    _run_pump(pump)
+    release = threading.Event()
+    blocker = threading.Thread(
+        target=lambda: pump.submit(release.wait, label="slow", timeout=10), daemon=True
+    )
+    blocker.start()
+    time.sleep(0.05)
+
+    errors = []
+
+    def pending():
+        try:
+            pump.submit(lambda: "never", label="pending", timeout=10)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    waiter = threading.Thread(target=pending, daemon=True)
+    waiter.start()
+    time.sleep(0.05)
+    pump.stop()
+    release.set()
+    waiter.join(timeout=5)
+
+    assert errors and "shutting down" in str(errors[0])
+
+
+def test_job_submitted_before_run_is_queued_not_rejected():
+    """Arming closes the window between serve() and run()."""
+    pump = MainThreadPump()
+    pump.arm()
+    results: list = []
+    submitter = threading.Thread(
+        target=lambda: results.append(pump.submit(lambda: "late", timeout=5)),
+        daemon=True,
+    )
+    submitter.start()
+    time.sleep(0.05)
+    assert results == []
+    runner = threading.Thread(target=pump.run, kwargs={"poll_interval": 0.01}, daemon=True)
+    runner.start()
+    submitter.join(timeout=5)
+    pump.stop()
+    assert results == ["late"]

--- a/tests/test_worker_lifecycle.py
+++ b/tests/test_worker_lifecycle.py
@@ -101,3 +101,19 @@ def test_set_idle_ttl_ignores_negative_load_time():
     lc = WorkerLifecycle(idle_ttl_sec=10.0)
     lc.set_idle_ttl(600.0, load_time_sec=-5.0)
     assert lc.idle_ttl_sec == 600.0
+
+
+def test_zero_idle_ttl_never_self_exits():
+    lc = WorkerLifecycle(idle_ttl_sec=0.0, poll_interval_sec=0.05)
+    time.sleep(0.10)
+    assert lc.check_shutdown_reason() is None
+
+
+def test_busy_probe_keeps_worker_alive_past_ttl():
+    lc = WorkerLifecycle(idle_ttl_sec=0.05, poll_interval_sec=0.05)
+    busy = [True]
+    lc.set_busy_probe(lambda: busy[0])
+    time.sleep(0.10)
+    assert lc.check_shutdown_reason() is None
+    busy[0] = False
+    assert lc.check_shutdown_reason() is not None


### PR DESCRIPTION
Closes #494.

A tool call longer than the health-probe timeout made the worker look dead to the supervisor, which dropped the session and killed the process mid-analysis.

**Why the obvious fix doesn't work?** idalib has no UI event loop, so `execute_sync` posted from a secondary thread is never dispatched. Just making the worker's HTTP server threaded deadlocks instead of fixing it.

**Worker:** the main thread now drains a job pump and HTTP moves to background threads. `@idasync` submits to the pump, so IDA still runs on the thread that owns the database while ping/health/cancel stay answerable. `server_health`
reports busy without touching IDA, the idle watchdog no longer counts an in-flight call as idle.

**Supervisor:** probes classify ok/busy/dead, busy is forwarded to, and only a worker silent past a grace window is reaped. Serving threaded keeps a busy worker from blocking calls to other sessions, which in turn required fixing a same-path concurrent `idb_open` race (the loser now gets the winner's session instead of a locked-database error).

**Side effect:** `notifications/cancelled` now works headless. Previously a busy worker couldn't receive it.

Tested on IDA 9.3