### PR TITLE
Forward IDA MCP environment variables in Codex plugin

### DIFF
--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -7,7 +7,22 @@
         "idalib-mcp",
         "--stdio"
       ],
-      "cwd": "."
+      "cwd": ".",
+      "env_vars": [
+        "IDA_MCP_ANALYSIS_PROMPT",
+        "IDA_MCP_HEALTH_RETRIES",
+        "IDA_MCP_HEALTH_RETRY_BACKOFF",
+        "IDA_MCP_HEALTH_RPC_TIMEOUT",
+        "IDA_MCP_HEALTH_TCP_TIMEOUT",
+        "IDA_MCP_LOG_REQUESTS",
+        "IDA_MCP_LOG_SKIP_METHODS",
+        "IDA_MCP_MAX_WORKERS",
+        "IDA_MCP_OPEN_TIMEOUT",
+        "IDA_MCP_TOOL_TIMEOUT_SEC",
+        "IDA_MCP_URL",
+        "IDA_MCP_WEDGED_GRACE_SEC",
+        "IDA_MCP_WORKER_CALL_TIMEOUT"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ Worker controls:
 - `--max-workers N`: maximum simultaneous database workers (`0` = unlimited, default `4`).
 - `IDA_MCP_MAX_WORKERS`: environment default for `--max-workers`.
 
+The bundled Codex plugin forwards the runtime's `IDA_MCP_*` configuration variables from the Codex host environment:
+
+- Capacity and lifecycle: `IDA_MCP_MAX_WORKERS`, `IDA_MCP_OPEN_TIMEOUT`, `IDA_MCP_WEDGED_GRACE_SEC`, `IDA_MCP_WORKER_CALL_TIMEOUT`.
+- Health probes: `IDA_MCP_HEALTH_TCP_TIMEOUT`, `IDA_MCP_HEALTH_RPC_TIMEOUT`, `IDA_MCP_HEALTH_RETRIES`, `IDA_MCP_HEALTH_RETRY_BACKOFF`.
+- Worker behavior: `IDA_MCP_TOOL_TIMEOUT_SEC`, `IDA_MCP_ANALYSIS_PROMPT`, `IDA_MCP_URL`.
+- Request logging: `IDA_MCP_LOG_REQUESTS`, `IDA_MCP_LOG_SKIP_METHODS`.
+
 
 ## MCP Resources
 


### PR DESCRIPTION
## Summary

This PR exposes the complete environment-based configuration surface already supported by the `idalib-mcp` runtime to users of the bundled Codex plugin.

- add an `env_vars` allowlist to `.codex-plugin/mcp.json`
- forward every `IDA_MCP_*` variable currently read by the runtime
- document the forwarded variables by capacity, health, worker behavior, and request logging
- preserve existing behavior when none of the variables are set

## Forwarded configuration

### Capacity and lifecycle

- `IDA_MCP_MAX_WORKERS`
- `IDA_MCP_OPEN_TIMEOUT`
- `IDA_MCP_WEDGED_GRACE_SEC`
- `IDA_MCP_WORKER_CALL_TIMEOUT`

### Health probes

- `IDA_MCP_HEALTH_TCP_TIMEOUT`
- `IDA_MCP_HEALTH_RPC_TIMEOUT`
- `IDA_MCP_HEALTH_RETRIES`
- `IDA_MCP_HEALTH_RETRY_BACKOFF`

### Worker behavior

- `IDA_MCP_TOOL_TIMEOUT_SEC`
- `IDA_MCP_ANALYSIS_PROMPT`
- `IDA_MCP_URL`

### Request logging

- `IDA_MCP_LOG_REQUESTS`
- `IDA_MCP_LOG_SKIP_METHODS`

## Behavior

Codex forwards only variables present in the host environment. The supervisor reads its own configuration from that environment, and worker subprocesses inherit it. Existing runtime defaults remain unchanged when a variable is absent. Explicit command-line options, such as `--max-workers`, continue to take precedence over their environment defaults.

## Files changed

- `.codex-plugin/mcp.json`: declares all 13 runtime configuration variables in `env_vars`
- `README.md`: documents the forwarded variables and groups them by purpose

## Validation

- `python3 -m json.tool .codex-plugin/mcp.json`
- verified that the manifest allowlist exactly matches every `IDA_MCP_*` variable read by the runtime source
- verified that the current Codex CLI accepts the complete `env_vars` list for the effective STDIO MCP transport
- `uv run pytest -q tests/test_idalib_supervisor.py` (`65 passed`)
- `git diff --check`