### PR TITLE
fix(http): omit notification response bodies

### DIFF
--- a/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
+++ b/src/ida_pro_mcp/ida_mcp/zeromcp/mcp.py
@@ -755,7 +755,7 @@ class McpHttpRequestHandler(BaseHTTPRequestHandler):
 
         # Check if notification (returns None)
         if response is None:
-            send_response(202, b"Accepted")
+            send_response(202, b"")
         else:
             send_response(200, json.dumps(response).encode("utf-8"))
 

--- a/tests/test_mcp_spec_http_e2e.py
+++ b/tests/test_mcp_spec_http_e2e.py
@@ -262,6 +262,32 @@ class HttpSessionManagementTests(unittest.TestCase):
         if session_id is not None:
             self.assertGreater(len(session_id), 0)
 
+    def test_notification_response_is_bodyless(self):
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        ).encode("utf-8")
+        connection = http.client.HTTPConnection(
+            self.harness.host, self.harness.port, timeout=2
+        )
+        try:
+            connection.request(
+                "POST",
+                "/mcp",
+                body=payload,
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                },
+            )
+            response = connection.getresponse()
+            body = response.read()
+        finally:
+            connection.close()
+
+        self.assertEqual(response.status, 202)
+        self.assertEqual(response.getheader("Content-Length"), "0")
+        self.assertEqual(body, b"")
+
 
 class Http11TransportTests(unittest.TestCase):
     def test_rejects_missing_and_duplicate_host(self):


### PR DESCRIPTION
## Summary

- Fixes: Accepted Streamable HTTP notifications receive a 202 response containing `Accepted`, while the [MCP 2025-06-18 transport specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) requires a 202 response with no body.
- Root cause: The notification branch passes an eight-byte `Accepted` payload to the shared HTTP response helper instead of an empty byte string.

## Regression evidence

- Before: `uv run pytest -p no:cacheprovider -q tests/test_mcp_spec_http_e2e.py::HttpSessionManagementTests::test_notification_response_is_bodyless` exited `1`

- After: `uv run pytest -p no:cacheprovider -q tests/test_mcp_spec_http_e2e.py::HttpSessionManagementTests::test_notification_response_is_bodyless` exited `0`

## Verification

- `uv run pytest -p no:cacheprovider -q tests/test_mcp_spec_http_e2e.py tests/test_mcp_spec_envelope.py`
- `uv run pytest -p no:cacheprovider -q tests`
- `uv build`
- `git diff --check`
- Not run: `uv run ida-mcp-test tests/crackme03.elf -q` requires a local IDA 9.x installation and `IDADIR`; this pure-Python transport change is covered by the real-socket regression and protocol suites above.

## Scope

- 2 files changed, +27 / -1 lines
